### PR TITLE
Add missing namespace option to port-forward command

### DIFF
--- a/docs/content/en/docs/operator-manual/control-plane/installation.md
+++ b/docs/content/en/docs/operator-manual/control-plane/installation.md
@@ -119,7 +119,7 @@ If your installation was including an [ingress](https://github.com/pipe-cd/manif
 Otherwise, private PipeCD web can be accessed by using `kubectl port-forward` to expose the installed control-plane on your localhost:
 
 ``` console
-kubectl port-forward svc/pipecd 8080:443
+kubectl port-forward svc/pipecd 8080:443 --namespace=NAMESPACE
 ```
 
 Now go to [http://localhost:8080](http://localhost:8080) on your browser, you will see a page to login to your project. But before logging in, you need to initialize a new project by following the [next section](/docs/operator-manual/control-plane/adding-a-project/).


### PR DESCRIPTION
**What this PR does / why we need it**:
If namespace is specified in the `helm install` command, namespace should be specified in the `kubectl port-forward` command.

**Which issue(s) this PR fixes**:
Namespace is added to `kubectl port-forward` command.

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
