### PR TITLE
Increase the timeout value of the build to make the binary on macos

### DIFF
--- a/.kapetanios/postsubmit.yaml
+++ b/.kapetanios/postsubmit.yaml
@@ -44,7 +44,7 @@ spec:
         type: PROJECT
 
   - name: publish-piped-darwin
-    timeout: 15m
+    timeout: 30m
     machine:
       resource: medium
     skipBranches:


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
