### PR TITLE
Ensure to check variant label only when necessary

### DIFF
--- a/pkg/app/piped/executor/kubernetes/sync_test.go
+++ b/pkg/app/piped/executor/kubernetes/sync_test.go
@@ -1,3 +1,17 @@
+// Copyright 2020 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package kubernetes
 
 import (

--- a/pkg/config/BUILD.bazel
+++ b/pkg/config/BUILD.bazel
@@ -36,6 +36,7 @@ go_test(
         "control_plane_test.go",
         "deployment_kubernetes_test.go",
         "deployment_terraform_test.go",
+        "deployment_test.go",
         "piped_test.go",
         "replicas_test.go",
         "sealed_secret_test.go",

--- a/pkg/config/deployment.go
+++ b/pkg/config/deployment.go
@@ -42,6 +42,19 @@ func (s GenericDeploymentSpec) GetStage(index int32) (PipelineStage, bool) {
 	return s.Pipeline.Stages[index], true
 }
 
+// HasStage checks if the given stage is included in the pipeline.
+func (s GenericDeploymentSpec) HasStage(stage model.Stage) bool {
+	if s.Pipeline == nil {
+		return false
+	}
+	for _, s := range s.Pipeline.Stages {
+		if s.Name == stage {
+			return true
+		}
+	}
+	return false
+}
+
 // DeploymentCommitMatcher provides a way to decide how to deploy.
 type DeploymentCommitMatcher struct {
 	// It makes sure to perform syncing if the commit message matches this regular expression.

--- a/pkg/config/deployment_test.go
+++ b/pkg/config/deployment_test.go
@@ -1,0 +1,73 @@
+// Copyright 2020 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/pipe-cd/pipe/pkg/model"
+)
+
+func TestHasStage(t *testing.T) {
+	testcase := []struct {
+		name  string
+		s     GenericDeploymentSpec
+		stage model.Stage
+		want  bool
+	}{
+		{
+			name:  "no pipeline configured",
+			s:     GenericDeploymentSpec{},
+			stage: model.StageK8sSync,
+			want:  false,
+		},
+		{
+			name: "given one doesn't exist",
+			s: GenericDeploymentSpec{
+				Pipeline: &DeploymentPipeline{
+					Stages: []PipelineStage{
+						{
+							Name: model.StageK8sSync,
+						},
+					},
+				},
+			},
+			stage: model.StageK8sPrimaryRollout,
+			want:  false,
+		},
+		{
+			name: "given one exists",
+			s: GenericDeploymentSpec{
+				Pipeline: &DeploymentPipeline{
+					Stages: []PipelineStage{
+						{
+							Name: model.StageK8sSync,
+						},
+					},
+				},
+			},
+			stage: model.StageK8sSync,
+			want:  true,
+		},
+	}
+	for _, tc := range testcase {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.s.HasStage(tc.stage)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/pkg/config/deployment_test.go
+++ b/pkg/config/deployment_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestHasStage(t *testing.T) {
-	testcase := []struct {
+	testcases := []struct {
 		name  string
 		s     GenericDeploymentSpec
 		stage model.Stage
@@ -64,7 +64,7 @@ func TestHasStage(t *testing.T) {
 			want:  true,
 		},
 	}
-	for _, tc := range testcase {
+	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			got := tc.s.HasStage(tc.stage)
 			assert.Equal(t, tc.want, got)


### PR DESCRIPTION
**What this PR does / why we need it**:
We decided to check the variant label exists only when:
- TRAFFIC_ROUTING stage is configured
- The pod selector is set as the method of traffic routing

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
