### PR TITLE
Remove credentials config from terraform provider

### DIFF
--- a/docs/content/en/docs/operator-manual/piped/configuration-reference.md
+++ b/docs/content/en/docs/operator-manual/piped/configuration-reference.md
@@ -84,8 +84,6 @@ Must be one of the following structs:
 
 | Field | Type | Description | Required |
 |-|-|-|-|
-| credentialsDirName | string | The name of directory where to put the configured credentials files. Default is `.terraform-crendentials`. | No |
-| credentialsFiles | []string | List of credentials files that will be copied to the CredentialsDir before running terraform commands. | No |
 | vars | []string | List of variables that will be set directly on terraform commands with `-var` flag. The variable must be formatted by `key=value`. | No |
 
 ### CloudProviderCloudRunConfig

--- a/pkg/app/piped/executor/terraform/apply.go
+++ b/pkg/app/piped/executor/terraform/apply.go
@@ -26,14 +26,6 @@ func (e *Executor) ensureApply(ctx context.Context) model.StageStatus {
 	appDir := filepath.Join(e.RepoDir, e.Deployment.GitPath.Path)
 	cmd := provider.NewTerraform(e.terraformPath, appDir, e.vars, e.config.Input.VarFiles)
 
-	if files := e.cloudProviderConfig.CredentialsFiles; len(files) > 0 {
-		if err := prepareCredentialsDirectory(appDir, e.cloudProviderConfig.CredentialsDirName, files); err != nil {
-			e.LogPersister.Errorf("Unable to prepare credentials files (%v)", err)
-			return model.StageStatus_STAGE_FAILURE
-		}
-		e.LogPersister.Infof("Successfully prepared %d credentials files for terraform executions", len(files))
-	}
-
 	if ok := e.showUsingVersion(ctx, cmd); !ok {
 		return model.StageStatus_STAGE_FAILURE
 	}

--- a/pkg/app/piped/executor/terraform/plan.go
+++ b/pkg/app/piped/executor/terraform/plan.go
@@ -26,14 +26,6 @@ func (e *Executor) ensurePlan(ctx context.Context) model.StageStatus {
 	appDir := filepath.Join(e.RepoDir, e.Deployment.GitPath.Path)
 	cmd := provider.NewTerraform(e.terraformPath, appDir, e.vars, e.config.Input.VarFiles)
 
-	if files := e.cloudProviderConfig.CredentialsFiles; len(files) > 0 {
-		if err := prepareCredentialsDirectory(appDir, e.cloudProviderConfig.CredentialsDirName, files); err != nil {
-			e.LogPersister.Errorf("Unable to prepare credentials files (%v)", err)
-			return model.StageStatus_STAGE_FAILURE
-		}
-		e.LogPersister.Infof("Successfully prepared %d credentials files for terraform executions", len(files))
-	}
-
 	if ok := e.showUsingVersion(ctx, cmd); !ok {
 		return model.StageStatus_STAGE_FAILURE
 	}

--- a/pkg/app/piped/executor/terraform/rollback.go
+++ b/pkg/app/piped/executor/terraform/rollback.go
@@ -34,14 +34,6 @@ func (e *Executor) ensureRollback(ctx context.Context) model.StageStatus {
 	appDir := filepath.Join(e.RunningRepoDir, e.Deployment.GitPath.Path)
 	cmd := provider.NewTerraform(e.terraformPath, appDir, e.vars, e.config.Input.VarFiles)
 
-	if files := e.cloudProviderConfig.CredentialsFiles; len(files) > 0 {
-		if err := prepareCredentialsDirectory(appDir, e.cloudProviderConfig.CredentialsDirName, files); err != nil {
-			e.LogPersister.Errorf("Unable to prepare credentials files (%v)", err)
-			return model.StageStatus_STAGE_FAILURE
-		}
-		e.LogPersister.Infof("Successfully prepared %d credentials files for terraform executions", len(files))
-	}
-
 	if ok := e.showUsingVersion(ctx, cmd); !ok {
 		return model.StageStatus_STAGE_FAILURE
 	}

--- a/pkg/app/piped/executor/terraform/sync.go
+++ b/pkg/app/piped/executor/terraform/sync.go
@@ -26,14 +26,6 @@ func (e *Executor) ensureSync(ctx context.Context) model.StageStatus {
 	appDir := filepath.Join(e.RepoDir, e.Deployment.GitPath.Path)
 	cmd := provider.NewTerraform(e.terraformPath, appDir, e.vars, e.config.Input.VarFiles)
 
-	if files := e.cloudProviderConfig.CredentialsFiles; len(files) > 0 {
-		if err := prepareCredentialsDirectory(appDir, e.cloudProviderConfig.CredentialsDirName, files); err != nil {
-			e.LogPersister.Errorf("Unable to prepare credentials files (%v)", err)
-			return model.StageStatus_STAGE_FAILURE
-		}
-		e.LogPersister.Infof("Successfully prepared %d credentials files for terraform executions", len(files))
-	}
-
 	if ok := e.showUsingVersion(ctx, cmd); !ok {
 		return model.StageStatus_STAGE_FAILURE
 	}

--- a/pkg/app/piped/executor/terraform/terraform.go
+++ b/pkg/app/piped/executor/terraform/terraform.go
@@ -16,21 +16,12 @@ package terraform
 
 import (
 	"context"
-	"fmt"
-	"io/ioutil"
-	"os"
-	"path"
-	"path/filepath"
 
 	provider "github.com/pipe-cd/pipe/pkg/app/piped/cloudprovider/terraform"
 	"github.com/pipe-cd/pipe/pkg/app/piped/executor"
 	"github.com/pipe-cd/pipe/pkg/app/piped/toolregistry"
 	"github.com/pipe-cd/pipe/pkg/config"
 	"github.com/pipe-cd/pipe/pkg/model"
-)
-
-const (
-	DefaultCredentialsDirName = ".terraform-credentials"
 )
 
 type Executor struct {
@@ -150,29 +141,4 @@ func (e *Executor) findTerraform(ctx context.Context, version string) (string, b
 		e.LogPersister.Infof("Terraform %q has just been installed to %q because of no pre-installed binary for that version", version, path)
 	}
 	return path, true
-}
-
-func prepareCredentialsDirectory(appDir, credentialsDirName string, files []string) error {
-	if credentialsDirName == "" {
-		credentialsDirName = DefaultCredentialsDirName
-	}
-	dirPath := filepath.Join(appDir, credentialsDirName)
-	if err := os.MkdirAll(dirPath, os.ModePerm); err != nil {
-		return fmt.Errorf("unable to ensure the existence of credentials directory %s (%w)", dirPath, err)
-	}
-
-	for _, f := range files {
-		input, err := ioutil.ReadFile(f)
-		if err != nil {
-			return fmt.Errorf("unable to read credentials file %s (%w)", f, err)
-		}
-
-		des := filepath.Join(dirPath, path.Base(f))
-		err = ioutil.WriteFile(des, input, 0644)
-		if err != nil {
-			return fmt.Errorf("unable to write credentials file %s to %s (%w)", f, des, err)
-		}
-	}
-
-	return nil
 }

--- a/pkg/config/piped.go
+++ b/pkg/config/piped.go
@@ -285,11 +285,6 @@ type KubernetesResourceMatcher struct {
 }
 
 type CloudProviderTerraformConfig struct {
-	// The name of directory where to put the configured credentials files.
-	// Default is ".terraform-credentials"
-	CredentialsDirName string `json:"credentialsDirName"`
-	// List of credentials files that will be copied to the CredentialsDir before running terraform commands.
-	CredentialsFiles []string `json:"credentialsFiles"`
 	// List of variables that will be set directly on terraform commands with "-var" flag.
 	// The variable must be formatted by "key=value" as below:
 	// "image_id=ami-abc123"

--- a/pkg/config/piped_test.go
+++ b/pkg/config/piped_test.go
@@ -104,9 +104,6 @@ func TestPipedConfig(t *testing.T) {
 								"project=gcp-project",
 								"region=us-centra1",
 							},
-							CredentialsFiles: []string{
-								"/path-to-credentials-file",
-							},
 						},
 					},
 					{

--- a/pkg/config/testdata/piped/piped-config.yaml
+++ b/pkg/config/testdata/piped/piped-config.yaml
@@ -48,8 +48,6 @@ spec:
         vars:
           - "project=gcp-project"
           - "region=us-centra1"
-        credentialsFiles:
-          - /path-to-credentials-file
 
     - name: cloudrun
       type: CLOUDRUN


### PR DESCRIPTION
**What this PR does / why we need it**:

Because from now we can use the sealed secret for storing the credentials.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```

/approve