### PR TITLE
Change the default ssh config path to the home directory of pipecd user

### DIFF
--- a/docs/content/en/docs/operator-manual/piped/configuration-reference.md
+++ b/docs/content/en/docs/operator-manual/piped/configuration-reference.md
@@ -38,7 +38,7 @@ spec:
 |-|-|-|-|
 | username | string | The username that will be configured for `git` user. | No |
 | email | string | The email that will be configured for `git` user. | No |
-| sshConfigFilePath | string | Where to write ssh config file. Default is `etc/ssh/ssh_config`. | No |
+| sshConfigFilePath | string | Where to write ssh config file. Default is `/home/pipecd/.ssh/config`. | No |
 | host | string | The host name. Default is `github.com`. | No |
 | hostName | string | The hostname or IP address of the remote git server. Default is the same value with Host. | No |
 | sshKeyFile | string | The path to the private ssh key file. This will be used to clone the source code of the specified git repositories. | No |

--- a/pkg/config/piped.go
+++ b/pkg/config/piped.go
@@ -162,7 +162,7 @@ type PipedGit struct {
 	// The email that will be configured for `git` user.
 	Email string `json:"email"`
 	// Where to write ssh config file.
-	// Default is "/etc/ssh/ssh_config".
+	// Default is "/home/pipecd/.ssh/config".
 	SSHConfigFilePath string `json:"sshConfigFilePath"`
 	// The host name.
 	// e.g. github.com, gitlab.com

--- a/pkg/git/ssh_config.go
+++ b/pkg/git/ssh_config.go
@@ -33,7 +33,10 @@ Host {{ .Host }}
     StrictHostKeyChecking no
 `
 
-var sshConfigTmpl = template.Must(template.New("ssh-config").Parse(sshConfigTemplate))
+var (
+	sshConfigTmpl            = template.Must(template.New("ssh-config").Parse(sshConfigTemplate))
+	defaultSSHConfigFilePath = "/home/pipecd/.ssh/config"
+)
 
 type sshConfig struct {
 	Host         string
@@ -54,7 +57,7 @@ func AddSSHConfig(cfg config.PipedGit) error {
 
 	path := cfg.SSHConfigFilePath
 	if path == "" {
-		path = "/etc/ssh/ssh_config"
+		path = defaultSSHConfigFilePath
 	}
 	dir := filepath.Dir(path)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes https://github.com/pipe-cd/pipe/issues/987

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
