### PR TITLE
Fix the bug that cancelling a planning deployment causes the piped to be blocked

### DIFF
--- a/pkg/app/piped/controller/planner.go
+++ b/pkg/app/piped/controller/planner.go
@@ -97,6 +97,7 @@ func newPlanner(
 		pipedConfig:              pipedConfig,
 		plannerRegistry:          registry.DefaultRegistry(),
 		appManifestsCache:        appManifestsCache,
+		cancelledCh:              make(chan *model.ReportableCommand, 1),
 		nowFunc:                  time.Now,
 		logger:                   logger,
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #972 
Fixes #934

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```

/cc @nakabonne 
