### PR TITLE
Add notes on using pod selector as a traffic routing method

### DIFF
--- a/docs/content/en/docs/user-guide/configuration-reference.md
+++ b/docs/content/en/docs/user-guide/configuration-reference.md
@@ -323,6 +323,9 @@ spec:
 | | | | |
 
 ### KubernetesTrafficRoutingStageOptions
+This stage routes traffic with the method specified in [KubernetesTrafficRouting](https://pipecd.dev/docs/user-guide/configuration-reference/#kubernetestrafficrouting).
+When using `podselector` method as a traffic routing method, routing is done by updating the Service selector.
+Therefore, note that all traffic will be routed to the primary if the the primary variant's service is rolled out by running the `K8S_PRIMARY_ROLLOUT` stage.
 
 | Field | Type | Description | Required |
 |-|-|-|-|


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, there is no page to describe each stage. Then I came up with the Configuration references page is available for that.

That's linked by [the configuring deployment page](https://pipecd.dev/docs/user-guide/configuring-deployment/kubernetes/#sync-with-the-specified-pipeline), hence I feel like it's not weird at all.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
