### PR TITLE
Do not apply to the default namespace at Quickstart guide

### DIFF
--- a/docs/content/en/docs/quickstart/_index.md
+++ b/docs/content/en/docs/quickstart/_index.md
@@ -28,8 +28,8 @@ cd manifests
 ``` console
 kubectl create namespace pipecd
 helm install pipecd ./manifests/pipecd \
-  --values ./quickstart/control-plane-values.yaml \
-  --namespace pipecd
+  --namespace pipecd \
+  --values ./quickstart/control-plane-values.yaml
 ```
 
 ### 3. Accessing the PipeCD web
@@ -79,9 +79,9 @@ You can complete the installation by running the following after replacing `YOUR
 
 ``` console
 helm install piped ./manifests/piped \
+  --namespace pipecd \
   --values ./quickstart/piped-values.yaml \
-  --set secret.pipedKey.data=YOUR_PIPED_SECRET_KEY \
-  --namespace pipecd
+  --set secret.pipedKey.data=YOUR_PIPED_SECRET_KEY
 ```
 
 ### 6. Configuring a kubernetes application

--- a/docs/content/en/docs/quickstart/_index.md
+++ b/docs/content/en/docs/quickstart/_index.md
@@ -26,7 +26,10 @@ cd manifests
 ### 2. Installing control plane
 
 ``` console
-helm install pipecd ./manifests/pipecd --values ./quickstart/control-plane-values.yaml
+kubectl create namespace pipecd
+helm install pipecd ./manifests/pipecd \
+  --values ./quickstart/control-plane-values.yaml \
+  --namespace pipecd
 ```
 
 ### 3. Accessing the PipeCD web
@@ -34,7 +37,7 @@ PipeCD comes with an embedded web-based UI.
 First up, using kubectl port-forward to expose the installed control-plane on your localhost:
 
 ``` console
-kubectl port-forward svc/pipecd 8080:443
+kubectl port-forward svc/pipecd -n pipecd 8080:443
 ```
 
 Point your web browser to [http://localhost:8080](http://localhost:8080) to login with the configured static admin account.
@@ -77,7 +80,8 @@ You can complete the installation by running the following after replacing `YOUR
 ``` console
 helm install piped ./manifests/piped \
   --values ./quickstart/piped-values.yaml \
-  --set secret.pipedKey.data=YOUR_PIPED_SECRET_KEY
+  --set secret.pipedKey.data=YOUR_PIPED_SECRET_KEY \
+  --namespace pipecd
 ```
 
 ### 6. Configuring a kubernetes application
@@ -106,8 +110,8 @@ After a short wait, a new deployment will be started to update to `v0.2.0`.
 When you’re finished experimenting with PipeCD, you can uninstall with:
 
 ``` console
-helm uninstall piped
-helm uninstall pipecd
-kubectl delete deploy canary
-kubectl delete svc canary
+helm uninstall piped -n pipecd
+helm uninstall pipecd -n pipecd
+kubectl delete deploy canary -n pipecd
+kubectl delete svc canary -n pipecd
 ```


### PR DESCRIPTION
**What this PR does / why we need it**:
Some people don't like to have their default namespace's tainted.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
