### PR TITLE
Add secret encryption feature on control-plane

### DIFF
--- a/pkg/app/api/api/BUILD.bazel
+++ b/pkg/app/api/api/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//pkg/app/api/service/webservice:go_default_library",
         "//pkg/app/api/stagelogstore:go_default_library",
         "//pkg/config:go_default_library",
+        "//pkg/crypto:go_default_library",
         "//pkg/datastore:go_default_library",
         "//pkg/git:go_default_library",
         "//pkg/model:go_default_library",

--- a/pkg/app/api/api/fake_web_api.go
+++ b/pkg/app/api/api/fake_web_api.go
@@ -300,6 +300,10 @@ func (a *FakeWebAPI) GetApplication(ctx context.Context, req *webservice.GetAppl
 	}, nil
 }
 
+func (a *FakeWebAPI) GenerateApplicationSealedSecret(ctx context.Context, req *webservice.GenerateApplicationSealedSecretRequest) (*webservice.GenerateApplicationSealedSecretResponse, error) {
+	return &webservice.GenerateApplicationSealedSecretResponse{}, nil
+}
+
 func (a *FakeWebAPI) ListDeployments(ctx context.Context, req *webservice.ListDeploymentsRequest) (*webservice.ListDeploymentsResponse, error) {
 	now := time.Now()
 	deploymentTime := now

--- a/pkg/app/api/api/piped_api.go
+++ b/pkg/app/api/api/piped_api.go
@@ -88,7 +88,7 @@ func (a *PipedAPI) ReportPipedMeta(ctx context.Context, req *pipedservice.Report
 	now := time.Now().Unix()
 	connStatus := model.Piped_ONLINE
 
-	if err = a.pipedStore.UpdatePiped(ctx, pipedID, datastore.PipedMetadataUpdater(req.CloudProviders, req.Repositories, connStatus, req.Version, now)); err != nil {
+	if err = a.pipedStore.UpdatePiped(ctx, pipedID, datastore.PipedMetadataUpdater(req.CloudProviders, req.Repositories, connStatus, req.SealedSecretEncryption, req.Version, now)); err != nil {
 		switch err {
 		case datastore.ErrNotFound:
 			return nil, status.Error(codes.InvalidArgument, "piped is not found")

--- a/pkg/app/api/service/pipedservice/service.proto
+++ b/pkg/app/api/service/pipedservice/service.proto
@@ -144,6 +144,7 @@ message ReportPipedMetaRequest {
     string version = 1;
     repeated pipe.model.Piped.CloudProvider cloud_providers = 2;
     repeated pipe.model.ApplicationGitRepository repositories = 3;
+    pipe.model.Piped.SealedSecretEncryption sealed_secret_encryption = 4;
 }
 
 message ReportPipedMetaResponse {

--- a/pkg/app/api/service/webservice/service.proto
+++ b/pkg/app/api/service/webservice/service.proto
@@ -53,6 +53,7 @@ service WebService {
     rpc ListApplications(ListApplicationsRequest) returns (ListApplicationsResponse) {}
     rpc SyncApplication(SyncApplicationRequest) returns (SyncApplicationResponse) {}
     rpc GetApplication(GetApplicationRequest) returns (GetApplicationResponse) {}
+    rpc GenerateApplicationSealedSecret(GenerateApplicationSealedSecretRequest) returns (GenerateApplicationSealedSecretResponse) {}
 
     // Deployment
     rpc ListDeployments(ListDeploymentsRequest) returns (ListDeploymentsResponse) {}
@@ -210,6 +211,15 @@ message GetApplicationRequest {
 
 message GetApplicationResponse {
     pipe.model.Application application = 1;
+}
+
+message GenerateApplicationSealedSecretRequest {
+    string piped_id = 1 [(validate.rules).string.min_len = 1];
+    string data = 2 [(validate.rules).string.min_len = 1];
+}
+
+message GenerateApplicationSealedSecretResponse {
+    string data = 1 [(validate.rules).string.min_len = 1];
 }
 
 message ListDeploymentsRequest {

--- a/pkg/app/piped/cmd/piped/piped.go
+++ b/pkg/app/piped/cmd/piped/piped.go
@@ -397,11 +397,32 @@ func (p *piped) sendPipedMeta(ctx context.Context, client pipedservice.Client, c
 		err   error
 	)
 
+	// Configure the list of specified cloud providers.
 	for _, cp := range cfg.CloudProviders {
 		req.CloudProviders = append(req.CloudProviders, &model.Piped_CloudProvider{
 			Name: cp.Name,
 			Type: cp.Type.String(),
 		})
+	}
+
+	// Configure sealed secret management.
+	if sm := cfg.SealedSecretManagement; sm != nil {
+		switch sm.Type {
+		case model.SealedSecretManagementSealingKey:
+			publicKey, err := ioutil.ReadFile(sm.PublicKeyFile)
+			if err != nil {
+				return fmt.Errorf("failed to read public key for sealed secret management (%v)", err)
+			}
+			req.SealedSecretEncryption = &model.Piped_SealedSecretEncryption{
+				Type:      sm.Type.String(),
+				PublicKey: string(publicKey),
+			}
+		}
+	}
+	if req.SealedSecretEncryption == nil {
+		req.SealedSecretEncryption = &model.Piped_SealedSecretEncryption{
+			Type: model.SealedSecretManagementNone.String(),
+		}
 	}
 
 	for retry.WaitNext(ctx) {

--- a/pkg/app/piped/cmd/piped/piped.go
+++ b/pkg/app/piped/cmd/piped/piped.go
@@ -411,7 +411,7 @@ func (p *piped) sendPipedMeta(ctx context.Context, client pipedservice.Client, c
 		case model.SealedSecretManagementSealingKey:
 			publicKey, err := ioutil.ReadFile(sm.PublicKeyFile)
 			if err != nil {
-				return fmt.Errorf("failed to read public key for sealed secret management (%v)", err)
+				return fmt.Errorf("failed to read public key for sealed secret management (%w)", err)
 			}
 			req.SealedSecretEncryption = &model.Piped_SealedSecretEncryption{
 				Type:      sm.Type.String(),

--- a/pkg/app/web/src/modules/pipeds.ts
+++ b/pkg/app/web/src/modules/pipeds.ts
@@ -7,7 +7,7 @@ import {
 import { Piped as PipedModel } from "pipe/pkg/app/web/model/piped_pb";
 import * as pipedsApi from "../api/piped";
 
-export type Piped = Required<PipedModel.AsObject>;
+export type Piped = PipedModel.AsObject;
 
 export interface RegisteredPiped {
   id: string;

--- a/pkg/config/piped_test.go
+++ b/pkg/config/piped_test.go
@@ -200,6 +200,11 @@ func TestPipedConfig(t *testing.T) {
 						},
 					},
 				},
+				SealedSecretManagement: &SealedSecretManagement{
+					Type:           model.SealedSecretManagementSealingKey,
+					PrivateKeyFile: "/etc/piped-secret/sealing-private-key",
+					PublicKeyFile:  "/etc/piped-secret/sealing-public-key",
+				},
 			},
 			expectedError: nil,
 		},

--- a/pkg/config/testdata/piped/piped-config.yaml
+++ b/pkg/config/testdata/piped/piped-config.yaml
@@ -111,3 +111,12 @@ spec:
       - name: ci-webhook
         webhook:
           url: https://pipecd.dev/dev-hook
+
+  sealedSecretManagement:
+    type: SEALING_KEY
+    privateKeyFile: /etc/piped-secret/sealing-private-key
+    publicKeyFile: /etc/piped-secret/sealing-public-key
+    # type: GCP_KMS
+    # keyName: key-name
+    # decryptServiceAccountFile: /etc/piped-secret/decrypt-service-account.json 
+    # encryptServiceAccountFile: /etc/piped-secret/encrypt-service-account.json

--- a/pkg/crypto/rsa.go
+++ b/pkg/crypto/rsa.go
@@ -25,13 +25,13 @@ type RSAEncrypter struct {
 	key *rsa.PublicKey
 }
 
-func NewRSAEncrypter(keyFile string) (*RSAEncrypter, error) {
-	key, err := LoadRSAPublicKey(keyFile)
+func NewRSAEncrypter(key string) (*RSAEncrypter, error) {
+	k, err := ParseRSAPublicKeyFromPem([]byte(key))
 	if err != nil {
 		return nil, err
 	}
 	return &RSAEncrypter{
-		key: key,
+		key: k,
 	}, nil
 }
 

--- a/pkg/crypto/rsa_test.go
+++ b/pkg/crypto/rsa_test.go
@@ -15,6 +15,7 @@
 package crypto
 
 import (
+	"io/ioutil"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -22,7 +23,10 @@ import (
 )
 
 func TestRSAEncryptDecrypt(t *testing.T) {
-	encrypter, err := NewRSAEncrypter("testdata/public-rsa-pem")
+	data, err := ioutil.ReadFile("testdata/public-rsa-pem")
+	require.NoError(t, err)
+
+	encrypter, err := NewRSAEncrypter(string(data))
 	require.NoError(t, err)
 
 	text := "original-text"

--- a/pkg/datastore/pipedstore.go
+++ b/pkg/datastore/pipedstore.go
@@ -27,11 +27,22 @@ var (
 	pipedFactory = func() interface{} {
 		return &model.Piped{}
 	}
-	PipedMetadataUpdater = func(cloudProviders []*model.Piped_CloudProvider, repos []*model.ApplicationGitRepository, status model.Piped_ConnectionStatus, version string, startedAt int64) func(piped *model.Piped) error {
+	PipedMetadataUpdater = func(
+		cloudProviders []*model.Piped_CloudProvider,
+		repos []*model.ApplicationGitRepository,
+		status model.Piped_ConnectionStatus,
+		sse *model.Piped_SealedSecretEncryption,
+		version string,
+		startedAt int64,
+	) func(piped *model.Piped) error {
+
 		return func(piped *model.Piped) error {
 			piped.CloudProviders = cloudProviders
 			piped.Repositories = repos
 			piped.Status = status
+			if sse != nil {
+				piped.SealedSecretEncryption = sse
+			}
 			piped.Version = version
 			piped.StartedAt = startedAt
 			return nil

--- a/pkg/model/piped.go
+++ b/pkg/model/piped.go
@@ -27,6 +27,19 @@ const (
 	redactedMessage = "redacted"
 )
 
+type SealedSecretManagementType string
+
+const (
+	SealedSecretManagementNone       SealedSecretManagementType = "NONE"
+	SealedSecretManagementSealingKey SealedSecretManagementType = "SEALING_KEY"
+	SealedSecretManagementGCPKMS     SealedSecretManagementType = "GCP_KMS"
+	SealedSecretManagementAWSKMS     SealedSecretManagementType = "AWS_KMS"
+)
+
+func (t SealedSecretManagementType) String() string {
+	return string(t)
+}
+
 // GeneratePipedKey generates a new key for piped.
 // This returns raw key value for used by piped and
 // a hash value of the key for storing in datastore.

--- a/pkg/model/piped.proto
+++ b/pkg/model/piped.proto
@@ -26,6 +26,12 @@ message Piped {
         string type = 2 [(validate.rules).string.min_len = 1];
     }
 
+    message SealedSecretEncryption {
+        string type = 1 [(validate.rules).string = {in: ["SEALING_KEY", "GCP_KMS", "AWS_KMS", "NONE"]}];
+        string public_key = 2;
+        string encrypt_service_account = 3;
+    }
+
     enum ConnectionStatus {
         ONLINE = 0;
         OFFLINE = 1;
@@ -55,6 +61,8 @@ message Piped {
     repeated ApplicationGitRepository repositories = 10;
     // The latest connection status of piped.
     ConnectionStatus status = 11 [(validate.rules).enum.defined_only = true];
+    // The public key/service account for encrypting the secret data.
+    SealedSecretEncryption sealed_secret_encryption = 12;
 
     // Whether the piped is disabled or not.
     bool disabled = 13;


### PR DESCRIPTION
**What this PR does / why we need it**:

- Send public key to control-plane when piped started
- Add encryption gRPC API for web

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
