### PR TITLE
Ensure to give back resources owned by requested Piped

### DIFF
--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -183,7 +183,7 @@ func (s *server) run(ctx context.Context, t cli.Telemetry) error {
 	{
 		var (
 			verifier = pipedtokenverifier.NewVerifier(ctx, cfg, ds)
-			service  = api.NewPipedAPI(ds, sls, alss, cmds, t.Logger)
+			service  = api.NewPipedAPI(ctx, ds, sls, alss, cmds, t.Logger)
 			opts     = []rpc.Option{
 				rpc.WithPort(s.pipedAPIPort),
 				rpc.WithGracePeriod(s.gracePeriod),

--- a/pkg/app/api/api/BUILD.bazel
+++ b/pkg/app/api/api/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//pkg/app/api/service/pipedservice:go_default_library",
         "//pkg/app/api/service/webservice:go_default_library",
         "//pkg/app/api/stagelogstore:go_default_library",
+        "//pkg/cache:go_default_library",
         "//pkg/cache/memorycache:go_default_library",
         "//pkg/config:go_default_library",
         "//pkg/crypto:go_default_library",
@@ -35,9 +36,21 @@ go_library(
 go_test(
     name = "go_default_test",
     size = "small",
-    srcs = ["web_api_test.go"],
+    srcs = [
+        "piped_api_test.go",
+        "web_api_test.go",
+    ],
     embed = [":go_default_library"],
-    deps = ["//pkg/app/api/service/webservice:go_default_library"],
+    deps = [
+        "//pkg/app/api/service/webservice:go_default_library",
+        "//pkg/cache:go_default_library",
+        "//pkg/cache/cachetest:go_default_library",
+        "//pkg/datastore:go_default_library",
+        "//pkg/datastore/datastoretest:go_default_library",
+        "//pkg/model:go_default_library",
+        "@com_github_golang_mock//gomock:go_default_library",
+        "@com_github_stretchr_testify//assert:go_default_library",
+    ],
 )
 
 load("@io_bazel_rules_go//go:def.bzl", "go_embed_data")

--- a/pkg/app/api/api/piped_api.go
+++ b/pkg/app/api/api/piped_api.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pipe-cd/pipe/pkg/app/api/commandstore"
 	"github.com/pipe-cd/pipe/pkg/app/api/service/pipedservice"
 	"github.com/pipe-cd/pipe/pkg/app/api/stagelogstore"
+	"github.com/pipe-cd/pipe/pkg/cache"
 	"github.com/pipe-cd/pipe/pkg/cache/memorycache"
 	"github.com/pipe-cd/pipe/pkg/datastore"
 	"github.com/pipe-cd/pipe/pkg/model"
@@ -46,9 +47,9 @@ type PipedAPI struct {
 	applicationLiveStateStore applicationlivestatestore.Store
 	commandStore              commandstore.Store
 
-	appPipedCache        *memorycache.TTLCache
-	deploymentPipedCache *memorycache.TTLCache
-	envProjectCache      *memorycache.TTLCache
+	appPipedCache        cache.Cache
+	deploymentPipedCache cache.Cache
+	envProjectCache      cache.Cache
 
 	logger *zap.Logger
 }

--- a/pkg/app/api/api/piped_api_test.go
+++ b/pkg/app/api/api/piped_api_test.go
@@ -1,0 +1,306 @@
+// Copyright 2020 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/pipe-cd/pipe/pkg/cache"
+	"github.com/pipe-cd/pipe/pkg/cache/cachetest"
+	"github.com/pipe-cd/pipe/pkg/datastore"
+	"github.com/pipe-cd/pipe/pkg/datastore/datastoretest"
+	"github.com/pipe-cd/pipe/pkg/model"
+)
+
+func TestValidateAppBelongsToPiped(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	tests := []struct {
+		name             string
+		appID            string
+		pipedID          string
+		appPipedCache    cache.Cache
+		applicationStore datastore.ApplicationStore
+		wantErr          bool
+	}{
+		{
+			name:    "valid with cached value",
+			appID:   "appID",
+			pipedID: "pipedID",
+			appPipedCache: func() cache.Cache {
+				c := cachetest.NewMockCache(ctrl)
+				c.EXPECT().
+					Get("appID").Return("pipedID", nil)
+				return c
+			}(),
+			wantErr: false,
+		},
+		{
+			name:    "invalid with cached value",
+			appID:   "appID",
+			pipedID: "wrong",
+			appPipedCache: func() cache.Cache {
+				c := cachetest.NewMockCache(ctrl)
+				c.EXPECT().
+					Get("appID").Return("pipedID", nil)
+				return c
+			}(),
+			wantErr: true,
+		},
+		{
+			name:    "valid with stored value",
+			appID:   "appID",
+			pipedID: "pipedID",
+			appPipedCache: func() cache.Cache {
+				c := cachetest.NewMockCache(ctrl)
+				c.EXPECT().
+					Get("appID").Return("", errors.New("not found"))
+				c.EXPECT().
+					Put("appID", "pipedID").Return(nil)
+				return c
+			}(),
+			applicationStore: func() datastore.ApplicationStore {
+				s := datastoretest.NewMockApplicationStore(ctrl)
+				s.EXPECT().
+					GetApplication(gomock.Any(), "appID").Return(&model.Application{PipedId: "pipedID"}, nil)
+				return s
+			}(),
+			wantErr: false,
+		},
+		{
+			name:    "invalid with stored value",
+			appID:   "appID",
+			pipedID: "wrong",
+			appPipedCache: func() cache.Cache {
+				c := cachetest.NewMockCache(ctrl)
+				c.EXPECT().
+					Get("appID").Return("", errors.New("not found"))
+				c.EXPECT().
+					Put("appID", "pipedID").Return(nil)
+				return c
+			}(),
+			applicationStore: func() datastore.ApplicationStore {
+				s := datastoretest.NewMockApplicationStore(ctrl)
+				s.EXPECT().
+					GetApplication(gomock.Any(), "appID").Return(&model.Application{PipedId: "pipedID"}, nil)
+				return s
+			}(),
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			api := &PipedAPI{
+				appPipedCache:    tt.appPipedCache,
+				applicationStore: tt.applicationStore,
+			}
+			err := api.validateAppBelongsToPiped(ctx, tt.appID, tt.pipedID)
+			assert.Equal(t, tt.wantErr, err != nil)
+		})
+	}
+}
+
+func TestValidateDeploymentBelongsToPiped(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	tests := []struct {
+		name                 string
+		deploymentID         string
+		pipedID              string
+		deploymentPipedCache cache.Cache
+		deploymentStore      datastore.DeploymentStore
+		wantErr              bool
+	}{
+		{
+			name:         "valid with cached value",
+			deploymentID: "deploymentID",
+			pipedID:      "pipedID",
+			deploymentPipedCache: func() cache.Cache {
+				c := cachetest.NewMockCache(ctrl)
+				c.EXPECT().
+					Get("deploymentID").Return("pipedID", nil)
+				return c
+			}(),
+			wantErr: false,
+		},
+		{
+			name:         "invalid with cached value",
+			deploymentID: "deploymentID",
+			pipedID:      "wrong",
+			deploymentPipedCache: func() cache.Cache {
+				c := cachetest.NewMockCache(ctrl)
+				c.EXPECT().
+					Get("deploymentID").Return("pipedID", nil)
+				return c
+			}(),
+			wantErr: true,
+		},
+		{
+			name:         "valid with stored value",
+			deploymentID: "deploymentID",
+			pipedID:      "pipedID",
+			deploymentPipedCache: func() cache.Cache {
+				c := cachetest.NewMockCache(ctrl)
+				c.EXPECT().
+					Get("deploymentID").Return("", errors.New("not found"))
+				c.EXPECT().
+					Put("deploymentID", "pipedID").Return(nil)
+				return c
+			}(),
+			deploymentStore: func() datastore.DeploymentStore {
+				s := datastoretest.NewMockDeploymentStore(ctrl)
+				s.EXPECT().
+					GetDeployment(gomock.Any(), "deploymentID").Return(&model.Deployment{PipedId: "pipedID"}, nil)
+				return s
+			}(),
+			wantErr: false,
+		},
+		{
+			name:         "invalid with stored value",
+			deploymentID: "deploymentID",
+			pipedID:      "wrong",
+			deploymentPipedCache: func() cache.Cache {
+				c := cachetest.NewMockCache(ctrl)
+				c.EXPECT().
+					Get("deploymentID").Return("", errors.New("not found"))
+				c.EXPECT().
+					Put("deploymentID", "pipedID").Return(nil)
+				return c
+			}(),
+			deploymentStore: func() datastore.DeploymentStore {
+				s := datastoretest.NewMockDeploymentStore(ctrl)
+				s.EXPECT().
+					GetDeployment(gomock.Any(), "deploymentID").Return(&model.Deployment{PipedId: "pipedID"}, nil)
+				return s
+			}(),
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			api := &PipedAPI{
+				deploymentPipedCache: tt.deploymentPipedCache,
+				deploymentStore:      tt.deploymentStore,
+			}
+			err := api.validateDeploymentBelongsToPiped(ctx, tt.deploymentID, tt.pipedID)
+			assert.Equal(t, tt.wantErr, err != nil)
+		})
+	}
+}
+
+func TestValidateEnvBelongsToProject(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	tests := []struct {
+		name             string
+		envID            string
+		projectID        string
+		envProjectCache  cache.Cache
+		environmentStore datastore.EnvironmentStore
+		wantErr          bool
+	}{
+		{
+			name:      "valid with cached value",
+			envID:     "envID",
+			projectID: "projectID",
+			envProjectCache: func() cache.Cache {
+				c := cachetest.NewMockCache(ctrl)
+				c.EXPECT().
+					Get("envID").Return("projectID", nil)
+				return c
+			}(),
+			wantErr: false,
+		},
+		{
+			name:      "invalid with cached value",
+			envID:     "envID",
+			projectID: "wrong",
+			envProjectCache: func() cache.Cache {
+				c := cachetest.NewMockCache(ctrl)
+				c.EXPECT().
+					Get("envID").Return("projectID", nil)
+				return c
+			}(),
+			wantErr: true,
+		},
+		{
+			name:      "valid with stored value",
+			envID:     "envID",
+			projectID: "projectID",
+			envProjectCache: func() cache.Cache {
+				c := cachetest.NewMockCache(ctrl)
+				c.EXPECT().
+					Get("envID").Return("", errors.New("not found"))
+				c.EXPECT().
+					Put("envID", "projectID").Return(nil)
+				return c
+			}(),
+			environmentStore: func() datastore.EnvironmentStore {
+				s := datastoretest.NewMockEnvironmentStore(ctrl)
+				s.EXPECT().
+					GetEnvironment(gomock.Any(), "envID").Return(&model.Environment{ProjectId: "projectID"}, nil)
+				return s
+			}(),
+			wantErr: false,
+		},
+		{
+			name:      "invalid with stored value",
+			envID:     "envID",
+			projectID: "wrong",
+			envProjectCache: func() cache.Cache {
+				c := cachetest.NewMockCache(ctrl)
+				c.EXPECT().
+					Get("envID").Return("", errors.New("not found"))
+				c.EXPECT().
+					Put("envID", "projectID").Return(nil)
+				return c
+			}(),
+			environmentStore: func() datastore.EnvironmentStore {
+				s := datastoretest.NewMockEnvironmentStore(ctrl)
+				s.EXPECT().
+					GetEnvironment(gomock.Any(), "envID").Return(&model.Environment{ProjectId: "projectID"}, nil)
+				return s
+			}(),
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			api := &PipedAPI{
+				envProjectCache:  tt.envProjectCache,
+				environmentStore: tt.environmentStore,
+			}
+			err := api.validateEnvBelongsToProject(ctx, tt.envID, tt.projectID)
+			assert.Equal(t, tt.wantErr, err != nil)
+		})
+	}
+}

--- a/pkg/app/api/api/web_api.go
+++ b/pkg/app/api/api/web_api.go
@@ -334,7 +334,10 @@ func (a *WebAPI) getPiped(ctx context.Context, pipedID string) (*model.Piped, er
 // It gives back error unless the piped belongs to the project.
 func (a *WebAPI) validatePipedBelongsToProject(ctx context.Context, pipedID, projectID string) error {
 	pid, err := a.pipedProjectCache.Get(pipedID)
-	if err == nil && pid == projectID {
+	if err == nil {
+		if pid != projectID {
+			return status.Error(codes.PermissionDenied, "Requested piped doesn't belong to the project you logged in")
+		}
 		return nil
 	}
 
@@ -671,7 +674,10 @@ func (a *WebAPI) getApplication(ctx context.Context, appID string) (*model.Appli
 // It gives back error unless the application belongs to the project.
 func (a *WebAPI) validateApplicationBelongsToProject(ctx context.Context, appID, projectID string) error {
 	pid, err := a.appProjectCache.Get(appID)
-	if err == nil && pid == projectID {
+	if err == nil {
+		if pid != projectID {
+			return status.Error(codes.PermissionDenied, "Requested application doesn't belong to the project you logged in")
+		}
 		return nil
 	}
 
@@ -796,7 +802,10 @@ func (a *WebAPI) getDeployment(ctx context.Context, deploymentID string) (*model
 // It gives back error unless the deployment belongs to the project.
 func (a *WebAPI) validateDeploymentBelongsToProject(ctx context.Context, deploymentID, projectID string) error {
 	pid, err := a.deploymentProjectCache.Get(deploymentID)
-	if err == nil && pid == projectID {
+	if err == nil {
+		if pid != projectID {
+			return status.Error(codes.PermissionDenied, "Requested deployment doesn't belong to the project you logged in")
+		}
 		return nil
 	}
 

--- a/pkg/app/api/api/web_api_test.go
+++ b/pkg/app/api/api/web_api_test.go
@@ -1,10 +1,34 @@
+// Copyright 2020 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package api
 
 import (
+	"context"
+	"errors"
 	"reflect"
 	"testing"
 
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/pipe-cd/pipe/pkg/app/api/service/webservice"
+	"github.com/pipe-cd/pipe/pkg/cache"
+	"github.com/pipe-cd/pipe/pkg/cache/cachetest"
+	"github.com/pipe-cd/pipe/pkg/datastore"
+	"github.com/pipe-cd/pipe/pkg/datastore/datastoretest"
+	"github.com/pipe-cd/pipe/pkg/model"
 )
 
 func Test_filterDeploymentConfigTemplates(t *testing.T) {
@@ -84,6 +108,282 @@ func Test_filterDeploymentConfigTemplates(t *testing.T) {
 			if got := filterDeploymentConfigTemplates(tt.args.templates, tt.args.labels); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("filterDeploymentConfigTemplates() = %v, want %v", got, tt.want)
 			}
+		})
+	}
+}
+
+func TestValidateAppBelongsToProject(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	tests := []struct {
+		name             string
+		appID            string
+		projectID        string
+		appProjectCache  cache.Cache
+		applicationStore datastore.ApplicationStore
+		wantErr          bool
+	}{
+		{
+			name:      "valid with cached value",
+			appID:     "appID",
+			projectID: "projectID",
+			appProjectCache: func() cache.Cache {
+				c := cachetest.NewMockCache(ctrl)
+				c.EXPECT().
+					Get("appID").Return("projectID", nil)
+				return c
+			}(),
+			wantErr: false,
+		},
+		{
+			name:      "invalid with cached value",
+			appID:     "appID",
+			projectID: "wrong",
+			appProjectCache: func() cache.Cache {
+				c := cachetest.NewMockCache(ctrl)
+				c.EXPECT().
+					Get("appID").Return("projectID", nil)
+				return c
+			}(),
+			wantErr: true,
+		},
+		{
+			name:      "valid with stored value",
+			appID:     "appID",
+			projectID: "projectID",
+			appProjectCache: func() cache.Cache {
+				c := cachetest.NewMockCache(ctrl)
+				c.EXPECT().
+					Get("appID").Return("", errors.New("not found"))
+				c.EXPECT().
+					Put("appID", "projectID").Return(nil)
+				return c
+			}(),
+			applicationStore: func() datastore.ApplicationStore {
+				s := datastoretest.NewMockApplicationStore(ctrl)
+				s.EXPECT().
+					GetApplication(gomock.Any(), "appID").Return(&model.Application{ProjectId: "projectID"}, nil)
+				return s
+			}(),
+			wantErr: false,
+		},
+		{
+			name:      "invalid with stored value",
+			appID:     "appID",
+			projectID: "wrong",
+			appProjectCache: func() cache.Cache {
+				c := cachetest.NewMockCache(ctrl)
+				c.EXPECT().
+					Get("appID").Return("", errors.New("not found"))
+				c.EXPECT().
+					Put("appID", "projectID").Return(nil)
+				return c
+			}(),
+			applicationStore: func() datastore.ApplicationStore {
+				s := datastoretest.NewMockApplicationStore(ctrl)
+				s.EXPECT().
+					GetApplication(gomock.Any(), "appID").Return(&model.Application{ProjectId: "projectID"}, nil)
+				return s
+			}(),
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			api := &WebAPI{
+				appProjectCache:  tt.appProjectCache,
+				applicationStore: tt.applicationStore,
+			}
+			err := api.validateAppBelongsToProject(ctx, tt.appID, tt.projectID)
+			assert.Equal(t, tt.wantErr, err != nil)
+		})
+	}
+}
+
+func TestValidateDeploymentBelongsToProject(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	tests := []struct {
+		name                   string
+		deploymentID           string
+		projectID              string
+		deploymentProjectCache cache.Cache
+		deploymentStore        datastore.DeploymentStore
+		wantErr                bool
+	}{
+		{
+			name:         "valid with cached value",
+			deploymentID: "deploymentID",
+			projectID:    "projectID",
+			deploymentProjectCache: func() cache.Cache {
+				c := cachetest.NewMockCache(ctrl)
+				c.EXPECT().
+					Get("deploymentID").Return("projectID", nil)
+				return c
+			}(),
+			wantErr: false,
+		},
+		{
+			name:         "invalid with cached value",
+			deploymentID: "deploymentID",
+			projectID:    "wrong",
+			deploymentProjectCache: func() cache.Cache {
+				c := cachetest.NewMockCache(ctrl)
+				c.EXPECT().
+					Get("deploymentID").Return("projectID", nil)
+				return c
+			}(),
+			wantErr: true,
+		},
+		{
+			name:         "valid with stored value",
+			deploymentID: "deploymentID",
+			projectID:    "projectID",
+			deploymentProjectCache: func() cache.Cache {
+				c := cachetest.NewMockCache(ctrl)
+				c.EXPECT().
+					Get("deploymentID").Return("", errors.New("not found"))
+				c.EXPECT().
+					Put("deploymentID", "projectID").Return(nil)
+				return c
+			}(),
+			deploymentStore: func() datastore.DeploymentStore {
+				s := datastoretest.NewMockDeploymentStore(ctrl)
+				s.EXPECT().
+					GetDeployment(gomock.Any(), "deploymentID").Return(&model.Deployment{ProjectId: "projectID"}, nil)
+				return s
+			}(),
+			wantErr: false,
+		},
+		{
+			name:         "invalid with stored value",
+			deploymentID: "deploymentID",
+			projectID:    "wrong",
+			deploymentProjectCache: func() cache.Cache {
+				c := cachetest.NewMockCache(ctrl)
+				c.EXPECT().
+					Get("deploymentID").Return("", errors.New("not found"))
+				c.EXPECT().
+					Put("deploymentID", "projectID").Return(nil)
+				return c
+			}(),
+			deploymentStore: func() datastore.DeploymentStore {
+				s := datastoretest.NewMockDeploymentStore(ctrl)
+				s.EXPECT().
+					GetDeployment(gomock.Any(), "deploymentID").Return(&model.Deployment{ProjectId: "projectID"}, nil)
+				return s
+			}(),
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			api := &WebAPI{
+				deploymentProjectCache: tt.deploymentProjectCache,
+				deploymentStore:        tt.deploymentStore,
+			}
+			err := api.validateDeploymentBelongsToProject(ctx, tt.deploymentID, tt.projectID)
+			assert.Equal(t, tt.wantErr, err != nil)
+		})
+	}
+}
+
+func TestValidatePipedBelongsToProject(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	tests := []struct {
+		name              string
+		pipedID           string
+		projectID         string
+		pipedProjectCache cache.Cache
+		pipedStore        datastore.PipedStore
+		wantErr           bool
+	}{
+		{
+			name:      "valid with cached value",
+			pipedID:   "pipedID",
+			projectID: "projectID",
+			pipedProjectCache: func() cache.Cache {
+				c := cachetest.NewMockCache(ctrl)
+				c.EXPECT().
+					Get("pipedID").Return("projectID", nil)
+				return c
+			}(),
+			wantErr: false,
+		},
+		{
+			name:      "invalid with cached value",
+			pipedID:   "pipedID",
+			projectID: "wrong",
+			pipedProjectCache: func() cache.Cache {
+				c := cachetest.NewMockCache(ctrl)
+				c.EXPECT().
+					Get("pipedID").Return("projectID", nil)
+				return c
+			}(),
+			wantErr: true,
+		},
+		{
+			name:      "valid with stored value",
+			pipedID:   "pipedID",
+			projectID: "projectID",
+			pipedProjectCache: func() cache.Cache {
+				c := cachetest.NewMockCache(ctrl)
+				c.EXPECT().
+					Get("pipedID").Return("", errors.New("not found"))
+				c.EXPECT().
+					Put("pipedID", "projectID").Return(nil)
+				return c
+			}(),
+			pipedStore: func() datastore.PipedStore {
+				s := datastoretest.NewMockPipedStore(ctrl)
+				s.EXPECT().
+					GetPiped(gomock.Any(), "pipedID").Return(&model.Piped{ProjectId: "projectID"}, nil)
+				return s
+			}(),
+			wantErr: false,
+		},
+		{
+			name:      "invalid with stored value",
+			pipedID:   "pipedID",
+			projectID: "wrong",
+			pipedProjectCache: func() cache.Cache {
+				c := cachetest.NewMockCache(ctrl)
+				c.EXPECT().
+					Get("pipedID").Return("", errors.New("not found"))
+				c.EXPECT().
+					Put("pipedID", "projectID").Return(nil)
+				return c
+			}(),
+			pipedStore: func() datastore.PipedStore {
+				s := datastoretest.NewMockPipedStore(ctrl)
+				s.EXPECT().
+					GetPiped(gomock.Any(), "pipedID").Return(&model.Piped{ProjectId: "projectID"}, nil)
+				return s
+			}(),
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			api := &WebAPI{
+				pipedProjectCache: tt.pipedProjectCache,
+				pipedStore:        tt.pipedStore,
+			}
+			err := api.validatePipedBelongsToProject(ctx, tt.pipedID, tt.projectID)
+			assert.Equal(t, tt.wantErr, err != nil)
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
I also fixed WebAPI to do not overwrite the cached value even when it was different from the cached value.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
