### PR TITLE
Add deployment URL to the toast that showing after triggering application sync

### DIFF
--- a/pkg/app/web/BUILD.bazel
+++ b/pkg/app/web/BUILD.bazel
@@ -67,6 +67,7 @@ tsc(
             "**/__mocks__/**",
             "**/__fixtures__/**",
             "src/**/*.test.*",
+            "src/mocks/**",
             "src/**/*.stories.*",
         ],
     ) + [

--- a/pkg/app/web/src/__fixtures__/dummy-command.ts
+++ b/pkg/app/web/src/__fixtures__/dummy-command.ts
@@ -1,4 +1,5 @@
 import { Command, CommandModel, CommandStatus } from "../modules/commands";
+import { dummyDeployment } from "./dummy-deployment";
 
 export const dummyCommand: Command = {
   id: "command-1",
@@ -16,4 +17,11 @@ export const dummyCommand: Command = {
   },
   createdAt: 0,
   updatedAt: 0,
+};
+
+export const dummySyncSucceededCommand: Command = {
+  ...dummyCommand,
+  id: "sync-succeeded",
+  status: CommandStatus.COMMAND_SUCCEEDED,
+  metadataMap: [["TriggeredDeploymentID", dummyDeployment.id]],
 };

--- a/pkg/app/web/src/components/toasts.stories.tsx
+++ b/pkg/app/web/src/components/toasts.stories.tsx
@@ -1,12 +1,16 @@
 import React from "react";
 import { Toasts } from "./toasts";
-import { createDecoratorRedux } from "../../.storybook/redux-decorator";
+import { Provider } from "react-redux";
+import { createStore } from "../../test-utils";
 
 export default {
   title: "COMMON/Toasts",
   component: Toasts,
-  decorators: [
-    createDecoratorRedux({
+};
+
+export const overview: React.FC = () => (
+  <Provider
+    store={createStore({
       toasts: {
         entities: {
           "1": {
@@ -17,8 +21,28 @@ export default {
         },
         ids: ["1"],
       },
-    }),
-  ],
-};
+    })}
+  >
+    <Toasts />
+  </Provider>
+);
 
-export const overview: React.FC = () => <Toasts />;
+export const url: React.FC = () => (
+  <Provider
+    store={createStore({
+      toasts: {
+        entities: {
+          "1": {
+            id: "1",
+            message: "toast message",
+            severity: "success",
+            to: "/",
+          },
+        },
+        ids: ["1"],
+      },
+    })}
+  >
+    <Toasts />
+  </Provider>
+);

--- a/pkg/app/web/src/components/toasts.tsx
+++ b/pkg/app/web/src/components/toasts.tsx
@@ -1,7 +1,8 @@
-import { Snackbar } from "@material-ui/core";
+import { Button, Snackbar } from "@material-ui/core";
 import MuiAlert from "@material-ui/lab/Alert";
 import React, { FC } from "react";
 import { useDispatch, useSelector } from "react-redux";
+import { Link as RouterLink } from "react-router-dom";
 import { AppState } from "../modules";
 import { IToast, removeToast, selectAll } from "../modules/toasts";
 
@@ -15,30 +16,46 @@ export const Toasts: FC = () => {
 
   return (
     <>
-      {toasts.map((item) => (
-        <Snackbar
-          open
-          key={item.id}
-          anchorOrigin={{
-            vertical: "bottom",
-            horizontal: "left",
-          }}
-          autoHideDuration={
-            item.severity === "error" ? null : AUTO_HIDE_DURATION
-          }
-          onClose={() => dispatch(removeToast({ id: item.id }))}
-          message={item.message}
-        >
-          {item.severity && (
-            <MuiAlert
-              onClose={() => dispatch(removeToast({ id: item.id }))}
-              severity={item.severity}
-            >
-              {item.message}
-            </MuiAlert>
-          )}
-        </Snackbar>
-      ))}
+      {toasts.map((item) => {
+        const handleClose = (): void => {
+          dispatch(removeToast({ id: item.id }));
+        };
+        return (
+          <Snackbar
+            open
+            key={item.id}
+            anchorOrigin={{
+              vertical: "bottom",
+              horizontal: "left",
+            }}
+            autoHideDuration={
+              item.severity === "error" ? null : AUTO_HIDE_DURATION
+            }
+            onClose={handleClose}
+            message={item.message}
+          >
+            {item.severity && (
+              <MuiAlert
+                onClose={handleClose}
+                severity={item.severity}
+                action={
+                  item.to ? (
+                    <Button
+                      onClick={handleClose}
+                      component={RouterLink}
+                      to={item.to}
+                    >
+                      OPEN
+                    </Button>
+                  ) : null
+                }
+              >
+                {item.message}
+              </MuiAlert>
+            )}
+          </Snackbar>
+        );
+      })}
     </>
   );
 };

--- a/pkg/app/web/src/mocks/handlers.ts
+++ b/pkg/app/web/src/mocks/handlers.ts
@@ -1,2 +1,3 @@
 import { meHandlers } from "./services/me";
-export const handlers = [...meHandlers];
+import { commandHandlers } from "./services/command";
+export const handlers = [...meHandlers, ...commandHandlers];

--- a/pkg/app/web/src/mocks/services/command.ts
+++ b/pkg/app/web/src/mocks/services/command.ts
@@ -1,0 +1,54 @@
+import { rest } from "msw";
+import {
+  GetCommandRequest,
+  GetCommandResponse,
+} from "pipe/pkg/app/web/api_client/service_pb";
+import { CommandModel } from "../../modules/commands";
+import {
+  dummyCommand,
+  dummySyncSucceededCommand,
+} from "../../__fixtures__/dummy-command";
+import { serialize } from "../serializer";
+import { createMask } from "../utils";
+
+const createCommandModel = (
+  commandObj: CommandModel.AsObject
+): CommandModel => {
+  const command = new CommandModel();
+  command.setId(commandObj.id);
+  command.setApplicationId(commandObj.applicationId);
+  command.setPipedId(commandObj.pipedId);
+  command.setDeploymentId(commandObj.deploymentId);
+  command.setStageId(commandObj.stageId);
+  command.setCommander(commandObj.commander);
+  command.setStatus(commandObj.status);
+  command.setHandledAt(commandObj.handledAt);
+  command.setType(commandObj.type);
+  command.setCreatedAt(commandObj.createdAt);
+  command.setUpdatedAt(commandObj.updatedAt);
+  commandObj.metadataMap.forEach(([key, value]) => {
+    command.getMetadataMap().set(key, value);
+  });
+  return command;
+};
+
+export const commandHandlers = [
+  rest.post<Uint8Array>(createMask("/GetCommand"), (req, res, ctx) => {
+    const response = new GetCommandResponse();
+
+    const request = GetCommandRequest.deserializeBinary(req.body.slice(5));
+
+    if (request.getCommandId() === dummySyncSucceededCommand.id) {
+      response.setCommand(createCommandModel(dummySyncSucceededCommand));
+    } else {
+      response.setCommand(createCommandModel(dummyCommand));
+    }
+
+    const data = serialize(response.serializeBinary());
+    return res(
+      ctx.status(200),
+      ctx.set("Content-Type", "application/grpc-web+proto"),
+      ctx.body(data)
+    );
+  }),
+];

--- a/pkg/app/web/src/modules/commands.test.ts
+++ b/pkg/app/web/src/modules/commands.test.ts
@@ -1,5 +1,41 @@
-import { dummyCommand } from "../__fixtures__/dummy-command";
+import { createStore } from "../../test-utils";
+import { server } from "../mocks/server";
+import {
+  dummyCommand,
+  dummySyncSucceededCommand,
+} from "../__fixtures__/dummy-command";
 import { commandsSlice, CommandStatus, fetchCommand } from "./commands";
+import { addToast } from "./toasts";
+
+beforeAll(() => {
+  server.listen();
+});
+
+afterEach(() => {
+  server.resetHandlers();
+});
+
+afterAll(() => {
+  server.close();
+});
+
+describe("fetchCommand", () => {
+  it("should dispatch addToast if command type is SYNC_APPLICATION and that is succeeded", async () => {
+    const store = createStore({});
+    await store.dispatch(fetchCommand(dummySyncSucceededCommand.id));
+
+    expect(store.getActions()).toMatchObject([
+      { type: fetchCommand.pending.type },
+      {
+        type: addToast.type,
+        payload: {
+          to: "/deployments/deployment-1",
+        },
+      },
+      { type: fetchCommand.fulfilled.type },
+    ]);
+  });
+});
 
 describe("commandsSlice reducer", () => {
   it("should handle initial state", () => {

--- a/pkg/app/web/src/modules/toasts.ts
+++ b/pkg/app/web/src/modules/toasts.ts
@@ -1,6 +1,6 @@
 import {
-  createSlice,
   createEntityAdapter,
+  createSlice,
   PayloadAction,
 } from "@reduxjs/toolkit";
 
@@ -10,6 +10,7 @@ export interface IToast {
   id: string;
   message: string;
   severity?: ToastSeverity;
+  to?: string;
 }
 
 const toastsAdapter = createEntityAdapter<IToast>();
@@ -18,16 +19,21 @@ export const { selectAll } = toastsAdapter.getSelectors();
 
 export const toastsSlice = createSlice({
   name: "toasts",
-  initialState: toastsAdapter.getInitialState(),
+  initialState: toastsAdapter.getInitialState({}),
   reducers: {
     addToast(
       state,
-      action: PayloadAction<{ message: string; severity?: ToastSeverity }>
+      action: PayloadAction<{
+        message: string;
+        severity?: ToastSeverity;
+        to?: string;
+      }>
     ) {
       toastsAdapter.addOne(state, {
         id: `${Date.now()}`,
         message: action.payload.message,
         severity: action.payload.severity,
+        to: action.payload.to,
       });
     },
     removeToast(state, action: PayloadAction<{ id: string }>) {

--- a/pkg/app/web/src/utils/find-metadata-by-key.test.ts
+++ b/pkg/app/web/src/utils/find-metadata-by-key.test.ts
@@ -1,0 +1,15 @@
+import { findMetadataByKey } from "./find-metadata-by-key";
+
+test("findMetadataByKey", () => {
+  expect(findMetadataByKey([], "key")).toBeUndefined();
+  expect(findMetadataByKey([["key2", "value"]], "key")).toBeUndefined();
+  expect(
+    findMetadataByKey(
+      [
+        ["key", "value"],
+        ["key2", "value2"],
+      ],
+      "key"
+    )
+  ).toBe("value");
+});

--- a/pkg/app/web/src/utils/find-metadata-by-key.ts
+++ b/pkg/app/web/src/utils/find-metadata-by-key.ts
@@ -1,0 +1,12 @@
+export const findMetadataByKey = (
+  metadata: [string, string][],
+  key: string
+): string | undefined => {
+  const find = metadata.find(([k]) => k === key);
+
+  if (!find) {
+    return undefined;
+  }
+
+  return find[1];
+};


### PR DESCRIPTION
**What this PR does / why we need it**:

![Kapture 2020-10-26 at 17 59 19](https://user-images.githubusercontent.com/6136383/97152933-05472480-17b5-11eb-8304-8c76989582be.gif)


**Which issue(s) this PR fixes**:

Fixes #907 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Add deployment URL to the toast that showing after triggering application sync 
```
