### PR TITLE
Update kubernetes manifests to ensure piped container runs as a non root user

### DIFF
--- a/manifests/piped/templates/deployment.yaml
+++ b/manifests/piped/templates/deployment.yaml
@@ -49,8 +49,8 @@ spec:
             - name: piped-config
               mountPath: /etc/piped-config
               readOnly: true
-            - name: ssh-config
-              mountPath: /home/pipecd/.ssh
+            - name: pipecd-home
+              mountPath: /home/pipecd
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:
@@ -61,7 +61,8 @@ spec:
         - name: piped-config
           configMap:
             name: {{ include "piped.configMapName" . }}
-        - name: ssh-config
+        # TODO: Grant write access to the pipecd user's home direcotry in other ways.
+        - name: pipecd-home
           emptyDir: {}
       securityContext:
         runAsNonRoot: true

--- a/manifests/piped/templates/deployment.yaml
+++ b/manifests/piped/templates/deployment.yaml
@@ -49,6 +49,8 @@ spec:
             - name: piped-config
               mountPath: /etc/piped-config
               readOnly: true
+            - name: ssh-config
+              mountPath: /home/pipecd/.ssh
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:
@@ -59,6 +61,12 @@ spec:
         - name: piped-config
           configMap:
             name: {{ include "piped.configMapName" . }}
+        - name: ssh-config
+          emptyDir: {}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/manifests/piped/templates/deployment.yaml
+++ b/manifests/piped/templates/deployment.yaml
@@ -49,8 +49,6 @@ spec:
             - name: piped-config
               mountPath: /etc/piped-config
               readOnly: true
-            - name: pipecd-home
-              mountPath: /home/pipecd
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:
@@ -61,9 +59,6 @@ spec:
         - name: piped-config
           configMap:
             name: {{ include "piped.configMapName" . }}
-        # TODO: Grant write access to the pipecd user's home direcotry in other ways.
-        - name: pipecd-home
-          emptyDir: {}
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Part of https://github.com/pipe-cd/pipe/issues/987

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
