### PR TITLE
Fix the bug that caused validtion error while registering a new piped

### DIFF
--- a/pkg/model/piped.proto
+++ b/pkg/model/piped.proto
@@ -45,7 +45,7 @@ message Piped {
     string desc = 3;
     // The hash value of the secret key generated for the piped.
     // This is used to authenticate while communicating with the control plane.
-    string key_hash = 4 [(validate.rules).string.min_len = 1, deprecated=true];
+    string key_hash = 4 [deprecated=true];
     // The ID of the project this enviroment belongs to.
     string project_id = 5 [(validate.rules).string.min_len = 1];
     // The IDs of environments where this piped can be connected to.


### PR DESCRIPTION
**What this PR does / why we need it**:

`key_hash` field was deprecated but its validator was still existing.
This PR removes that validator.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```

/approve
