### PR TITLE
Refactor the error messages of the web api

### DIFF
--- a/pkg/app/api/api/web_api.go
+++ b/pkg/app/api/api/web_api.go
@@ -597,7 +597,7 @@ func (a *WebAPI) GenerateApplicationSealedSecret(ctx context.Context, req *webse
 	encryptedText, err := enc.Encrypt(req.Data)
 	if err != nil {
 		a.logger.Error("failed to encrypt the secret", zap.Error(err))
-		return nil, status.Error(codes.FailedPrecondition, "Tailed to encrypt the secret")
+		return nil, status.Error(codes.FailedPrecondition, "Failed to encrypt the secret")
 	}
 
 	return &webservice.GenerateApplicationSealedSecretResponse{

--- a/pkg/rpc/rpcauth/interceptor.go
+++ b/pkg/rpc/rpcauth/interceptor.go
@@ -28,8 +28,8 @@ import (
 )
 
 var (
-	errUnauthenticated  = status.Error(codes.Unauthenticated, "unauthenticated")
-	errPermissionDenied = status.Error(codes.PermissionDenied, "permission denied")
+	errUnauthenticated  = status.Error(codes.Unauthenticated, "Unauthenticated")
+	errPermissionDenied = status.Error(codes.PermissionDenied, "Permission Denied")
 )
 
 // RBACAuthorizer defines a function to check required role for a specific RPC method.


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, the web client is showing the message of gRPC error to users.
So this PR refactors these messages to make them more readable.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
