### PR TITLE
Fix doubled word in the drift description

### DIFF
--- a/pkg/app/piped/driftdetector/kubernetes/detector.go
+++ b/pkg/app/piped/driftdetector/kubernetes/detector.go
@@ -390,7 +390,7 @@ func makeSyncedState() model.ApplicationSyncState {
 
 func makeOutOfSyncState(adds, deletes []provider.Manifest, changes map[provider.Manifest]*diff.Result, commit string) model.ApplicationSyncState {
 	total := len(adds) + len(deletes) + len(changes)
-	shortReason := fmt.Sprintf("There are %d manifests are not synced (%d adds, %d deletes, %d changes)", total, len(adds), len(deletes), len(changes))
+	shortReason := fmt.Sprintf("There are %d manifests not synced (%d adds, %d deletes, %d changes)", total, len(adds), len(deletes), len(changes))
 
 	var b strings.Builder
 	if len(commit) >= 7 {


### PR DESCRIPTION
**What this PR does / why we need it**:
There is a wrong spelling in dectector.go

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
