### PR TITLE
Add rfc template to docs

### DIFF
--- a/docs/rfcs/0000-template.md
+++ b/docs/rfcs/0000-template.md
@@ -1,0 +1,22 @@
+- Start Date: (fill me in with today's date, YYYY-MM-DD)
+- Target Version: (1.x / 2.x)
+
+# Summary
+
+One paragraph explanation of the feature.
+
+# Motivation
+
+Why are we doing this? What do we expect?
+
+# Detailed design
+
+Explain the design in detail including what components should be added or changed, examples of how the feature is used.
+
+# Alternatives
+
+What other designs have been considered? What is the impact of not doing this?
+
+# Unresolved questions
+
+What parts of the design are still TBD?


### PR DESCRIPTION
**What this PR does / why we need it**:

I added the RFC template for us inside `docs/rfcs` directory.
This template is brought from

https://github.com/rust-lang/rfcs/tree/master/text


**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
