### PR TITLE
Update alpine to 3.12.1

### DIFF
--- a/dockers/piped-base/DOCKER_BUILD
+++ b/dockers/piped-base/DOCKER_BUILD
@@ -1,2 +1,2 @@
-version: 0.1.3
+version: 0.1.4
 registry: gcr.io/pipecd/piped-base

--- a/dockers/piped-base/Dockerfile
+++ b/dockers/piped-base/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.10.1
+FROM alpine:3.12.1
 
 ENV PIPED_BIN_DIR=/home/pipecd/tools
 ENV PATH="${PIPED_BIN_DIR}:${PATH}"


### PR DESCRIPTION
**What this PR does / why we need it**:
alpine 3.10.1 includes a critical vulnerability and a high severity vulnerability:
- https://nvd.nist.gov/vuln/detail/CVE-2019-14697
- https://nvd.nist.gov/vuln/detail/CVE-2020-1967


Trivy actually tells me this fact:
```
❯ trivy alpine:3.10.1
2020-10-27T11:00:28.880+0900	INFO	Detecting Alpine vulnerabilities...

alpine:3.10.1 (alpine 3.10.1)
=============================
Total: 12 (UNKNOWN: 0, LOW: 2, MEDIUM: 6, HIGH: 2, CRITICAL: 2)

+--------------+------------------+----------+-------------------+---------------+--------------------------------+
|   LIBRARY    | VULNERABILITY ID | SEVERITY | INSTALLED VERSION | FIXED VERSION |             TITLE              |
+--------------+------------------+----------+-------------------+---------------+--------------------------------+
| libcrypto1.1 | CVE-2020-1967    | HIGH     | 1.1.1c-r0         | 1.1.1g-r0     | openssl: Segmentation fault in |
|              |                  |          |                   |               | SSL_check_chain causes denial  |
|              |                  |          |                   |               | of service                     |
+              +------------------+----------+                   +---------------+--------------------------------+
|              | CVE-2019-1547    | MEDIUM   |                   | 1.1.1d-r0     | openssl: side-channel weak     |
|              |                  |          |                   |               | encryption vulnerability       |
+              +------------------+          +                   +               +--------------------------------+
|              | CVE-2019-1549    |          |                   |               | openssl: information           |
|              |                  |          |                   |               | disclosure in fork()           |
+              +------------------+          +                   +---------------+--------------------------------+
|              | CVE-2019-1551    |          |                   | 1.1.1d-r2     | openssl: Integer overflow in   |
|              |                  |          |                   |               | RSAZ modular exponentiation on |
|              |                  |          |                   |               | x86_64                         |
+              +------------------+----------+                   +---------------+--------------------------------+
|              | CVE-2019-1563    | LOW      |                   | 1.1.1d-r0     | openssl: information           |
|              |                  |          |                   |               | disclosure in PKCS7_dataDecode |
|              |                  |          |                   |               | and CMS_decrypt_set1_pkey      |
+--------------+------------------+----------+                   +---------------+--------------------------------+
| libssl1.1    | CVE-2020-1967    | HIGH     |                   | 1.1.1g-r0     | openssl: Segmentation fault in |
|              |                  |          |                   |               | SSL_check_chain causes denial  |
|              |                  |          |                   |               | of service                     |
+              +------------------+----------+                   +---------------+--------------------------------+
|              | CVE-2019-1547    | MEDIUM   |                   | 1.1.1d-r0     | openssl: side-channel weak     |
|              |                  |          |                   |               | encryption vulnerability       |
+              +------------------+          +                   +               +--------------------------------+
|              | CVE-2019-1549    |          |                   |               | openssl: information           |
|              |                  |          |                   |               | disclosure in fork()           |
+              +------------------+          +                   +---------------+--------------------------------+
|              | CVE-2019-1551    |          |                   | 1.1.1d-r2     | openssl: Integer overflow in   |
|              |                  |          |                   |               | RSAZ modular exponentiation on |
|              |                  |          |                   |               | x86_64                         |
+              +------------------+----------+                   +---------------+--------------------------------+
|              | CVE-2019-1563    | LOW      |                   | 1.1.1d-r0     | openssl: information           |
|              |                  |          |                   |               | disclosure in PKCS7_dataDecode |
|              |                  |          |                   |               | and CMS_decrypt_set1_pkey      |
+--------------+------------------+----------+-------------------+---------------+--------------------------------+
| musl         | CVE-2019-14697   | CRITICAL | 1.1.22-r2         | 1.1.22-r3     | musl libc through 1.1.23       |
|              |                  |          |                   |               | has an x87 floating-point      |
|              |                  |          |                   |               | stack adjustment imbalance,    |
|              |                  |          |                   |               | related...                     |
+--------------+                  +          +                   +               +                                +
| musl-utils   |                  |          |                   |               |                                |
|              |                  |          |                   |               |                                |
|              |                  |          |                   |               |                                |
|              |                  |          |                   |               |                                |
+--------------+------------------+----------+-------------------+---------------+--------------------------------+
```
If it needs to be v3.10.x, I would also consider bump to non-vulnerable v3.10.5:
```
❯ trivy alpine:3.10.5
2020-10-27T11:05:06.029+0900	INFO	Detecting Alpine vulnerabilities...

alpine:3.10.5 (alpine 3.10.5)
=============================
Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)
```

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
