### PR TITLE
Ensure to sync progressively when configmap/secret added/deleted

### DIFF
--- a/pkg/app/piped/planner/kubernetes/BUILD.bazel
+++ b/pkg/app/piped/planner/kubernetes/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -16,5 +16,21 @@ go_library(
         "//pkg/config:go_default_library",
         "//pkg/model:go_default_library",
         "@org_uber_go_zap//:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    size = "small",
+    srcs = [
+        "kubernetes_test.go",
+        "pipeline_test.go",
+    ],
+    embed = [":go_default_library"],
+    deps = [
+        "//pkg/app/piped/cloudprovider/kubernetes:go_default_library",
+        "//pkg/model:go_default_library",
+        "@com_github_stretchr_testify//assert:go_default_library",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1/unstructured:go_default_library",
     ],
 )

--- a/pkg/app/piped/planner/kubernetes/kubernetes.go
+++ b/pkg/app/piped/planner/kubernetes/kubernetes.go
@@ -205,29 +205,29 @@ func decideStrategy(olds, news []provider.Manifest) (progressive bool, desc stri
 		progressive = true
 		desc = fmt.Sprintf("Sync progressively because %d configmap/secret deleted", len(oldConfigs)-len(newConfigs))
 		return
-	} else if len(oldConfigs) < len(newConfigs) {
+	}
+	if len(oldConfigs) < len(newConfigs) {
 		progressive = true
 		desc = fmt.Sprintf("Sync progressively because new %d configmap/secret added", len(newConfigs)-len(oldConfigs))
 		return
-	} else {
-		for k, oc := range oldConfigs {
-			nc, ok := newConfigs[k]
-			if !ok {
-				progressive = true
-				desc = fmt.Sprintf("Sync progressively because %s %s was deleted", oc.Key.Kind, oc.Key.Name)
-				return
-			}
-			result, err := provider.Diff(oc, nc)
-			if err != nil {
-				progressive = true
-				desc = fmt.Sprintf("Sync progressively due to an error while calculating the diff (%v)", err)
-				return
-			}
-			if result.HasDiff() {
-				progressive = true
-				desc = fmt.Sprintf("Sync progressively because %s %s was updated", oc.Key.Kind, oc.Key.Name)
-				return
-			}
+	}
+	for k, oc := range oldConfigs {
+		nc, ok := newConfigs[k]
+		if !ok {
+			progressive = true
+			desc = fmt.Sprintf("Sync progressively because %s %s was deleted", oc.Key.Kind, oc.Key.Name)
+			return
+		}
+		result, err := provider.Diff(oc, nc)
+		if err != nil {
+			progressive = true
+			desc = fmt.Sprintf("Sync progressively due to an error while calculating the diff (%v)", err)
+			return
+		}
+		if result.HasDiff() {
+			progressive = true
+			desc = fmt.Sprintf("Sync progressively because %s %s was updated", oc.Key.Kind, oc.Key.Name)
+			return
 		}
 	}
 

--- a/pkg/app/piped/planner/kubernetes/kubernetes_test.go
+++ b/pkg/app/piped/planner/kubernetes/kubernetes_test.go
@@ -1,0 +1,226 @@
+package kubernetes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	provider "github.com/pipe-cd/pipe/pkg/app/piped/cloudprovider/kubernetes"
+)
+
+func TestDecideStrategy(t *testing.T) {
+	tests := []struct {
+		name            string
+		olds            []provider.Manifest
+		news            []provider.Manifest
+		wantProgressive bool
+		wantDesc        string
+	}{
+		{
+			name: "no running workloads found",
+			olds: []provider.Manifest{
+				{
+					Key: provider.ResourceKey{
+						APIVersion: "v1",
+						Kind:       provider.KindService,
+					},
+				},
+			},
+			wantProgressive: false,
+			wantDesc:        "Quick sync by applying all manifests because it was unable to find the currently running workloads",
+		},
+		{
+			name: "no workloads found in the new manifests",
+			olds: []provider.Manifest{
+				{
+					Key: provider.ResourceKey{
+						APIVersion: "apps/v1",
+						Kind:       provider.KindDeployment,
+					},
+				},
+			},
+			news: []provider.Manifest{
+				{
+					Key: provider.ResourceKey{
+						APIVersion: "v1",
+						Kind:       provider.KindService,
+					},
+				},
+			},
+			wantProgressive: false,
+			wantDesc:        "Quick sync by applying all manifests because it was unable to find workloads in the new manifests",
+		},
+		{
+			name: "pod template was changed",
+			olds: func() []provider.Manifest {
+				m := provider.MakeManifest(provider.ResourceKey{
+					APIVersion: "apps/v1",
+					Kind:       provider.KindDeployment,
+				}, &unstructured.Unstructured{
+					Object: map[string]interface{}{"spec": map[string]interface{}{"template": "foo"}}},
+				)
+				return []provider.Manifest{m}
+			}(),
+			news: func() []provider.Manifest {
+				m := provider.MakeManifest(provider.ResourceKey{
+					APIVersion: "apps/v1",
+					Kind:       provider.KindDeployment,
+					Name:       "name",
+				}, &unstructured.Unstructured{
+					Object: map[string]interface{}{"spec": map[string]interface{}{"template": "bar"}}},
+				)
+				return []provider.Manifest{m}
+			}(),
+			wantProgressive: true,
+			wantDesc:        "Sync progressively because pod template of workload name was changed",
+		},
+		{
+			name: "configmap deleted",
+			olds: func() []provider.Manifest {
+				m1 := provider.MakeManifest(provider.ResourceKey{
+					APIVersion: "apps/v1",
+					Kind:       provider.KindDeployment,
+				}, &unstructured.Unstructured{})
+				m2 := provider.MakeManifest(provider.ResourceKey{
+					APIVersion: "v1",
+					Kind:       provider.KindConfigMap,
+				}, &unstructured.Unstructured{})
+				return []provider.Manifest{m1, m2}
+			}(),
+			news: func() []provider.Manifest {
+				m := provider.MakeManifest(provider.ResourceKey{
+					APIVersion: "apps/v1",
+					Kind:       provider.KindDeployment,
+				}, &unstructured.Unstructured{})
+				return []provider.Manifest{m}
+			}(),
+			wantProgressive: true,
+			wantDesc:        "Sync progressively because 1 configmap/secret deleted",
+		},
+		{
+			name: "new configmap added",
+			olds: func() []provider.Manifest {
+				m := provider.MakeManifest(provider.ResourceKey{
+					APIVersion: "apps/v1",
+					Kind:       provider.KindDeployment,
+				}, &unstructured.Unstructured{})
+				return []provider.Manifest{m}
+			}(),
+			news: func() []provider.Manifest {
+				m1 := provider.MakeManifest(provider.ResourceKey{
+					APIVersion: "apps/v1",
+					Kind:       provider.KindDeployment,
+				}, &unstructured.Unstructured{})
+				m2 := provider.MakeManifest(provider.ResourceKey{
+					APIVersion: "v1",
+					Kind:       provider.KindConfigMap,
+				}, &unstructured.Unstructured{})
+				return []provider.Manifest{m1, m2}
+			}(),
+			wantProgressive: true,
+			wantDesc:        "Sync progressively because new 1 configmap/secret added",
+		},
+		{
+			name: "one configmap updated",
+			olds: func() []provider.Manifest {
+				m1 := provider.MakeManifest(provider.ResourceKey{
+					APIVersion: "apps/v1",
+					Kind:       provider.KindDeployment,
+				}, &unstructured.Unstructured{})
+				m2 := provider.MakeManifest(provider.ResourceKey{
+					APIVersion: "v1",
+					Kind:       provider.KindConfigMap,
+					Name:       "configmap1",
+				}, &unstructured.Unstructured{
+					Object: map[string]interface{}{"data": "foo"}},
+				)
+				m3 := provider.MakeManifest(provider.ResourceKey{
+					APIVersion: "v1",
+					Kind:       provider.KindConfigMap,
+					Name:       "configmap2",
+				}, &unstructured.Unstructured{
+					Object: map[string]interface{}{"data": "baz"}},
+				)
+				return []provider.Manifest{m1, m2, m3}
+			}(),
+			news: func() []provider.Manifest {
+				m1 := provider.MakeManifest(provider.ResourceKey{
+					APIVersion: "apps/v1",
+					Kind:       provider.KindDeployment,
+				}, &unstructured.Unstructured{})
+				m2 := provider.MakeManifest(provider.ResourceKey{
+					APIVersion: "v1",
+					Kind:       provider.KindConfigMap,
+					Name:       "configmap1",
+				}, &unstructured.Unstructured{
+					Object: map[string]interface{}{"data": "bar"}},
+				)
+				m3 := provider.MakeManifest(provider.ResourceKey{
+					APIVersion: "v1",
+					Kind:       provider.KindConfigMap,
+					Name:       "configmap2",
+				}, &unstructured.Unstructured{
+					Object: map[string]interface{}{"data": "baz"}},
+				)
+				return []provider.Manifest{m1, m2, m3}
+			}(),
+			wantProgressive: true,
+			wantDesc:        "Sync progressively because ConfigMap configmap1 was updated",
+		},
+		{
+			name: "all configmaps as is",
+			olds: func() []provider.Manifest {
+				m1 := provider.MakeManifest(provider.ResourceKey{
+					APIVersion: "apps/v1",
+					Kind:       provider.KindDeployment,
+				}, &unstructured.Unstructured{})
+				m2 := provider.MakeManifest(provider.ResourceKey{
+					APIVersion: "v1",
+					Kind:       provider.KindConfigMap,
+					Name:       "configmap1",
+				}, &unstructured.Unstructured{
+					Object: map[string]interface{}{"data": "foo"}},
+				)
+				m3 := provider.MakeManifest(provider.ResourceKey{
+					APIVersion: "v1",
+					Kind:       provider.KindConfigMap,
+					Name:       "configmap2",
+				}, &unstructured.Unstructured{
+					Object: map[string]interface{}{"data": "baz"}},
+				)
+				return []provider.Manifest{m1, m2, m3}
+			}(),
+			news: func() []provider.Manifest {
+				m1 := provider.MakeManifest(provider.ResourceKey{
+					APIVersion: "apps/v1",
+					Kind:       provider.KindDeployment,
+				}, &unstructured.Unstructured{})
+				m2 := provider.MakeManifest(provider.ResourceKey{
+					APIVersion: "v1",
+					Kind:       provider.KindConfigMap,
+					Name:       "configmap1",
+				}, &unstructured.Unstructured{
+					Object: map[string]interface{}{"data": "foo"}},
+				)
+				m3 := provider.MakeManifest(provider.ResourceKey{
+					APIVersion: "v1",
+					Kind:       provider.KindConfigMap,
+					Name:       "configmap2",
+				}, &unstructured.Unstructured{
+					Object: map[string]interface{}{"data": "baz"}},
+				)
+				return []provider.Manifest{m1, m2, m3}
+			}(),
+			wantProgressive: false,
+			wantDesc:        "Quick sync by applying all manifests",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotProgressive, gotDesc := decideStrategy(tc.olds, tc.news)
+			assert.Equal(t, tc.wantProgressive, gotProgressive)
+			assert.Equal(t, tc.wantDesc, gotDesc)
+		})
+	}
+}

