### PR TITLE
Add copy button for copying of encrypted secret

### DIFF
--- a/pkg/app/web/package.json
+++ b/pkg/app/web/package.json
@@ -66,6 +66,7 @@
     "@reduxjs/toolkit": "^1.3.6",
     "@types/dagre": "^0.7.44",
     "clsx": "^1.1.1",
+    "copy-to-clipboard": "^3.3.1",
     "dagre": "^0.8.5",
     "dayjs": "^1.8.28",
     "dotenv": "^8.2.0",

--- a/pkg/app/web/src/components/sealed-secret-dialog.stories.tsx
+++ b/pkg/app/web/src/components/sealed-secret-dialog.stories.tsx
@@ -1,26 +1,53 @@
 import { action } from "@storybook/addon-actions";
 import React from "react";
-import { createDecoratorRedux } from "../../.storybook/redux-decorator";
 import { dummyApplication } from "../__fixtures__/dummy-application";
 import { SealedSecretDialog } from "./sealed-secret-dialog";
+import { Provider } from "react-redux";
+import { createStore } from "../../test-utils";
 
 export default {
   title: "SealedSecretDialog",
   component: SealedSecretDialog,
-  decorators: [
-    createDecoratorRedux({
-      applications: {
-        entities: { [dummyApplication.id]: dummyApplication },
-        ids: [dummyApplication.id],
-      },
-    }),
-  ],
 };
 
-export const overview: React.FC = () => (
-  <SealedSecretDialog
-    open
-    applicationId={dummyApplication.id}
-    onClose={action("onClose")}
-  />
-);
+export const overview: React.FC = () => {
+  const store = createStore({
+    applications: {
+      entities: { [dummyApplication.id]: dummyApplication },
+      ids: [dummyApplication.id],
+    },
+  });
+  return (
+    <Provider store={store}>
+      <SealedSecretDialog
+        open
+        applicationId={dummyApplication.id}
+        onClose={action("onClose")}
+      />
+    </Provider>
+  );
+};
+
+export const encrypted: React.FC = () => {
+  const store = createStore({
+    applications: {
+      entities: { [dummyApplication.id]: dummyApplication },
+      ids: [dummyApplication.id],
+    },
+    sealedSecret: {
+      isLoading: false,
+      // dummy data
+      data:
+        "AgEAk+XZY0+8hJSv5GG8rDTZGV56xe3xCROxGtVwNVY3kSg3MAvq1BcbhkIToT1q7JVYnE/MQ/nuks5MXPrFpu5/bHCehlzsFc8tnffQeYtVO3XuCi771zd4KNsAmCMvN0Fo57eqzuhU/uEYt+1thRJh3FA/tJilZ0j1JiSvrn01Zfb1Xw0QGMCO4/C75YRUa6g2JC75yLKZ06Yzequ1wSglLzF7rzUdl1+kxCBWJM1HnFkBpLGtCcH7xqBbkQMEz1jOjgpluPDUD7nCwMmZzY9sw83jOXfsCdNvmy/uStIsTDBZDPE1uWxN8MAWEieLoOvLLUFWGXmMDEJAa6nv1iI/jv8OLXzUEOeklc/OKZ7jLOnylmqQ4U7YCFsfHqAMzAFadpORxHCHt09zHzm9nKoyhOCFo9gDVyX6HiD9h3V/j1gBmr9lgonfiVC0HbsghOLJMjf+9njNiEqD7IOhBVv6TEwGpGI+1SYoBu6m8+Jlex2j5VcspMybx6p5aKmuwQpLqrEFMZBYJwAXMrAxkMiiE5QnB9/K7YAcYr3a33qGPu+JmQKgg9QRN0X5jvl/FNaYDoXzNp1FBuFEQUtu0hw8QKtf/DWVAUj/zgyviPQ2j8fy5Yg7qwxuL12EQMeAtC0pwyFNE7SlyvGoGoKc+yp0/EfpFzyH3n807+UD8ueN+bbvKn0gXkePO2Af1a61LU/lPOe68A==",
+    },
+  });
+  return (
+    <Provider store={store}>
+      <SealedSecretDialog
+        open
+        applicationId={dummyApplication.id}
+        onClose={action("onClose")}
+      />
+    </Provider>
+  );
+};

