### PR TITLE
Stop checking if variant selector is in the workload

### DIFF
--- a/pkg/app/piped/executor/kubernetes/sync.go
+++ b/pkg/app/piped/executor/kubernetes/sync.go
@@ -34,21 +34,6 @@ func (e *Executor) ensureSync(ctx context.Context) model.StageStatus {
 	}
 	e.LogPersister.Successf("Successfully loaded %d manifests", len(manifests))
 
-	// Check the variant selector in the workloads.
-	if e.config.Pipeline != nil && !e.config.QuickSync.AddVariantLabelToSelector {
-		workloads := findWorkloadManifests(manifests, e.config.Workloads)
-		var invalid bool
-		for _, m := range workloads {
-			if err := checkVariantSelectorInWorkload(m, primaryVariant); err != nil {
-				invalid = true
-				e.LogPersister.Errorf("Missing %q in selector of workload %s (%v)", variantLabel+": "+primaryVariant, m.Key.ReadableString(), err)
-			}
-		}
-		if invalid {
-			return model.StageStatus_STAGE_FAILURE
-		}
-	}
-
 	// Because the loaded manifests are read-only
 	// we duplicate them to avoid updating the shared manifests data in cache.
 	manifests = duplicateManifests(manifests, "")

--- a/pkg/app/piped/executor/kubernetes/sync_test.go
+++ b/pkg/app/piped/executor/kubernetes/sync_test.go
@@ -54,42 +54,6 @@ func TestEnsureSync(t *testing.T) {
 			},
 		},
 		{
-			name: "missing variant selector",
-			want: model.StageStatus_STAGE_FAILURE,
-			executor: &Executor{
-				Input: executor.Input{
-					Deployment: &model.Deployment{
-						Trigger: &model.DeploymentTrigger{
-							Commit: &model.Commit{},
-						},
-					},
-					LogPersister: &fakeLogPersister{},
-					AppManifestsCache: func() cache.Cache {
-						c := cachetest.NewMockCache(ctrl)
-						c.EXPECT().Get(gomock.Any()).Return(nil, fmt.Errorf("not found"))
-						c.EXPECT().Put(gomock.Any(), gomock.Any()).Return(nil)
-						return c
-					}(),
-					Logger: zap.NewNop(),
-				},
-				provider: func() provider.Provider {
-					p := providertest.NewMockProvider(ctrl)
-					p.EXPECT().LoadManifests(gomock.Any()).Return([]provider.Manifest{
-						provider.MakeManifest(provider.ResourceKey{
-							APIVersion: "apps/v1",
-							Kind:       provider.KindDeployment,
-						}, &unstructured.Unstructured{}),
-					}, nil)
-					return p
-				}(),
-				config: &config.KubernetesDeploymentSpec{
-					GenericDeploymentSpec: config.GenericDeploymentSpec{
-						Pipeline: &config.DeploymentPipeline{},
-					},
-				},
-			},
-		},
-		{
 			name: "unable to apply manifests",
 			want: model.StageStatus_STAGE_FAILURE,
 			executor: &Executor{


### PR DESCRIPTION
**What this PR does / why we need it**:
We decided to add the variant label if addVariantLabelToSelector is true, but do not check anymore.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
