### PR TITLE
Rename the application configuration directory

### DIFF
--- a/docs/content/en/docs/concepts/_index.md
+++ b/docs/content/en/docs/concepts/_index.md
@@ -48,10 +48,10 @@ When the deployment is success, it means the running state is synced with the de
 A `.pipe.yaml` yaml file that contains configuration data to define how to deploy the application.
 Each application requires one deployment configuration file at application directory in the Git repository.
 
-### Application Configuration Directory
+### Application Directory
 
 A directory in Git repository containing deployment configuration file (`.pipe.yaml`) and application manifests.
-Each application must have one application configuration directory.
+Each application must have one application directory.
 
 ### Quick Sync
 

--- a/docs/content/en/docs/examples/_index.md
+++ b/docs/content/en/docs/examples/_index.md
@@ -17,7 +17,7 @@ https://github.com/pipe-cd/examples
 
 | Name                                                                        | Description |
 |-----------------------------------------------------------------------------|-------------|
-| [simple](https://github.com/pipe-cd/examples/tree/master/kubernetes/simple) | Deploy plain-yaml manifests in application configuration directory without using pipeline. |
+| [simple](https://github.com/pipe-cd/examples/tree/master/kubernetes/simple) | Deploy plain-yaml manifests in application directory without using pipeline. |
 | [helm-local-chart](https://github.com/pipe-cd/examples/tree/master/kubernetes/helm-local-chart) | Deploy a helm chart sourced from the same Git repository. |
 | [helm-remote-chart](https://github.com/pipe-cd/examples/tree/master/kubernetes/helm-remote-chart) | Deploy a helm chart sourced from a [Helm Chart Repository](https://helm.sh/docs/topics/chart_repository/). |
 | [helm-remote-git-chart](https://github.com/pipe-cd/examples/tree/master/kubernetes/helm-remote-git-chart) | Deploy a helm chart sourced from another Git repository. |

--- a/docs/content/en/docs/operator-manual/piped/adding-a-git-repository.md
+++ b/docs/content/en/docs/operator-manual/piped/adding-a-git-repository.md
@@ -7,7 +7,7 @@ description: >
 ---
 
 In the `piped` configuration file, we specify the list of Git repositories should be handled by the `piped`.
-A Git repository contains one or more deployable applications where each application is put inside a directory called as [application configuration directory](/docs/concepts/#application-configuration-directory).
+A Git repository contains one or more deployable applications where each application is put inside a directory called as [application directory](/docs/concepts/#application-configuration-directory).
 That directory contains a deployment configuration file (.pipe.yaml) as well as application manifests.
 The `piped` periodically checks the new commits and fetches the needed manifests from those repositories for executing the deployment.
 

--- a/docs/content/en/docs/user-guide/adding-an-application.md
+++ b/docs/content/en/docs/user-guide/adding-an-application.md
@@ -7,9 +7,9 @@ description: >
 ---
 
 An application is a collect of resources and configurations that are managed together.
-It represents the service which you are going to deploy. With PipeCD, all application's manifests and its deployment configuration (`.piped.yaml`) must be committed into a directory of a Git repository. That directory is called as application configuration directory.
+It represents the service which you are going to deploy. With PipeCD, all application's manifests and its deployment configuration (`.piped.yaml`) must be committed into a directory of a Git repository. That directory is called as application directory.
 
-Before deploying an application, the application must be registered from the web UI and a deployment configuration file (`.piped.yaml`) must be committed to the application configuration directory.
+Before deploying an application, the application must be registered from the web UI and a deployment configuration file (`.piped.yaml`) must be committed to the application directory.
 An application must belong to exactly one environment and can be handled by one of the registered `piped`s. Currently, PipeCD is supporting the following kinds of application:
 
 - Kubernetes application
@@ -45,7 +45,7 @@ Here are the list of fields in the register form:
 
 ## Adding deployment configuration file
 
-After registering the application, one more step left is adding the deployment configuration file (`.pipe.yaml`) for that application into the application configuration directory in Git repository.
+After registering the application, one more step left is adding the deployment configuration file (`.pipe.yaml`) for that application into the application directory in Git repository.
 
 While registering application helps `control-plane` know the basic information about application, the deployment configuration file is used by `piped`, and it helps `piped` know how the application should be deployed, such as doing canary/bluegreen strategy or requiring a manual approval...
 That deployment configuration file is in `YAML` format as below:

--- a/docs/content/en/docs/user-guide/configuring-deployment/cloudrun.md
+++ b/docs/content/en/docs/user-guide/configuring-deployment/cloudrun.md
@@ -6,7 +6,7 @@ description: >
   Specific guide for configuring CloudRun deployment.
 ---
 
-Deploying a CloudRun application requires a `service.yaml` file placing inside the application configuration directory. That file contains the service specification used by CloudRun as following: 
+Deploying a CloudRun application requires a `service.yaml` file placing inside the application directory. That file contains the service specification used by CloudRun as following: 
 
 ``` yaml
 apiVersion: serving.knative.dev/v1

--- a/docs/content/en/docs/user-guide/configuring-deployment/kubernetes.md
+++ b/docs/content/en/docs/user-guide/configuring-deployment/kubernetes.md
@@ -68,7 +68,7 @@ See the description of each stage at [Configuration Reference](/docs/user-guide/
 In addition to plain-YAML, PipeCD also supports Helm and Kustomize for templating application manifests.
 
 A helm chart can be loaded from:
-- the same git repository with the application configuration directory, we call as a `local chart`
+- the same git repository with the application directory, we call as a `local chart`
 
 ``` yaml
 apiVersion: pipecd.dev/v1beta1
@@ -106,7 +106,7 @@ spec:
 ```
 
 A kustomize base can be loaded from:
-- the same git repository with the application configuration directory, we call as a `local base`
+- the same git repository with the application directory, we call as a `local base`
 - a different git repository, we call as a `remote base`
 
 See [Examples](/docs/user-guide/examples/#kubernetes-applications) for more specific.

--- a/docs/content/en/docs/user-guide/configuring-deployment/terraform.md
+++ b/docs/content/en/docs/user-guide/configuring-deployment/terraform.md
@@ -34,7 +34,7 @@ See the description of each stage at [Configuration Reference](/docs/user-guide/
 
 Terraform module can be loaded from:
 
-- the same git repository with the application configuration directory, we call as a `local module`
+- the same git repository with the application directory, we call as a `local module`
 - a different git repository, we call as a `remote module`
 
 ## Reference

--- a/docs/content/en/docs/user-guide/examples.md
+++ b/docs/content/en/docs/user-guide/examples.md
@@ -17,7 +17,7 @@ https://github.com/pipe-cd/examples
 
 | Name                                                                        | Description |
 |-----------------------------------------------------------------------------|-------------|
-| [simple](https://github.com/pipe-cd/examples/tree/master/kubernetes/simple) | Deploy plain-yaml manifests in application configuration directory without using pipeline. |
+| [simple](https://github.com/pipe-cd/examples/tree/master/kubernetes/simple) | Deploy plain-yaml manifests in application directory without using pipeline. |
 | [helm-local-chart](https://github.com/pipe-cd/examples/tree/master/kubernetes/helm-local-chart) | Deploy a helm chart sourced from the same Git repository. |
 | [helm-remote-chart](https://github.com/pipe-cd/examples/tree/master/kubernetes/helm-remote-chart) | Deploy a helm chart sourced from a [Helm Chart Repository](https://helm.sh/docs/topics/chart_repository/). |
 | [helm-remote-git-chart](https://github.com/pipe-cd/examples/tree/master/kubernetes/helm-remote-git-chart) | Deploy a helm chart sourced from another Git repository. |

--- a/docs/content/en/docs/user-guide/triggering-a-deployment.md
+++ b/docs/content/en/docs/user-guide/triggering-a-deployment.md
@@ -11,7 +11,7 @@ The mission of the deployments is syncing all running resources/components of ap
 So by default, when a new merged pull request touches an application, a new deployment for that application will be triggered to sync the application to the state specified in the newest merged commit.
 
 A pull request (commit) is considered as touching an application whenever its changes include:
-- one or more files inside the application configuration directory
+- one or more files inside the application directory
 - one or more files inside one of the [dependencies](/docs/user-guide/configuration-reference/#kubernetesdeploymentinput) of the application
 
 After a new deployment was triggered, it will be queued to handle by the appropriate `piped`. And at this time the deployment pipeline was not decided yet.

--- a/examples/README.remote.md
+++ b/examples/README.remote.md
@@ -10,7 +10,7 @@ A repository contains some examples for PipeCD.
 
 | Name                                                                        | Description |
 |-----------------------------------------------------------------------------|-------------|
-| [simple](https://github.com/pipe-cd/examples/tree/master/kubernetes/simple) | Deploy plain-yaml manifests in application configuration directory without using pipeline. |
+| [simple](https://github.com/pipe-cd/examples/tree/master/kubernetes/simple) | Deploy plain-yaml manifests in application directory without using pipeline. |
 | [helm-local-chart](https://github.com/pipe-cd/examples/tree/master/kubernetes/helm-local-chart) | Deploy a helm chart sourced from the same Git repository. |
 | [helm-remote-chart](https://github.com/pipe-cd/examples/tree/master/kubernetes/helm-remote-chart) | Deploy a helm chart sourced from a [Helm Chart Repository](https://helm.sh/docs/topics/chart_repository/). |
 | [helm-remote-git-chart](https://github.com/pipe-cd/examples/tree/master/kubernetes/helm-remote-git-chart) | Deploy a helm chart sourced from another Git repository. |

--- a/examples/kubernetes/simple/.pipe.yaml
+++ b/examples/kubernetes/simple/.pipe.yaml
@@ -1,4 +1,4 @@
-# Deploy plain-yaml manifests in the application configuration directory
+# Deploy plain-yaml manifests in the application directory
 # without using pipeline.
 apiVersion: pipecd.dev/v1beta1
 kind: KubernetesApp

--- a/pkg/app/api/api/deploymentconfigtemplates/KubernetesSimple
+++ b/pkg/app/api/api/deploymentconfigtemplates/KubernetesSimple
@@ -1,4 +1,4 @@
-# Deploy plain-yaml manifests placing in the application configuration directory without specifying pipeline.
+# Deploy plain-yaml manifests placing in the application directory without specifying pipeline.
 apiVersion: pipecd.dev/v1beta1
 kind: KubernetesApp
 spec:

--- a/pkg/config/deployment.go
+++ b/pkg/config/deployment.go
@@ -266,7 +266,7 @@ type ImageWatcherTargetPath struct {
 }
 
 type SealedSecretMapping struct {
-	// Relative path from the application configuration directory to sealed secret file.
+	// Relative path from the application directory to sealed secret file.
 	Path string `json:"path"`
 	// The filename for the decrypted secret.
 	// Empty means the same name with the sealed secret file.

--- a/pkg/config/deployment_cloudrun.go
+++ b/pkg/config/deployment_cloudrun.go
@@ -29,7 +29,7 @@ func (s *CloudRunDeploymentSpec) Validate() error {
 }
 
 type CloudRunDeploymentInput struct {
-	// The name of service manifest file placing in application configuration directory.
+	// The name of service manifest file placing in application directory.
 	// Default is service.yaml
 	ServiceManifestFile string `json:"serviceManifestFile"`
 	// Automatically reverts to the previous state when the deployment is failed.

--- a/pkg/config/deployment_kubernetes.go
+++ b/pkg/config/deployment_kubernetes.go
@@ -45,7 +45,7 @@ func (s *KubernetesDeploymentSpec) Validate() error {
 
 // KubernetesDeploymentInput represents needed input for triggering a Kubernetes deployment.
 type KubernetesDeploymentInput struct {
-	// List of manifest files in the application configuration directory used to deploy.
+	// List of manifest files in the application directory used to deploy.
 	// Empty means all manifest files in the directory will be used.
 	Manifests []string `json:"manifests"`
 	// Version of kubectl will be used.


### PR DESCRIPTION
**What this PR does / why we need it**:

I realized that "application configuration directory" is too long, and we can just use "application directory" instead.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```

/cc @nakabonne 
