### PR TITLE
Refactor kubernetes executor

### DIFF
--- a/pkg/app/piped/executor/kubernetes/BUILD.bazel
+++ b/pkg/app/piped/executor/kubernetes/BUILD.bazel
@@ -15,8 +15,8 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/app/piped/cloudprovider/kubernetes:go_default_library",
-        "//pkg/app/piped/deploysource:go_default_library",
         "//pkg/app/piped/executor:go_default_library",
+        "//pkg/cache:go_default_library",
         "//pkg/config:go_default_library",
         "//pkg/model:go_default_library",
         "@io_istio_api//networking/v1alpha3:go_default_library",

--- a/pkg/app/piped/executor/kubernetes/baseline.go
+++ b/pkg/app/piped/executor/kubernetes/baseline.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	provider "github.com/pipe-cd/pipe/pkg/app/piped/cloudprovider/kubernetes"
+	"github.com/pipe-cd/pipe/pkg/app/piped/executor"
 	"github.com/pipe-cd/pipe/pkg/config"
 	"github.com/pipe-cd/pipe/pkg/model"
 )
@@ -29,10 +30,10 @@ const (
 	addedBaselineResourcesMetadataKey = "baseline-resources"
 )
 
-func (e *Executor) ensureBaselineRollout(ctx context.Context) model.StageStatus {
+func (e *deployExecutor) ensureBaselineRollout(ctx context.Context) model.StageStatus {
 	var (
-		commitHash = e.Deployment.RunningCommitHash
-		options    = e.StageConfig.K8sBaselineRolloutStageOptions
+		runningCommit = e.Deployment.RunningCommitHash
+		options       = e.StageConfig.K8sBaselineRolloutStageOptions
 	)
 	if options == nil {
 		e.LogPersister.Errorf("Malformed configuration for stage %s", e.Stage.Name)
@@ -40,7 +41,7 @@ func (e *Executor) ensureBaselineRollout(ctx context.Context) model.StageStatus 
 	}
 
 	// Load running manifests at the most successful deployed commit.
-	e.LogPersister.Infof("Loading running manifests at commit %s for handling", commitHash)
+	e.LogPersister.Infof("Loading running manifests at commit %s for handling", runningCommit)
 	manifests, err := e.loadRunningManifests(ctx)
 	if err != nil {
 		e.LogPersister.Errorf("Failed while loading running manifests (%v)", err)
@@ -60,7 +61,13 @@ func (e *Executor) ensureBaselineRollout(ctx context.Context) model.StageStatus 
 	}
 
 	// Add builtin annotations for tracking application live state.
-	e.addBuiltinAnnontations(baselineManifests, baselineVariant, commitHash)
+	addBuiltinAnnontations(
+		baselineManifests,
+		baselineVariant,
+		runningCommit,
+		e.PipedConfig.PipedID,
+		e.Deployment.ApplicationId,
+	)
 
 	// Store added resource keys into metadata for cleaning later.
 	addedResources := make([]string, 0, len(baselineManifests))
@@ -76,7 +83,8 @@ func (e *Executor) ensureBaselineRollout(ctx context.Context) model.StageStatus 
 
 	// Start rolling out the resources for BASELINE variant.
 	e.LogPersister.Info("Start rolling out BASELINE variant...")
-	if err := e.applyManifests(ctx, baselineManifests); err != nil {
+	err = applyManifests(ctx, e.provider, baselineManifests, e.deployCfg.Input.Namespace, e.LogPersister)
+	if err != nil {
 		return model.StageStatus_STAGE_FAILURE
 	}
 
@@ -84,7 +92,7 @@ func (e *Executor) ensureBaselineRollout(ctx context.Context) model.StageStatus 
 	return model.StageStatus_STAGE_SUCCESS
 }
 
-func (e *Executor) ensureBaselineClean(ctx context.Context) model.StageStatus {
+func (e *deployExecutor) ensureBaselineClean(ctx context.Context) model.StageStatus {
 	value, ok := e.MetadataStore.Get(addedBaselineResourcesMetadataKey)
 	if !ok {
 		e.LogPersister.Error("Unable to determine the applied BASELINE resources")
@@ -92,57 +100,20 @@ func (e *Executor) ensureBaselineClean(ctx context.Context) model.StageStatus {
 	}
 
 	resources := strings.Split(value, ",")
-	if err := e.removeBaselineResources(ctx, resources); err != nil {
+	if err := removeBaselineResources(ctx, e.provider, resources, e.LogPersister); err != nil {
 		e.LogPersister.Errorf("Unable to remove baseline resources: %v", err)
 		return model.StageStatus_STAGE_FAILURE
 	}
 	return model.StageStatus_STAGE_SUCCESS
 }
 
-func (e *Executor) removeBaselineResources(ctx context.Context, resources []string) error {
-	if len(resources) == 0 {
-		return nil
-	}
-
-	var (
-		workloadKeys = make([]provider.ResourceKey, 0)
-		serviceKeys  = make([]provider.ResourceKey, 0)
-	)
-	for _, r := range resources {
-		key, err := provider.DecodeResourceKey(r)
-		if err != nil {
-			e.LogPersister.Errorf("Had an error while decoding BASELINE resource key: %s, %v", r, err)
-			continue
-		}
-		if key.IsWorkload() {
-			workloadKeys = append(workloadKeys, key)
-		} else {
-			serviceKeys = append(serviceKeys, key)
-		}
-	}
-
-	// We delete the service first to close all incoming connections.
-	e.LogPersister.Info("Starting finding and deleting service resources of BASELINE variant")
-	if err := e.deleteResources(ctx, serviceKeys); err != nil {
-		return err
-	}
-
-	// Next, delete all workloads.
-	e.LogPersister.Info("Starting finding and deleting workload resources of BASELINE variant")
-	if err := e.deleteResources(ctx, workloadKeys); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (e *Executor) generateBaselineManifests(manifests []provider.Manifest, opts config.K8sBaselineRolloutStageOptions) ([]provider.Manifest, error) {
+func (e *deployExecutor) generateBaselineManifests(manifests []provider.Manifest, opts config.K8sBaselineRolloutStageOptions) ([]provider.Manifest, error) {
 	suffix := baselineVariant
 	if opts.Suffix != "" {
 		suffix = opts.Suffix
 	}
 
-	workloads := findWorkloadManifests(manifests, e.config.Workloads)
+	workloads := findWorkloadManifests(manifests, e.deployCfg.Workloads)
 	if len(workloads) == 0 {
 		return nil, fmt.Errorf("unable to find any workload manifests for BASELINE variant")
 	}
@@ -151,7 +122,7 @@ func (e *Executor) generateBaselineManifests(manifests []provider.Manifest, opts
 
 	// Find service manifests and duplicate them for BASELINE variant.
 	if opts.CreateService {
-		serviceName := e.config.Service.Name
+		serviceName := e.deployCfg.Service.Name
 		services := findManifests(provider.KindService, serviceName, manifests)
 		if len(services) == 0 {
 			return nil, fmt.Errorf("unable to find any service for name=%q", serviceName)
@@ -183,4 +154,43 @@ func (e *Executor) generateBaselineManifests(manifests []provider.Manifest, opts
 	baselineManifests = append(baselineManifests, generatedWorkloads...)
 
 	return baselineManifests, nil
+}
+
+func removeBaselineResources(ctx context.Context, applier provider.Applier, resources []string, lp executor.LogPersister) error {
+	if len(resources) == 0 {
+		return nil
+	}
+
+	var (
+		workloadKeys = make([]provider.ResourceKey, 0)
+		serviceKeys  = make([]provider.ResourceKey, 0)
+	)
+	for _, r := range resources {
+		key, err := provider.DecodeResourceKey(r)
+		if err != nil {
+			lp.Errorf("Had an error while decoding BASELINE resource key: %s, %v", r, err)
+			continue
+		}
+		if key.IsWorkload() {
+			workloadKeys = append(workloadKeys, key)
+		} else {
+			serviceKeys = append(serviceKeys, key)
+		}
+	}
+
+	// We delete the service first to close all incoming connections.
+	lp.Info("Starting finding and deleting service resources of BASELINE variant")
+	err := deleteResources(ctx, applier, serviceKeys, lp)
+	if err != nil {
+		return err
+	}
+
+	// Next, delete all workloads.
+	lp.Info("Starting finding and deleting workload resources of BASELINE variant")
+	err = deleteResources(ctx, applier, workloadKeys, lp)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/pkg/app/piped/executor/kubernetes/baseline.go
+++ b/pkg/app/piped/executor/kubernetes/baseline.go
@@ -83,8 +83,7 @@ func (e *deployExecutor) ensureBaselineRollout(ctx context.Context) model.StageS
 
 	// Start rolling out the resources for BASELINE variant.
 	e.LogPersister.Info("Start rolling out BASELINE variant...")
-	err = applyManifests(ctx, e.provider, baselineManifests, e.deployCfg.Input.Namespace, e.LogPersister)
-	if err != nil {
+	if err := applyManifests(ctx, e.provider, baselineManifests, e.deployCfg.Input.Namespace, e.LogPersister); err != nil {
 		return model.StageStatus_STAGE_FAILURE
 	}
 
@@ -180,15 +179,13 @@ func removeBaselineResources(ctx context.Context, applier provider.Applier, reso
 
 	// We delete the service first to close all incoming connections.
 	lp.Info("Starting finding and deleting service resources of BASELINE variant")
-	err := deleteResources(ctx, applier, serviceKeys, lp)
-	if err != nil {
+	if err := deleteResources(ctx, applier, serviceKeys, lp); err != nil {
 		return err
 	}
 
 	// Next, delete all workloads.
 	lp.Info("Starting finding and deleting workload resources of BASELINE variant")
-	err = deleteResources(ctx, applier, workloadKeys, lp)
-	if err != nil {
+	if err := deleteResources(ctx, applier, workloadKeys, lp); err != nil {
 		return err
 	}
 

--- a/pkg/app/piped/executor/kubernetes/canary.go
+++ b/pkg/app/piped/executor/kubernetes/canary.go
@@ -88,8 +88,7 @@ func (e *deployExecutor) ensureCanaryRollout(ctx context.Context) model.StageSta
 
 	// Start rolling out the resources for CANARY variant.
 	e.LogPersister.Info("Start rolling out CANARY variant...")
-	err = applyManifests(ctx, e.provider, canaryManifests, e.deployCfg.Input.Namespace, e.LogPersister)
-	if err != nil {
+	if err := applyManifests(ctx, e.provider, canaryManifests, e.deployCfg.Input.Namespace, e.LogPersister); err != nil {
 		return model.StageStatus_STAGE_FAILURE
 	}
 
@@ -198,15 +197,13 @@ func removeCanaryResources(ctx context.Context, applier provider.Applier, resour
 
 	// We delete the service first to close all incoming connections.
 	lp.Info("Starting finding and deleting service resources of CANARY variant")
-	err := deleteResources(ctx, applier, serviceKeys, lp)
-	if err != nil {
+	if err := deleteResources(ctx, applier, serviceKeys, lp); err != nil {
 		return err
 	}
 
 	// Next, delete all workloads.
 	lp.Info("Starting finding and deleting workload resources of CANARY variant")
-	err = deleteResources(ctx, applier, workloadKeys, lp)
-	if err != nil {
+	if err := deleteResources(ctx, applier, workloadKeys, lp); err != nil {
 		return err
 	}
 

--- a/pkg/app/piped/executor/kubernetes/canary_test.go
+++ b/pkg/app/piped/executor/kubernetes/canary_test.go
@@ -39,13 +39,13 @@ func TestEnsureCanaryRollout(t *testing.T) {
 
 	testcases := []struct {
 		name     string
-		executor *Executor
+		executor *deployExecutor
 		want     model.StageStatus
 	}{
 		{
 			name: "malformed configuration",
 			want: model.StageStatus_STAGE_FAILURE,
-			executor: &Executor{
+			executor: &deployExecutor{
 				Input: executor.Input{
 					Deployment: &model.Deployment{
 						Trigger: &model.DeploymentTrigger{
@@ -61,7 +61,7 @@ func TestEnsureCanaryRollout(t *testing.T) {
 		{
 			name: "failed to load manifest",
 			want: model.StageStatus_STAGE_FAILURE,
-			executor: &Executor{
+			executor: &deployExecutor{
 				Input: executor.Input{
 					Deployment: &model.Deployment{
 						Trigger: &model.DeploymentTrigger{
@@ -90,7 +90,7 @@ func TestEnsureCanaryRollout(t *testing.T) {
 		{
 			name: "no manifests to handle",
 			want: model.StageStatus_STAGE_FAILURE,
-			executor: &Executor{
+			executor: &deployExecutor{
 				Input: executor.Input{
 					Deployment: &model.Deployment{
 						Trigger: &model.DeploymentTrigger{
@@ -120,7 +120,7 @@ func TestEnsureCanaryRollout(t *testing.T) {
 		{
 			name: "failed to apply manifests",
 			want: model.StageStatus_STAGE_FAILURE,
-			executor: &Executor{
+			executor: &deployExecutor{
 				Input: executor.Input{
 					Deployment: &model.Deployment{
 						Trigger: &model.DeploymentTrigger{
@@ -163,13 +163,13 @@ func TestEnsureCanaryRollout(t *testing.T) {
 					p.EXPECT().ApplyManifest(gomock.Any(), gomock.Any()).Return(fmt.Errorf("error"))
 					return p
 				}(),
-				config: &config.KubernetesDeploymentSpec{},
+				deployCfg: &config.KubernetesDeploymentSpec{},
 			},
 		},
 		{
 			name: "successfully applying manifests",
 			want: model.StageStatus_STAGE_SUCCESS,
-			executor: &Executor{
+			executor: &deployExecutor{
 				Input: executor.Input{
 					Deployment: &model.Deployment{
 						Trigger: &model.DeploymentTrigger{
@@ -212,7 +212,7 @@ func TestEnsureCanaryRollout(t *testing.T) {
 					p.EXPECT().ApplyManifest(gomock.Any(), gomock.Any()).Return(nil)
 					return p
 				}(),
-				config: &config.KubernetesDeploymentSpec{},
+				deployCfg: &config.KubernetesDeploymentSpec{},
 			},
 		},
 	}

--- a/pkg/app/piped/executor/kubernetes/kubernetes.go
+++ b/pkg/app/piped/executor/kubernetes/kubernetes.go
@@ -140,6 +140,7 @@ func (e *deployExecutor) loadRunningManifests(ctx context.Context) (manifests []
 			ds, err := e.RunningDSP.Get(ctx, e.LogPersister)
 			if err != nil {
 				e.LogPersister.Errorf("Failed to prepare running deploy source (%v)", err)
+				return nil, err
 			}
 
 			loader := provider.NewManifestLoader(

--- a/pkg/app/piped/executor/kubernetes/kubernetes.go
+++ b/pkg/app/piped/executor/kubernetes/kubernetes.go
@@ -26,8 +26,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	provider "github.com/pipe-cd/pipe/pkg/app/piped/cloudprovider/kubernetes"
-	"github.com/pipe-cd/pipe/pkg/app/piped/deploysource"
 	"github.com/pipe-cd/pipe/pkg/app/piped/executor"
+	"github.com/pipe-cd/pipe/pkg/cache"
 	"github.com/pipe-cd/pipe/pkg/config"
 	"github.com/pipe-cd/pipe/pkg/model"
 )
@@ -36,13 +36,12 @@ const (
 	variantLabel = "pipecd.dev/variant" // Variant name: primary, stage, baseline
 )
 
-type Executor struct {
+type deployExecutor struct {
 	executor.Input
 
-	repoDir  string
-	appDir   string
-	config   *config.KubernetesDeploymentSpec
-	provider provider.Provider
+	commit    string
+	deployCfg *config.KubernetesDeploymentSpec
+	provider  provider.Provider
 }
 
 type registerer interface {
@@ -53,7 +52,7 @@ type registerer interface {
 // Register registers this executor factory into a given registerer.
 func Register(r registerer) {
 	f := func(in executor.Input) executor.Executor {
-		return &Executor{
+		return &deployExecutor{
 			Input: in,
 		}
 	}
@@ -66,40 +65,33 @@ func Register(r registerer) {
 	r.Register(model.StageK8sBaselineClean, f)
 	r.Register(model.StageK8sTrafficRouting, f)
 
-	r.RegisterRollback(model.ApplicationKind_KUBERNETES, f)
+	r.RegisterRollback(model.ApplicationKind_KUBERNETES, func(in executor.Input) executor.Executor {
+		return &rollbackExecutor{
+			Input: in,
+		}
+	})
 }
 
-func (e *Executor) Execute(sig executor.StopSignal) model.StageStatus {
-	var ds *deploysource.DeploySource
-	var err error
+func (e *deployExecutor) Execute(sig executor.StopSignal) model.StageStatus {
 	ctx := sig.Context()
+	e.commit = e.Deployment.Trigger.Commit.Hash
 
-	if model.Stage(e.Stage.Name) == model.StageRollback {
-		ds, err = e.RunningDSP.Get(ctx, e.LogPersister)
-		if err != nil {
-			e.LogPersister.Errorf("Failed to prepare running deploy source data (%v)", err)
-			return model.StageStatus_STAGE_FAILURE
-		}
-	} else {
-		ds, err = e.TargetDSP.Get(ctx, e.LogPersister)
-		if err != nil {
-			e.LogPersister.Errorf("Failed to prepare target deploy source data (%v)", err)
-			return model.StageStatus_STAGE_FAILURE
-		}
+	ds, err := e.TargetDSP.Get(ctx, e.LogPersister)
+	if err != nil {
+		e.LogPersister.Errorf("Failed to prepare target deploy source data (%v)", err)
+		return model.StageStatus_STAGE_FAILURE
 	}
 
-	e.repoDir = ds.RepoDir
-	e.appDir = ds.AppDir
-	e.config = ds.DeploymentConfig.KubernetesDeploymentSpec
-	if e.config == nil {
+	e.deployCfg = ds.DeploymentConfig.KubernetesDeploymentSpec
+	if e.deployCfg == nil {
 		e.LogPersister.Error("Malformed deployment configuration: missing KubernetesDeploymentSpec")
 		return model.StageStatus_STAGE_FAILURE
 	}
 
-	e.provider = provider.NewProvider(e.Deployment.ApplicationName, e.appDir, e.repoDir, e.Deployment.GitPath.ConfigFilename, e.config.Input, e.Logger)
+	e.provider = provider.NewProvider(e.Deployment.ApplicationName, ds.AppDir, ds.RepoDir, e.Deployment.GitPath.ConfigFilename, e.deployCfg.Input, e.Logger)
 	e.Logger.Info("start executing kubernetes stage",
 		zap.String("stage-name", e.Stage.Name),
-		zap.String("app-dir", e.appDir),
+		zap.String("app-dir", ds.AppDir),
 	)
 
 	var (
@@ -129,9 +121,6 @@ func (e *Executor) Execute(sig executor.StopSignal) model.StageStatus {
 	case model.StageK8sTrafficRouting:
 		status = e.ensureTrafficRouting(ctx)
 
-	case model.StageRollback:
-		status = e.ensureRollback(ctx)
-
 	default:
 		e.LogPersister.Errorf("Unsupported stage %s for kubernetes application", e.Stage.Name)
 		return model.StageStatus_STAGE_FAILURE
@@ -140,72 +129,69 @@ func (e *Executor) Execute(sig executor.StopSignal) model.StageStatus {
 	return executor.DetermineStageStatus(sig.Signal(), originalStatus, status)
 }
 
-func (e *Executor) loadManifests(ctx context.Context) ([]provider.Manifest, error) {
-	cache := provider.AppManifestsCache{
-		AppID:  e.Deployment.ApplicationId,
-		Cache:  e.AppManifestsCache,
-		Logger: e.Logger,
-	}
-	manifests, ok := cache.Get(e.Deployment.Trigger.Commit.Hash)
-	if ok {
-		return manifests, nil
-	}
-
-	// When the manifests were not in the cache we have to load them.
-	manifests, err := e.provider.LoadManifests(ctx)
-	if err != nil {
-		return nil, err
-	}
-	cache.Put(e.Deployment.Trigger.Commit.Hash, manifests)
-
-	return manifests, nil
-}
-
-func (e *Executor) loadRunningManifests(ctx context.Context) (manifests []provider.Manifest, err error) {
-	runningCommit := e.Deployment.RunningCommitHash
-	if runningCommit == "" {
+func (e *deployExecutor) loadRunningManifests(ctx context.Context) (manifests []provider.Manifest, err error) {
+	commit := e.Deployment.RunningCommitHash
+	if commit == "" {
 		return nil, fmt.Errorf("unable to determine running commit")
 	}
 
-	cache := provider.AppManifestsCache{
-		AppID:  e.Deployment.ApplicationId,
-		Cache:  e.AppManifestsCache,
-		Logger: e.Logger,
+	loader := &manifestsLoadFunc{
+		loadFunc: func(ctx context.Context) ([]provider.Manifest, error) {
+			ds, err := e.RunningDSP.Get(ctx, e.LogPersister)
+			if err != nil {
+				e.LogPersister.Errorf("Failed to prepare running deploy source (%v)", err)
+			}
+
+			loader := provider.NewManifestLoader(
+				e.Deployment.ApplicationName,
+				ds.AppDir,
+				ds.RepoDir,
+				e.Deployment.GitPath.ConfigFilename,
+				e.deployCfg.Input,
+				e.Logger,
+			)
+			return loader.LoadManifests(ctx)
+		},
 	}
-	manifests, ok := cache.Get(runningCommit)
+
+	return loadManifests(ctx, e.Deployment.ApplicationId, commit, e.AppManifestsCache, loader, e.Logger)
+}
+
+type manifestsLoadFunc struct {
+	loadFunc func(context.Context) ([]provider.Manifest, error)
+}
+
+func (l *manifestsLoadFunc) LoadManifests(ctx context.Context) ([]provider.Manifest, error) {
+	return l.loadFunc(ctx)
+}
+
+func loadManifests(ctx context.Context, appID, commit string, manifestsCache cache.Cache, loader provider.ManifestLoader, logger *zap.Logger) (manifests []provider.Manifest, err error) {
+	cache := provider.AppManifestsCache{
+		AppID:  appID,
+		Cache:  manifestsCache,
+		Logger: logger,
+	}
+	manifests, ok := cache.Get(commit)
 	if ok {
 		return manifests, nil
 	}
 
 	// When the manifests were not in the cache we have to load them.
-	ds, err := e.RunningDSP.Get(ctx, e.LogPersister)
-	if err != nil {
-		e.LogPersister.Errorf("Failed to prepare running deploy source (%v)", err)
-	}
-
-	p := provider.NewProvider(
-		e.Deployment.ApplicationName,
-		ds.AppDir,
-		ds.RepoDir,
-		e.Deployment.GitPath.ConfigFilename,
-		e.config.Input,
-		e.Logger,
-	)
-	manifests, err = p.LoadManifests(ctx)
+	manifests, err = loader.LoadManifests(ctx)
 	if err != nil {
 		return nil, err
 	}
-	cache.Put(runningCommit, manifests)
+	cache.Put(commit, manifests)
 
 	return manifests, nil
 }
 
-func (e *Executor) addBuiltinAnnontations(manifests []provider.Manifest, variant, hash string) {
+func addBuiltinAnnontations(manifests []provider.Manifest, variant, hash, pipedID, appID string) {
 	for i := range manifests {
 		manifests[i].AddAnnotations(map[string]string{
 			provider.LabelManagedBy:          provider.ManagedByPiped,
-			provider.LabelPiped:              e.PipedConfig.PipedID,
-			provider.LabelApplication:        e.Deployment.ApplicationId,
+			provider.LabelPiped:              pipedID,
+			provider.LabelApplication:        appID,
 			variantLabel:                     variant,
 			provider.LabelOriginalAPIVersion: manifests[i].Key.APIVersion,
 			provider.LabelResourceKey:        manifests[i].Key.String(),
@@ -214,54 +200,54 @@ func (e *Executor) addBuiltinAnnontations(manifests []provider.Manifest, variant
 	}
 }
 
-func (e *Executor) applyManifests(ctx context.Context, manifests []provider.Manifest) error {
-	if e.config.Input.Namespace == "" {
-		e.LogPersister.Infof("Start applying %d manifests", len(manifests))
+func applyManifests(ctx context.Context, applier provider.Applier, manifests []provider.Manifest, namespace string, lp executor.LogPersister) error {
+	if namespace == "" {
+		lp.Infof("Start applying %d manifests", len(manifests))
 	} else {
-		e.LogPersister.Infof("Start applying %d manifests to %q namespace", len(manifests), e.config.Input.Namespace)
+		lp.Infof("Start applying %d manifests to %q namespace", len(manifests), namespace)
 	}
 	for _, m := range manifests {
-		if err := e.provider.ApplyManifest(ctx, m); err != nil {
-			e.LogPersister.Errorf("Failed to apply manifest: %s (%v)", m.Key.ReadableString(), err)
+		if err := applier.ApplyManifest(ctx, m); err != nil {
+			lp.Errorf("Failed to apply manifest: %s (%v)", m.Key.ReadableString(), err)
 			return err
 		}
-		e.LogPersister.Successf("- applied manifest: %s", m.Key.ReadableString())
+		lp.Successf("- applied manifest: %s", m.Key.ReadableString())
 	}
-	e.LogPersister.Successf("Successfully applied %d manifests", len(manifests))
+	lp.Successf("Successfully applied %d manifests", len(manifests))
 	return nil
 }
 
-func (e *Executor) deleteResources(ctx context.Context, resources []provider.ResourceKey) error {
+func deleteResources(ctx context.Context, applier provider.Applier, resources []provider.ResourceKey, lp executor.LogPersister) error {
 	resourcesLen := len(resources)
 	if resourcesLen == 0 {
-		e.LogPersister.Info("No resources to delete")
+		lp.Info("No resources to delete")
 		return nil
 	}
 
-	e.LogPersister.Infof("Start deleting %d resources", len(resources))
+	lp.Infof("Start deleting %d resources", len(resources))
 	var deletedCount int
 
 	for _, k := range resources {
-		err := e.provider.Delete(ctx, k)
+		err := applier.Delete(ctx, k)
 		if err == nil {
-			e.LogPersister.Successf("- deleted resource: %s", k.ReadableString())
+			lp.Successf("- deleted resource: %s", k.ReadableString())
 			deletedCount++
 			continue
 		}
 		if errors.Is(err, provider.ErrNotFound) {
-			e.LogPersister.Infof("- no resource %s to delete", k.ReadableString())
+			lp.Infof("- no resource %s to delete", k.ReadableString())
 			deletedCount++
 			continue
 		}
-		e.LogPersister.Errorf("- unable to delete resource: %s (%v)", k.ReadableString(), err)
+		lp.Errorf("- unable to delete resource: %s (%v)", k.ReadableString(), err)
 	}
 
 	if deletedCount < resourcesLen {
-		e.LogPersister.Infof("Deleted %d/%d resources", deletedCount, resourcesLen)
+		lp.Infof("Deleted %d/%d resources", deletedCount, resourcesLen)
 		return fmt.Errorf("unable to delete %d resources", resourcesLen-deletedCount)
 	}
 
-	e.LogPersister.Successf("Successfully deleted %d resources", len(resources))
+	lp.Successf("Successfully deleted %d resources", len(resources))
 	return nil
 }
 

--- a/pkg/app/piped/executor/kubernetes/kubernetes.go
+++ b/pkg/app/piped/executor/kubernetes/kubernetes.go
@@ -178,8 +178,7 @@ func loadManifests(ctx context.Context, appID, commit string, manifestsCache cac
 	}
 
 	// When the manifests were not in the cache we have to load them.
-	manifests, err = loader.LoadManifests(ctx)
-	if err != nil {
+	if manifests, err = loader.LoadManifests(ctx); err != nil {
 		return nil, err
 	}
 	cache.Put(commit, manifests)

--- a/pkg/app/piped/executor/kubernetes/primary.go
+++ b/pkg/app/piped/executor/kubernetes/primary.go
@@ -92,8 +92,7 @@ func (e *deployExecutor) ensurePrimaryRollout(ctx context.Context) model.StageSt
 
 	// Generate the manifests for applying.
 	e.LogPersister.Info("Start generating manifests for PRIMARY variant")
-	primaryManifests, err = e.generatePrimaryManifests(primaryManifests, *options)
-	if err != nil {
+	if primaryManifests, err = e.generatePrimaryManifests(primaryManifests, *options); err != nil {
 		e.LogPersister.Errorf("Unable to generate manifests for PRIMARY variant (%v)", err)
 		return model.StageStatus_STAGE_FAILURE
 	}
@@ -110,8 +109,7 @@ func (e *deployExecutor) ensurePrimaryRollout(ctx context.Context) model.StageSt
 
 	// Start applying all manifests to add or update running resources.
 	e.LogPersister.Info("Start rolling out PRIMARY variant...")
-	err = applyManifests(ctx, e.provider, primaryManifests, e.deployCfg.Input.Namespace, e.LogPersister)
-	if err != nil {
+	if err := applyManifests(ctx, e.provider, primaryManifests, e.deployCfg.Input.Namespace, e.LogPersister); err != nil {
 		return model.StageStatus_STAGE_FAILURE
 	}
 	e.LogPersister.Success("Successfully rolled out PRIMARY variant")
@@ -149,8 +147,7 @@ func (e *deployExecutor) ensurePrimaryRollout(ctx context.Context) model.StageSt
 
 	// Start deleting all running resources that are not defined in Git.
 	e.LogPersister.Infof("Start deleting %d resources", len(removeKeys))
-	err = deleteResources(ctx, e.provider, removeKeys, e.LogPersister)
-	if err != nil {
+	if err := deleteResources(ctx, e.provider, removeKeys, e.LogPersister); err != nil {
 		return model.StageStatus_STAGE_FAILURE
 	}
 

--- a/pkg/app/piped/executor/kubernetes/primary.go
+++ b/pkg/app/piped/executor/kubernetes/primary.go
@@ -28,32 +28,36 @@ const (
 	primaryVariant = "primary"
 )
 
-func (e *Executor) ensurePrimaryRollout(ctx context.Context) model.StageStatus {
-	var (
-		commitHash = e.Deployment.Trigger.Commit.Hash
-		options    = e.StageConfig.K8sPrimaryRolloutStageOptions
-	)
+func (e *deployExecutor) ensurePrimaryRollout(ctx context.Context) model.StageStatus {
+	options := e.StageConfig.K8sPrimaryRolloutStageOptions
 	if options == nil {
 		e.LogPersister.Errorf("Malformed configuration for stage %s", e.Stage.Name)
 		return model.StageStatus_STAGE_FAILURE
 	}
 
 	// Load the manifests at the triggered commit.
-	e.LogPersister.Infof("Loading manifests at trigered commit %s for handling", commitHash)
-	manifests, err := e.loadManifests(ctx)
+	e.LogPersister.Infof("Loading manifests at trigered commit %s for handling", e.commit)
+	manifests, err := loadManifests(
+		ctx,
+		e.Deployment.ApplicationId,
+		e.commit,
+		e.AppManifestsCache,
+		e.provider,
+		e.Logger,
+	)
 	if err != nil {
 		e.LogPersister.Errorf("Failed while loading manifests (%v)", err)
 		return model.StageStatus_STAGE_FAILURE
 	}
 	e.LogPersister.Successf("Successfully loaded %d manifests", len(manifests))
 
-	routingMethod := config.DetermineKubernetesTrafficRoutingMethod(e.config.TrafficRouting)
+	routingMethod := config.DetermineKubernetesTrafficRoutingMethod(e.deployCfg.TrafficRouting)
 	var primaryManifests []provider.Manifest
 	if routingMethod == config.KubernetesTrafficRoutingMethodPodSelector {
 		primaryManifests = manifests
 	} else {
 		// Find traffic routing manifests and filter out it from primary manifests.
-		trafficRoutingManifests, err := findTrafficRoutingManifests(manifests, e.config.Service.Name, e.config.TrafficRouting)
+		trafficRoutingManifests, err := findTrafficRoutingManifests(manifests, e.deployCfg.Service.Name, e.deployCfg.TrafficRouting)
 		if err != nil {
 			e.LogPersister.Errorf("Failed while finding traffic routing manifest: (%v)", err)
 			return model.StageStatus_STAGE_FAILURE
@@ -72,8 +76,8 @@ func (e *Executor) ensurePrimaryRollout(ctx context.Context) model.StageStatus {
 	// Check if the variant selector is in the workloads.
 	if !options.AddVariantLabelToSelector &&
 		routingMethod == config.KubernetesTrafficRoutingMethodPodSelector &&
-		e.config.HasStage(model.StageK8sTrafficRouting) {
-		workloads := findWorkloadManifests(primaryManifests, e.config.Workloads)
+		e.deployCfg.HasStage(model.StageK8sTrafficRouting) {
+		workloads := findWorkloadManifests(primaryManifests, e.deployCfg.Workloads)
 		var invalid bool
 		for _, m := range workloads {
 			if err := checkVariantSelectorInWorkload(m, primaryVariant); err != nil {
@@ -88,19 +92,26 @@ func (e *Executor) ensurePrimaryRollout(ctx context.Context) model.StageStatus {
 
 	// Generate the manifests for applying.
 	e.LogPersister.Info("Start generating manifests for PRIMARY variant")
-	applyManifests, err := e.generatePrimaryManifests(primaryManifests, *options)
+	primaryManifests, err = e.generatePrimaryManifests(primaryManifests, *options)
 	if err != nil {
 		e.LogPersister.Errorf("Unable to generate manifests for PRIMARY variant (%v)", err)
 		return model.StageStatus_STAGE_FAILURE
 	}
-	e.LogPersister.Successf("Successfully generated %d manifests for PRIMARY variant", len(applyManifests))
+	e.LogPersister.Successf("Successfully generated %d manifests for PRIMARY variant", len(primaryManifests))
 
 	// Add builtin annotations for tracking application live state.
-	e.addBuiltinAnnontations(applyManifests, primaryVariant, commitHash)
+	addBuiltinAnnontations(
+		primaryManifests,
+		primaryVariant,
+		e.commit,
+		e.PipedConfig.PipedID,
+		e.Deployment.ApplicationId,
+	)
 
 	// Start applying all manifests to add or update running resources.
 	e.LogPersister.Info("Start rolling out PRIMARY variant...")
-	if err := e.applyManifests(ctx, applyManifests); err != nil {
+	err = applyManifests(ctx, e.provider, primaryManifests, e.deployCfg.Input.Namespace, e.LogPersister)
+	if err != nil {
 		return model.StageStatus_STAGE_FAILURE
 	}
 	e.LogPersister.Success("Successfully rolled out PRIMARY variant")
@@ -129,7 +140,7 @@ func (e *Executor) ensurePrimaryRollout(ctx context.Context) model.StageStatus {
 		return model.StageStatus_STAGE_FAILURE
 	}
 
-	removeKeys := findRemoveManifests(runningManifests, manifests, e.config.Input.Namespace)
+	removeKeys := findRemoveManifests(runningManifests, manifests, e.deployCfg.Input.Namespace)
 	if len(removeKeys) == 0 {
 		e.LogPersister.Info("There are no live resources should be removed")
 		return model.StageStatus_STAGE_SUCCESS
@@ -138,7 +149,8 @@ func (e *Executor) ensurePrimaryRollout(ctx context.Context) model.StageStatus {
 
 	// Start deleting all running resources that are not defined in Git.
 	e.LogPersister.Infof("Start deleting %d resources", len(removeKeys))
-	if err := e.deleteResources(ctx, removeKeys); err != nil {
+	err = deleteResources(ctx, e.provider, removeKeys, e.LogPersister)
+	if err != nil {
 		return model.StageStatus_STAGE_FAILURE
 	}
 
@@ -166,7 +178,7 @@ func findRemoveManifests(prevs []provider.Manifest, curs []provider.Manifest, na
 	return removeKeys
 }
 
-func (e *Executor) generatePrimaryManifests(manifests []provider.Manifest, opts config.K8sPrimaryRolloutStageOptions) ([]provider.Manifest, error) {
+func (e *deployExecutor) generatePrimaryManifests(manifests []provider.Manifest, opts config.K8sPrimaryRolloutStageOptions) ([]provider.Manifest, error) {
 	suffix := primaryVariant
 	if opts.Suffix != "" {
 		suffix = opts.Suffix
@@ -179,7 +191,7 @@ func (e *Executor) generatePrimaryManifests(manifests []provider.Manifest, opts 
 	// When addVariantLabelToSelector is true, ensure that all workloads
 	// have the variant label in their selector.
 	if opts.AddVariantLabelToSelector {
-		workloads := findWorkloadManifests(manifests, e.config.Workloads)
+		workloads := findWorkloadManifests(manifests, e.deployCfg.Workloads)
 		for _, m := range workloads {
 			if err := ensureVariantSelectorInWorkload(m, primaryVariant); err != nil {
 				return nil, fmt.Errorf("unable to check/set %q in selector of workload %s (%v)", variantLabel+": "+primaryVariant, m.Key.ReadableString(), err)
@@ -189,7 +201,7 @@ func (e *Executor) generatePrimaryManifests(manifests []provider.Manifest, opts 
 
 	// Find service manifests and duplicate them for PRIMARY variant.
 	if opts.CreateService {
-		serviceName := e.config.Service.Name
+		serviceName := e.deployCfg.Service.Name
 		services := findManifests(provider.KindService, serviceName, manifests)
 		if len(services) == 0 {
 			return nil, fmt.Errorf("unable to find any service for name=%q", serviceName)

--- a/pkg/app/piped/executor/kubernetes/primary_test.go
+++ b/pkg/app/piped/executor/kubernetes/primary_test.go
@@ -39,13 +39,13 @@ func TestEnsurePrimaryRollout(t *testing.T) {
 
 	testcases := []struct {
 		name     string
-		executor *Executor
+		executor *deployExecutor
 		want     model.StageStatus
 	}{
 		{
 			name: "malformed configuration",
 			want: model.StageStatus_STAGE_FAILURE,
-			executor: &Executor{
+			executor: &deployExecutor{
 				Input: executor.Input{
 					Deployment: &model.Deployment{
 						Trigger: &model.DeploymentTrigger{
@@ -61,7 +61,7 @@ func TestEnsurePrimaryRollout(t *testing.T) {
 		{
 			name: "failed to load manifest",
 			want: model.StageStatus_STAGE_FAILURE,
-			executor: &Executor{
+			executor: &deployExecutor{
 				Input: executor.Input{
 					Deployment: &model.Deployment{
 						Trigger: &model.DeploymentTrigger{
@@ -90,7 +90,7 @@ func TestEnsurePrimaryRollout(t *testing.T) {
 		{
 			name: "successfully apply a manifest",
 			want: model.StageStatus_STAGE_SUCCESS,
-			executor: &Executor{
+			executor: &deployExecutor{
 				Input: executor.Input{
 					Deployment: &model.Deployment{
 						Trigger: &model.DeploymentTrigger{
@@ -126,13 +126,13 @@ func TestEnsurePrimaryRollout(t *testing.T) {
 					p.EXPECT().ApplyManifest(gomock.Any(), gomock.Any()).Return(nil)
 					return p
 				}(),
-				config: &config.KubernetesDeploymentSpec{},
+				deployCfg: &config.KubernetesDeploymentSpec{},
 			},
 		},
 		{
 			name: "successfully apply two manifests",
 			want: model.StageStatus_STAGE_SUCCESS,
-			executor: &Executor{
+			executor: &deployExecutor{
 				Input: executor.Input{
 					Deployment: &model.Deployment{
 						Trigger: &model.DeploymentTrigger{
@@ -176,7 +176,7 @@ func TestEnsurePrimaryRollout(t *testing.T) {
 					p.EXPECT().ApplyManifest(gomock.Any(), gomock.Any()).Return(nil)
 					return p
 				}(),
-				config: &config.KubernetesDeploymentSpec{
+				deployCfg: &config.KubernetesDeploymentSpec{
 					Service: config.K8sResourceReference{
 						Kind: "Service",
 						Name: "foo",
@@ -187,7 +187,7 @@ func TestEnsurePrimaryRollout(t *testing.T) {
 		{
 			name: "filter out VirtualService",
 			want: model.StageStatus_STAGE_SUCCESS,
-			executor: &Executor{
+			executor: &deployExecutor{
 				Input: executor.Input{
 					Deployment: &model.Deployment{
 						Trigger: &model.DeploymentTrigger{
@@ -222,7 +222,7 @@ func TestEnsurePrimaryRollout(t *testing.T) {
 					}, nil)
 					return p
 				}(),
-				config: &config.KubernetesDeploymentSpec{
+				deployCfg: &config.KubernetesDeploymentSpec{
 					TrafficRouting: &config.KubernetesTrafficRouting{
 						Method: config.KubernetesTrafficRoutingMethodIstio,
 					},
@@ -232,7 +232,7 @@ func TestEnsurePrimaryRollout(t *testing.T) {
 		{
 			name: "lack of variant label",
 			want: model.StageStatus_STAGE_FAILURE,
-			executor: &Executor{
+			executor: &deployExecutor{
 				Input: executor.Input{
 					Deployment: &model.Deployment{
 						Trigger: &model.DeploymentTrigger{
@@ -267,7 +267,7 @@ func TestEnsurePrimaryRollout(t *testing.T) {
 					}, nil)
 					return p
 				}(),
-				config: &config.KubernetesDeploymentSpec{
+				deployCfg: &config.KubernetesDeploymentSpec{
 					GenericDeploymentSpec: config.GenericDeploymentSpec{
 						Pipeline: &config.DeploymentPipeline{
 							Stages: []config.PipelineStage{

--- a/pkg/app/piped/executor/kubernetes/rollback.go
+++ b/pkg/app/piped/executor/kubernetes/rollback.go
@@ -18,10 +18,11 @@ import (
 	"context"
 	"strings"
 
+	"go.uber.org/zap"
+
 	provider "github.com/pipe-cd/pipe/pkg/app/piped/cloudprovider/kubernetes"
 	"github.com/pipe-cd/pipe/pkg/app/piped/executor"
 	"github.com/pipe-cd/pipe/pkg/model"
-	"go.uber.org/zap"
 )
 
 type rollbackExecutor struct {

--- a/pkg/app/piped/executor/kubernetes/rollback.go
+++ b/pkg/app/piped/executor/kubernetes/rollback.go
@@ -111,8 +111,7 @@ func (e *rollbackExecutor) ensureRollback(ctx context.Context) model.StageStatus
 	)
 
 	// Start applying all manifests to add or update running resources.
-	err = applyManifests(ctx, p, manifests, deployCfg.Input.Namespace, e.LogPersister)
-	if err != nil {
+	if err := applyManifests(ctx, p, manifests, deployCfg.Input.Namespace, e.LogPersister); err != nil {
 		return model.StageStatus_STAGE_FAILURE
 	}
 

--- a/pkg/app/piped/executor/kubernetes/rollback.go
+++ b/pkg/app/piped/executor/kubernetes/rollback.go
@@ -18,18 +18,66 @@ import (
 	"context"
 	"strings"
 
+	provider "github.com/pipe-cd/pipe/pkg/app/piped/cloudprovider/kubernetes"
+	"github.com/pipe-cd/pipe/pkg/app/piped/executor"
 	"github.com/pipe-cd/pipe/pkg/model"
+	"go.uber.org/zap"
 )
 
-func (e *Executor) ensureRollback(ctx context.Context) model.StageStatus {
-	commitHash := e.Deployment.RunningCommitHash
+type rollbackExecutor struct {
+	executor.Input
+}
+
+func (e *rollbackExecutor) Execute(sig executor.StopSignal) model.StageStatus {
+	var (
+		ctx            = sig.Context()
+		originalStatus = e.Stage.Status
+		status         model.StageStatus
+	)
+
+	switch model.Stage(e.Stage.Name) {
+	case model.StageRollback:
+		status = e.ensureRollback(ctx)
+
+	default:
+		e.LogPersister.Errorf("Unsupported stage %s for kubernetes application", e.Stage.Name)
+		return model.StageStatus_STAGE_FAILURE
+	}
+
+	return executor.DetermineStageStatus(sig.Signal(), originalStatus, status)
+}
+
+func (e *rollbackExecutor) ensureRollback(ctx context.Context) model.StageStatus {
+	// There is nothing to do if this is the first deployment.
+	if e.Deployment.RunningCommitHash == "" {
+		e.LogPersister.Errorf("Unable to determine the last deployed commit to rollback. It seems this is the first deployment.")
+		return model.StageStatus_STAGE_FAILURE
+	}
+
+	ds, err := e.RunningDSP.Get(ctx, e.LogPersister)
+	if err != nil {
+		e.LogPersister.Errorf("Failed to prepare running deploy source data (%v)", err)
+		return model.StageStatus_STAGE_FAILURE
+	}
+
+	deployCfg := ds.DeploymentConfig.KubernetesDeploymentSpec
+	if deployCfg == nil {
+		e.LogPersister.Error("Malformed deployment configuration: missing KubernetesDeploymentSpec")
+		return model.StageStatus_STAGE_FAILURE
+	}
+
+	p := provider.NewProvider(e.Deployment.ApplicationName, ds.AppDir, ds.RepoDir, e.Deployment.GitPath.ConfigFilename, deployCfg.Input, e.Logger)
+	e.Logger.Info("start executing kubernetes stage",
+		zap.String("stage-name", e.Stage.Name),
+		zap.String("app-dir", ds.AppDir),
+	)
 
 	// Firstly, we reapply all manifests at running commit
 	// to revert PRIMARY resources and TRAFFIC ROUTING resources.
 
 	// Load the manifests at the specified commit.
-	e.LogPersister.Infof("Loading manifests at running commit %s for handling", commitHash)
-	manifests, err := e.loadRunningManifests(ctx)
+	e.LogPersister.Infof("Loading manifests at running commit %s for handling", e.Deployment.RunningCommitHash)
+	manifests, err := loadManifests(ctx, e.Deployment.ApplicationId, e.Deployment.RunningCommitHash, e.AppManifestsCache, p, e.Logger)
 	if err != nil {
 		e.LogPersister.Errorf("Failed while loading running manifests (%v)", err)
 		return model.StageStatus_STAGE_FAILURE
@@ -42,8 +90,8 @@ func (e *Executor) ensureRollback(ctx context.Context) model.StageStatus {
 
 	// When addVariantLabelToSelector is true, ensure that all workloads
 	// have the variant label in their selector.
-	if e.config.QuickSync.AddVariantLabelToSelector {
-		workloads := findWorkloadManifests(manifests, e.config.Workloads)
+	if deployCfg.QuickSync.AddVariantLabelToSelector {
+		workloads := findWorkloadManifests(manifests, deployCfg.Workloads)
 		for _, m := range workloads {
 			if err := ensureVariantSelectorInWorkload(m, primaryVariant); err != nil {
 				e.LogPersister.Errorf("Unable to check/set %q in selector of workload %s (%v)", variantLabel+": "+primaryVariant, m.Key.ReadableString(), err)
@@ -53,10 +101,17 @@ func (e *Executor) ensureRollback(ctx context.Context) model.StageStatus {
 	}
 
 	// Add builtin annotations for tracking application live state.
-	e.addBuiltinAnnontations(manifests, primaryVariant, commitHash)
+	addBuiltinAnnontations(
+		manifests,
+		primaryVariant,
+		e.Deployment.RunningCommitHash,
+		e.PipedConfig.PipedID,
+		e.Deployment.ApplicationId,
+	)
 
 	// Start applying all manifests to add or update running resources.
-	if err := e.applyManifests(ctx, manifests); err != nil {
+	err = applyManifests(ctx, p, manifests, deployCfg.Input.Namespace, e.LogPersister)
+	if err != nil {
 		return model.StageStatus_STAGE_FAILURE
 	}
 
@@ -66,7 +121,7 @@ func (e *Executor) ensureRollback(ctx context.Context) model.StageStatus {
 	e.LogPersister.Info("Start checking to ensure that the CANARY variant should be removed")
 	if value, ok := e.MetadataStore.Get(addedCanaryResourcesMetadataKey); ok {
 		resources := strings.Split(value, ",")
-		if err := e.removeCanaryResources(ctx, resources); err != nil {
+		if err := removeCanaryResources(ctx, p, resources, e.LogPersister); err != nil {
 			errs = append(errs, err)
 		}
 	}
@@ -75,7 +130,7 @@ func (e *Executor) ensureRollback(ctx context.Context) model.StageStatus {
 	e.LogPersister.Info("Start checking to ensure that the BASELINE variant should be removed")
 	if value, ok := e.MetadataStore.Get(addedBaselineResourcesMetadataKey); ok {
 		resources := strings.Split(value, ",")
-		if err := e.removeBaselineResources(ctx, resources); err != nil {
+		if err := removeBaselineResources(ctx, p, resources, e.LogPersister); err != nil {
 			errs = append(errs, err)
 		}
 	}

--- a/pkg/app/piped/executor/kubernetes/sync.go
+++ b/pkg/app/piped/executor/kubernetes/sync.go
@@ -65,8 +65,7 @@ func (e *deployExecutor) ensureSync(ctx context.Context) model.StageStatus {
 	)
 
 	// Start applying all manifests to add or update running resources.
-	err = applyManifests(ctx, e.provider, manifests, e.deployCfg.Input.Namespace, e.LogPersister)
-	if err != nil {
+	if err := applyManifests(ctx, e.provider, manifests, e.deployCfg.Input.Namespace, e.LogPersister); err != nil {
 		return model.StageStatus_STAGE_FAILURE
 	}
 
@@ -102,8 +101,7 @@ func (e *deployExecutor) ensureSync(ctx context.Context) model.StageStatus {
 	e.LogPersister.Infof("Found %d live resources that are no longer defined in Git", len(removeKeys))
 
 	// Start deleting all running resources that are not defined in Git.
-	err = deleteResources(ctx, e.provider, removeKeys, e.LogPersister)
-	if err != nil {
+	if err := deleteResources(ctx, e.provider, removeKeys, e.LogPersister); err != nil {
 		return model.StageStatus_STAGE_FAILURE
 	}
 

--- a/pkg/app/piped/executor/kubernetes/sync.go
+++ b/pkg/app/piped/executor/kubernetes/sync.go
@@ -22,12 +22,17 @@ import (
 	"github.com/pipe-cd/pipe/pkg/model"
 )
 
-func (e *Executor) ensureSync(ctx context.Context) model.StageStatus {
-	commitHash := e.Deployment.Trigger.Commit.Hash
-
+func (e *deployExecutor) ensureSync(ctx context.Context) model.StageStatus {
 	// Load the manifests at the specified commit.
-	e.LogPersister.Infof("Loading manifests at commit %s for handling", commitHash)
-	manifests, err := e.loadManifests(ctx)
+	e.LogPersister.Infof("Loading manifests at commit %s for handling", e.commit)
+	manifests, err := loadManifests(
+		ctx,
+		e.Deployment.ApplicationId,
+		e.commit,
+		e.AppManifestsCache,
+		e.provider,
+		e.Logger,
+	)
 	if err != nil {
 		e.LogPersister.Errorf("Failed while loading manifests (%v)", err)
 		return model.StageStatus_STAGE_FAILURE
@@ -40,8 +45,8 @@ func (e *Executor) ensureSync(ctx context.Context) model.StageStatus {
 
 	// When addVariantLabelToSelector is true, ensure that all workloads
 	// have the variant label in their selector.
-	if e.config.QuickSync.AddVariantLabelToSelector {
-		workloads := findWorkloadManifests(manifests, e.config.Workloads)
+	if e.deployCfg.QuickSync.AddVariantLabelToSelector {
+		workloads := findWorkloadManifests(manifests, e.deployCfg.Workloads)
 		for _, m := range workloads {
 			if err := ensureVariantSelectorInWorkload(m, primaryVariant); err != nil {
 				e.LogPersister.Errorf("Unable to check/set %q in selector of workload %s (%v)", variantLabel+": "+primaryVariant, m.Key.ReadableString(), err)
@@ -51,14 +56,21 @@ func (e *Executor) ensureSync(ctx context.Context) model.StageStatus {
 	}
 
 	// Add builtin annotations for tracking application live state.
-	e.addBuiltinAnnontations(manifests, primaryVariant, commitHash)
+	addBuiltinAnnontations(
+		manifests,
+		primaryVariant,
+		e.commit,
+		e.PipedConfig.PipedID,
+		e.Deployment.ApplicationId,
+	)
 
 	// Start applying all manifests to add or update running resources.
-	if err := e.applyManifests(ctx, manifests); err != nil {
+	err = applyManifests(ctx, e.provider, manifests, e.deployCfg.Input.Namespace, e.LogPersister)
+	if err != nil {
 		return model.StageStatus_STAGE_FAILURE
 	}
 
-	if !e.config.QuickSync.Prune {
+	if !e.deployCfg.QuickSync.Prune {
 		e.LogPersister.Info("Resource GC was skipped because sync.prune was not configured")
 		return model.StageStatus_STAGE_SUCCESS
 	}
@@ -90,7 +102,8 @@ func (e *Executor) ensureSync(ctx context.Context) model.StageStatus {
 	e.LogPersister.Infof("Found %d live resources that are no longer defined in Git", len(removeKeys))
 
 	// Start deleting all running resources that are not defined in Git.
-	if err := e.deleteResources(ctx, removeKeys); err != nil {
+	err = deleteResources(ctx, e.provider, removeKeys, e.LogPersister)
+	if err != nil {
 		return model.StageStatus_STAGE_FAILURE
 	}
 

--- a/pkg/app/piped/executor/kubernetes/sync_test.go
+++ b/pkg/app/piped/executor/kubernetes/sync_test.go
@@ -39,13 +39,13 @@ func TestEnsureSync(t *testing.T) {
 
 	testcases := []struct {
 		name     string
-		executor *Executor
+		executor *deployExecutor
 		want     model.StageStatus
 	}{
 		{
 			name: "failed to load manifest",
 			want: model.StageStatus_STAGE_FAILURE,
-			executor: &Executor{
+			executor: &deployExecutor{
 				Input: executor.Input{
 					Deployment: &model.Deployment{
 						Trigger: &model.DeploymentTrigger{
@@ -70,7 +70,7 @@ func TestEnsureSync(t *testing.T) {
 		{
 			name: "unable to apply manifests",
 			want: model.StageStatus_STAGE_FAILURE,
-			executor: &Executor{
+			executor: &deployExecutor{
 				Input: executor.Input{
 					Deployment: &model.Deployment{
 						Trigger: &model.DeploymentTrigger{
@@ -100,7 +100,7 @@ func TestEnsureSync(t *testing.T) {
 					p.EXPECT().ApplyManifest(gomock.Any(), gomock.Any()).Return(fmt.Errorf("error"))
 					return p
 				}(),
-				config: &config.KubernetesDeploymentSpec{
+				deployCfg: &config.KubernetesDeploymentSpec{
 					QuickSync: config.K8sSyncStageOptions{
 						AddVariantLabelToSelector: true,
 					},
@@ -110,7 +110,7 @@ func TestEnsureSync(t *testing.T) {
 		{
 			name: "successfully apply manifests",
 			want: model.StageStatus_STAGE_SUCCESS,
-			executor: &Executor{
+			executor: &deployExecutor{
 				Input: executor.Input{
 					Deployment: &model.Deployment{
 						Trigger: &model.DeploymentTrigger{
@@ -140,7 +140,7 @@ func TestEnsureSync(t *testing.T) {
 					p.EXPECT().ApplyManifest(gomock.Any(), gomock.Any()).Return(nil)
 					return p
 				}(),
-				config: &config.KubernetesDeploymentSpec{
+				deployCfg: &config.KubernetesDeploymentSpec{
 					QuickSync: config.K8sSyncStageOptions{
 						AddVariantLabelToSelector: true,
 					},

--- a/pkg/app/piped/executor/kubernetes/traffic.go
+++ b/pkg/app/piped/executor/kubernetes/traffic.go
@@ -132,8 +132,7 @@ func (e *deployExecutor) ensureTrafficRouting(ctx context.Context) model.StageSt
 		canaryPercent,
 		baselinePercent,
 	)
-	err = applyManifests(ctx, e.provider, []provider.Manifest{trafficRoutingManifest}, e.deployCfg.Input.Namespace, e.LogPersister)
-	if err != nil {
+	if err := applyManifests(ctx, e.provider, []provider.Manifest{trafficRoutingManifest}, e.deployCfg.Input.Namespace, e.LogPersister); err != nil {
 		return model.StageStatus_STAGE_FAILURE
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

- Break `executor` to 2 separate `deployExecutor` and `rollbackExecutor` to avoid data coupling between rollback stage and other
- Move common functions to not be apart of `executor` to be more testable and reusable

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
