### PR TITLE
Emit target namespace on the stage log

### DIFF
--- a/pkg/app/piped/executor/kubernetes/kubernetes.go
+++ b/pkg/app/piped/executor/kubernetes/kubernetes.go
@@ -189,7 +189,11 @@ func (e *Executor) addBuiltinAnnontations(manifests []provider.Manifest, variant
 }
 
 func (e *Executor) applyManifests(ctx context.Context, manifests []provider.Manifest) error {
-	e.LogPersister.Infof("Start applying %d manifests to %q namespace", len(manifests), e.config.Input.Namespace)
+	if e.config.Input.Namespace == "" {
+		e.LogPersister.Infof("Start applying %d manifests", len(manifests))
+	} else {
+		e.LogPersister.Infof("Start applying %d manifests to %q namespace", len(manifests), e.config.Input.Namespace)
+	}
 	for _, m := range manifests {
 		if err := e.provider.ApplyManifest(ctx, m); err != nil {
 			e.LogPersister.Errorf("Failed to apply manifest: %s (%v)", m.Key.ReadableString(), err)

--- a/pkg/app/piped/executor/kubernetes/kubernetes.go
+++ b/pkg/app/piped/executor/kubernetes/kubernetes.go
@@ -189,7 +189,7 @@ func (e *Executor) addBuiltinAnnontations(manifests []provider.Manifest, variant
 }
 
 func (e *Executor) applyManifests(ctx context.Context, manifests []provider.Manifest) error {
-	e.LogPersister.Infof("Start applying %d manifests", len(manifests))
+	e.LogPersister.Infof("Start applying %d manifests to %q namespace", len(manifests), e.config.Input.Namespace)
 	for _, m := range manifests {
 		if err := e.provider.ApplyManifest(ctx, m); err != nil {
 			e.LogPersister.Errorf("Failed to apply manifest: %s (%v)", m.Key.ReadableString(), err)


### PR DESCRIPTION
**What this PR does / why we need it**:
The below log shows the contents of the manifest, so it appears to be correct:
```
- applied manifest: name="playground", kind="Deployment", namespace="default", apiVersion="apps/v1"
```

Instead, I appended target namespace info to another log.

**Which issue(s) this PR fixes**:

Fixes https://github.com/pipe-cd/pipe/issues/969

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