--- a/pkg/app/web/src/components/sealed-secret-dialog.test.tsx
+++ b/pkg/app/web/src/components/sealed-secret-dialog.test.tsx
@@ -1,0 +1,51 @@
+import { fireEvent } from "@testing-library/react";
+import React from "react";
+import { render, screen } from "../../test-utils";
+import { dummyApplication } from "../__fixtures__/dummy-application";
+import { SealedSecretDialog } from "./sealed-secret-dialog";
+
+test("render", () => {
+  render(
+    <SealedSecretDialog
+      applicationId={dummyApplication.id}
+      onClose={() => null}
+      open
+    />,
+    {
+      initialState: {
+        applications: {
+          entities: {
+            [dummyApplication.id]: dummyApplication,
+          },
+          ids: [dummyApplication.id],
+        },
+      },
+    }
+  );
+
+  expect(screen.getByText(dummyApplication.name)).toBeInTheDocument();
+});
+
+test("cancel", () => {
+  const onClose = jest.fn();
+  render(
+    <SealedSecretDialog
+      applicationId={dummyApplication.id}
+      onClose={onClose}
+      open
+    />,
+    {
+      initialState: {
+        applications: {
+          entities: {
+            [dummyApplication.id]: dummyApplication,
+          },
+          ids: [dummyApplication.id],
+        },
+      },
+    }
+  );
+
+  fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+  expect(onClose).toHaveBeenCalled();
+});

--- a/pkg/app/web/src/components/sealed-secret-dialog.tsx
+++ b/pkg/app/web/src/components/sealed-secret-dialog.tsx
@@ -4,11 +4,13 @@ import {
   DialogActions,
   DialogContent,
   DialogTitle,
+  IconButton,
   makeStyles,
   TextField,
   Typography,
 } from "@material-ui/core";
-import React, { FC, useState } from "react";
+import CopyIcon from "@material-ui/icons/FileCopyOutlined";
+import React, { FC, useRef, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { AppState } from "../modules";
 import { Application, selectById } from "../modules/applications";
@@ -17,6 +19,8 @@ import {
   SealedSecret,
   clearSealedSecret,
 } from "../modules/sealed-secret";
+import copy from "copy-to-clipboard";
+import { addToast } from "../modules/toasts";
 
 const useStyles = makeStyles((theme) => ({
   description: {
@@ -25,6 +29,9 @@ const useStyles = makeStyles((theme) => ({
   targetApp: {
     color: theme.palette.text.primary,
     fontWeight: theme.typography.fontWeightMedium,
+  },
+  encryptedSecret: {
+    wordBreak: "break-all",
   },
 }));
 
@@ -44,6 +51,7 @@ export const SealedSecretDialog: FC<Props> = ({
   const classes = useStyles();
   const dispatch = useDispatch();
   const [data, setData] = useState("");
+  const secretRef = useRef<HTMLDivElement>(null);
 
   const [application, sealedSecret] = useSelector<
     AppState,
@@ -71,6 +79,16 @@ export const SealedSecretDialog: FC<Props> = ({
     }, 200);
   };
 
+  const handleOnClickCopy = (): void => {
+    if (sealedSecret.data) {
+      copy(sealedSecret.data, {
+        onCopy: () => {
+          dispatch(addToast({ message: "Secret copied to clipboard" }));
+        },
+      });
+    }
+  };
+
   if (!application) {
     return null;
   }
@@ -86,20 +104,22 @@ export const SealedSecretDialog: FC<Props> = ({
         <>
           <DialogTitle>{DIALOG_TITLE}</DialogTitle>
           <DialogContent>
-            <TextField
-              value={sealedSecret.data}
-              variant="outlined"
-              margin="dense"
-              label="Secret Data"
-              multiline
-              fullWidth
-              rows={6}
-              required
-              autoFocus
-              onFocus={(e) => {
-                e.target.select();
-              }}
-            />
+            <Typography variant="caption">Encrypted secret data</Typography>
+            <Typography
+              variant="body2"
+              className={classes.encryptedSecret}
+              ref={secretRef}
+            >
+              {sealedSecret.data}
+              <IconButton
+                size="small"
+                style={{ marginLeft: 8 }}
+                aria-label="Copy secret"
+                onClick={handleOnClickCopy}
+              >
+                <CopyIcon style={{ fontSize: 20 }} />
+              </IconButton>
+            </Typography>
           </DialogContent>
           <DialogActions>
             <Button onClick={onClose}>Close</Button>

--- a/pkg/app/web/yarn.lock
+++ b/pkg/app/web/yarn.lock
@@ -5440,7 +5440,7 @@ copy-descriptor@^0.1.0:
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
-copy-to-clipboard@^3.0.8:
+copy-to-clipboard@^3.0.8, copy-to-clipboard@^3.3.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/copy-to-clipboard/-/copy-to-clipboard-3.3.1.tgz#115aa1a9998ffab6196f93076ad6da3b913662ae"
   integrity sha512-i13qo6kIHTTpCm8/Wup+0b1mVWETvu2kIMzKoK8FpkLkFxlt0znUAHcMzox+T8sPlqtZXq3CulEjQHsYiGFJUw==


### PR DESCRIPTION
**What this PR does / why we need it**:

![Kapture 2020-10-21 at 18 34 48](https://user-images.githubusercontent.com/6136383/96701938-203c2200-13cc-11eb-8ed6-e3da9c00c974.gif)


**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Add a copy to clipboard button to the dialog for showing encrypted secret.
```