--- a/pkg/app/piped/planner/kubernetes/pipeline_test.go
+++ b/pkg/app/piped/planner/kubernetes/pipeline_test.go
@@ -1,0 +1,67 @@
+package kubernetes
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/pipe-cd/pipe/pkg/config"
+	"github.com/pipe-cd/pipe/pkg/model"
+)
+
+func TestBuildPipeline(t *testing.T) {
+	tests := []struct {
+		name             string
+		wantAutoRollback bool
+	}{
+		{
+			name:             "want auto rollback stage",
+			wantAutoRollback: true,
+		},
+		{
+			name:             "don't want auto rollback stage",
+			wantAutoRollback: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotStages := buildPipeline(tc.wantAutoRollback, time.Now())
+			var gotAutoRollback bool
+			for _, stage := range gotStages {
+				if stage.Name == string(model.StageRollback) {
+					gotAutoRollback = true
+				}
+			}
+			assert.Equal(t, tc.wantAutoRollback, gotAutoRollback)
+		})
+	}
+}
+
+func TestBuildProgressivePipeline(t *testing.T) {
+	tests := []struct {
+		name             string
+		wantAutoRollback bool
+	}{
+		{
+			name:             "want auto rollback stage",
+			wantAutoRollback: true,
+		},
+		{
+			name:             "don't want auto rollback stage",
+			wantAutoRollback: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotStages := buildProgressivePipeline(&config.DeploymentPipeline{}, tc.wantAutoRollback, time.Now())
+			var gotAutoRollback bool
+			for _, stage := range gotStages {
+				if stage.Name == string(model.StageRollback) {
+					gotAutoRollback = true
+				}
+			}
+			assert.Equal(t, tc.wantAutoRollback, gotAutoRollback)
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
I encountered issues about deciding strategy:
- when removing all ConfigMaps/Secrets or adding the first Configmap/Secret, it does just sync.
- when the number of ConfigMaps/Secrets changed, it does just sync even though the description starts with "Sync progressively...".

I've fixed that and added tests to guarantee to perform progressive delivery when ConfigMap/Secret touched.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
