### PR TITLE
Show refresh button if fetching live state has error

### DIFF
--- a/pkg/app/web/src/__fixtures__/dummy-application-live-state.ts
+++ b/pkg/app/web/src/__fixtures__/dummy-application-live-state.ts
@@ -59,5 +59,5 @@ export const dummyApplicationLiveState: ApplicationLiveState = {
   cloudrun: {},
   lambda: {},
   terraform: {},
-  kubernetes: { resourcesList: [] },
+  kubernetes: { resourcesList },
 };

--- a/pkg/app/web/src/components/application-detail.stories.tsx
+++ b/pkg/app/web/src/components/application-detail.stories.tsx
@@ -31,6 +31,7 @@ const dummyStore: Partial<AppState> = {
       [dummyApplicationLiveState.applicationId]: dummyApplicationLiveState,
     },
     ids: [dummyApplicationLiveState.applicationId],
+    hasError: false,
   },
   pipeds: {
     entities: {

--- a/pkg/app/web/src/components/application-state-view.test.tsx
+++ b/pkg/app/web/src/components/application-state-view.test.tsx
@@ -4,6 +4,7 @@ import { fireEvent } from "@testing-library/react";
 import { ApplicationStateView } from "./application-state-view";
 import { dummyApplicationLiveState } from "../__fixtures__/dummy-application-live-state";
 import { clearError } from "../modules/applications-live-state";
+import { UI_TEXT_REFRESH } from "../constants/ui-text";
 
 it("shows refresh button if live state fetching has error", () => {
   const store = createStore({
@@ -24,11 +25,13 @@ it("shows refresh button if live state fetching has error", () => {
     }
   );
 
-  expect(screen.getByText("Sorry, something went wrong.")).toBeInTheDocument();
+  expect(
+    screen.getByText("It was unable to fetch the latest state of application.")
+  ).toBeInTheDocument();
 
   expect(store.getActions()).toEqual([]);
 
-  fireEvent.click(screen.getByRole("button", { name: "REFRESH" }));
+  fireEvent.click(screen.getByRole("button", { name: UI_TEXT_REFRESH }));
 
   expect(store.getActions()).toMatchObject([{ type: clearError.type }]);
 });

--- a/pkg/app/web/src/components/application-state-view.test.tsx
+++ b/pkg/app/web/src/components/application-state-view.test.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { createStore, render, screen } from "../../test-utils";
+import { fireEvent } from "@testing-library/react";
+import { ApplicationStateView } from "./application-state-view";
+import { dummyApplicationLiveState } from "../__fixtures__/dummy-application-live-state";
+import { clearError } from "../modules/applications-live-state";
+
+it("shows refresh button if live state fetching has error", () => {
+  const store = createStore({
+    applicationLiveState: {
+      entities: {
+        [dummyApplicationLiveState.applicationId]: dummyApplicationLiveState,
+      },
+      ids: [dummyApplicationLiveState.applicationId],
+      hasError: true,
+    },
+  });
+  render(
+    <ApplicationStateView
+      applicationId={dummyApplicationLiveState.applicationId}
+    />,
+    {
+      store,
+    }
+  );
+
+  expect(screen.getByText("Sorry, something went wrong.")).toBeInTheDocument();
+
+  expect(store.getActions()).toEqual([]);
+
+  fireEvent.click(screen.getByRole("button", { name: "REFRESH" }));
+
+  expect(store.getActions()).toMatchObject([{ type: clearError.type }]);
+});

--- a/pkg/app/web/src/components/application-state-view.tsx
+++ b/pkg/app/web/src/components/application-state-view.tsx
@@ -1,37 +1,66 @@
+import {
+  Button,
+  CircularProgress,
+  makeStyles,
+  Typography,
+} from "@material-ui/core";
+import { ApplicationKind } from "pipe/pkg/app/web/model/common_pb";
 import React, { FC, memo } from "react";
-import { useSelector } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { AppState } from "../modules";
 import {
   ApplicationLiveState,
-  selectById,
+  clearError,
+  selectById as selectLiveStateById,
 } from "../modules/applications-live-state";
 import { KubernetesStateView } from "./kubernetes-state-view";
-import { ApplicationKind } from "pipe/pkg/app/web/model/common_pb";
-import { CircularProgress, makeStyles } from "@material-ui/core";
-
-const useStyles = makeStyles(() => ({
-  loading: {
-    display: "flex",
-    justifyContent: "center",
-    alignItems: "center",
-    flex: 1,
-  },
-}));
 
 interface Props {
   applicationId: string;
 }
 
+const ERROR_MESSAGE = "Sorry, something went wrong.";
+
+const useStyles = makeStyles(() => ({
+  container: {
+    flex: 1,
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+}));
+
 export const ApplicationStateView: FC<Props> = memo(
   function ApplicationStateView({ applicationId }) {
     const classes = useStyles();
-    const liveState = useSelector<AppState, ApplicationLiveState | undefined>(
-      (state) => selectById(state.applicationLiveState, applicationId)
-    );
+    const dispatch = useDispatch();
+    const [hasError, liveState] = useSelector<
+      AppState,
+      [boolean, ApplicationLiveState | undefined]
+    >((state) => [
+      state.applicationLiveState.hasError,
+      selectLiveStateById(state.applicationLiveState, applicationId),
+    ]);
+
+    if (hasError) {
+      return (
+        <div className={classes.container}>
+          <Typography>{ERROR_MESSAGE}</Typography>
+          <Button
+            color="primary"
+            onClick={() => {
+              dispatch(clearError());
+            }}
+          >
+            REFRESH
+          </Button>
+        </div>
+      );
+    }
 
     if (!liveState) {
       return (
-        <div className={classes.loading}>
+        <div className={classes.container}>
           <CircularProgress />
         </div>
       );

--- a/pkg/app/web/src/components/application-state-view.tsx
+++ b/pkg/app/web/src/components/application-state-view.tsx
@@ -8,6 +8,7 @@ import {
 import { ApplicationKind } from "pipe/pkg/app/web/model/common_pb";
 import React, { FC, memo } from "react";
 import { useDispatch, useSelector } from "react-redux";
+import { UI_TEXT_REFRESH } from "../constants/ui-text";
 import { AppState } from "../modules";
 import {
   ApplicationLiveState,
@@ -53,7 +54,7 @@ export const ApplicationStateView: FC<Props> = memo(
               dispatch(clearError());
             }}
           >
-            REFRESH
+            {UI_TEXT_REFRESH}
           </Button>
         </Box>
       );

--- a/pkg/app/web/src/components/application-state-view.tsx
+++ b/pkg/app/web/src/components/application-state-view.tsx
@@ -1,4 +1,5 @@
 import {
+  Box,
   Button,
   CircularProgress,
   makeStyles,
@@ -19,7 +20,7 @@ interface Props {
   applicationId: string;
 }
 
-const ERROR_MESSAGE = "Sorry, something went wrong.";
+const ERROR_MESSAGE = "It was unable to fetch the latest state of application.";
 
 const useStyles = makeStyles(() => ({
   container: {
@@ -44,8 +45,8 @@ export const ApplicationStateView: FC<Props> = memo(
 
     if (hasError) {
       return (
-        <div className={classes.container}>
-          <Typography>{ERROR_MESSAGE}</Typography>
+        <Box className={classes.container} flexDirection="column">
+          <Typography variant="body1">{ERROR_MESSAGE}</Typography>
           <Button
             color="primary"
             onClick={() => {
@@ -54,7 +55,7 @@ export const ApplicationStateView: FC<Props> = memo(
           >
             REFRESH
           </Button>
-        </div>
+        </Box>
       );
     }
 

--- a/pkg/app/web/src/constants/ui-text.ts
+++ b/pkg/app/web/src/constants/ui-text.ts
@@ -2,3 +2,4 @@ export const UI_TEXT_SAVE = "Save";
 export const UI_TEXT_CANCEL = "Cancel";
 export const UI_TEXT_ADD = "Add";
 export const UI_TEXT_EDIT = "Edit";
+export const UI_TEXT_REFRESH = "REFRESH";

--- a/pkg/app/web/src/modules/applications-live-state.test.ts
+++ b/pkg/app/web/src/modules/applications-live-state.test.ts
@@ -9,6 +9,7 @@ describe("applicationLiveStateSlice reducer", () => {
     ).toMatchInlineSnapshot(`
       Object {
         "entities": Object {},
+        "hasError": false,
         "ids": Array [],
       }
     `);

--- a/pkg/app/web/src/modules/applications-live-state.ts
+++ b/pkg/app/web/src/modules/applications-live-state.ts
@@ -44,15 +44,31 @@ export const fetchApplicationStateById = createAsyncThunk<
 
 export const applicationLiveStateSlice = createSlice({
   name: "applicationLiveState",
-  initialState: applicationLiveStateAdapter.getInitialState({}),
-  reducers: {},
+  initialState: applicationLiveStateAdapter.getInitialState({
+    hasError: false,
+  }),
+  reducers: {
+    clearError(state) {
+      state.hasError = false;
+    },
+  },
   extraReducers: (builder) => {
-    builder.addCase(fetchApplicationStateById.fulfilled, (state, action) => {
-      if (action.payload) {
-        applicationLiveStateAdapter.upsertOne(state, action.payload);
-      }
-    });
+    builder
+      .addCase(fetchApplicationStateById.pending, (state) => {
+        state.hasError = false;
+      })
+      .addCase(fetchApplicationStateById.fulfilled, (state, action) => {
+        state.hasError = false;
+        if (action.payload) {
+          applicationLiveStateAdapter.upsertOne(state, action.payload);
+        }
+      })
+      .addCase(fetchApplicationStateById.rejected, (state) => {
+        state.hasError = true;
+      });
   },
 });
+
+export const { clearError } = applicationLiveStateSlice.actions;
 
 export { ApplicationLiveStateSnapshot as ApplicationLiveStateSnapshotModel } from "pipe/pkg/app/web/model/application_live_state_pb";

--- a/pkg/app/web/src/pages/applications/detail.tsx
+++ b/pkg/app/web/src/pages/applications/detail.tsx
@@ -1,5 +1,5 @@
 import React, { FC, memo, useEffect } from "react";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router";
 import { ApplicationDetail } from "../../components/application-detail";
 import { ApplicationStateView } from "../../components/application-state-view";
@@ -8,6 +8,7 @@ import { fetchApplicationStateById } from "../../modules/applications-live-state
 import { useInterval } from "../../hooks/use-interval";
 import { addToast } from "../../modules/toasts";
 import { AppDispatch } from "../../store";
+import { AppState } from "../../modules";
 
 const FETCH_INTERVAL = 4000;
 
@@ -15,24 +16,29 @@ export const ApplicationDetailPage: FC = memo(function ApplicationDetailPage() {
   const dispatch = useDispatch<AppDispatch>();
   const params = useParams<{ applicationId: string }>();
   const applicationId = decodeURIComponent(params.applicationId);
+  const hasLiveStateError = useSelector<AppState, boolean>(
+    (state) => state.applicationLiveState.hasError
+  );
 
   const fetchData = (): void => {
     if (applicationId) {
-      dispatch(fetchApplicationStateById(applicationId)).then((result) => {
-        if (fetchApplicationStateById.rejected.match(result)) {
-          dispatch(
-            addToast({
-              message: "Failed to get application live state",
-              severity: "error",
-            })
-          );
-        }
-      });
+      if (hasLiveStateError === false) {
+        dispatch(fetchApplicationStateById(applicationId)).then((result) => {
+          if (fetchApplicationStateById.rejected.match(result)) {
+            dispatch(
+              addToast({
+                message: "Failed to get application live state",
+                severity: "error",
+              })
+            );
+          }
+        });
+      }
       dispatch(fetchApplication(applicationId));
     }
   };
 
-  useEffect(fetchData, [applicationId, dispatch]);
+  useEffect(fetchData, [applicationId, dispatch, hasLiveStateError]);
   useInterval(fetchData, applicationId ? FETCH_INTERVAL : null);
 
   return (


### PR DESCRIPTION
**What this PR does / why we need it**:

![image](https://user-images.githubusercontent.com/6136383/96972250-37f0e300-1551-11eb-89bf-799d93d854e7.png)

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Show a button to refresh the live state instead of auto-refreshing if has an error
```
