### PR TITLE
Update helloworld image version to match quickstart guide

### DIFF
--- a/examples/kubernetes/canary/deployment.yaml
+++ b/examples/kubernetes/canary/deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: helloworld
-        image: gcr.io/pipecd/helloworld:v0.5.0
+        image: gcr.io/pipecd/helloworld:v0.1.0
         args:
           - server
         ports:


### PR DESCRIPTION
**What this PR does / why we need it**:

> According to QuickStart, the version of the helloworld image in kubernetes/canary/deployment.yaml L22 is v0.1.0, but in fact, v0.5.0 is correct.

fix it :) 

**Which issue(s) this PR fixes**:

Fixes #1149

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
