### PR TITLE
Remove TRAFFIC_ROUTINE stage from bluegreen example

### DIFF
--- a/examples/kubernetes/bluegreen/.pipe.yaml
+++ b/examples/kubernetes/bluegreen/.pipe.yaml
@@ -16,11 +16,7 @@ spec:
           all: canary
       - name: WAIT_APPROVAL
       # Update the workload of PRIMARY variant to the new version.
+      # All traffic will be routed to the PRIMARY variant.
       - name: K8S_PRIMARY_ROLLOUT
-      # The percentage of traffic each variant should receive.
-      # In this case, PRIMARY variant will receive all of the traffic.
-      - name: K8S_TRAFFIC_ROUTING
-        with:
-          primary: 100
       # Destroy all workloads of CANARY variant.
       - name: K8S_CANARY_CLEAN


### PR DESCRIPTION
**What this PR does / why we need it**:
Technically, this should be merged after https://github.com/pipe-cd/pipe/pull/1079 merged.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
