### PR TITLE
Read password and username via file from MongoDB datasource

### DIFF
--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -393,7 +393,9 @@ func (s *server) createDatastore(ctx context.Context, cfg *config.ControlPlaneSp
 		if mdConfig.UsernameFile != "" || mdConfig.PasswordFile != "" {
 			options = append(options, mongodb.WithAuthenticationFile(mdConfig.UsernameFile, mdConfig.PasswordFile))
 		}
-		return mongodb.NewMongoDB(ctx, mdConfig.URL,
+		return mongodb.NewMongoDB(
+			ctx,
+			mdConfig.URL,
 			mdConfig.Database,
 			options...)
 	default:

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -390,8 +390,12 @@ func (s *server) createDatastore(ctx context.Context, cfg *config.ControlPlaneSp
 		options := []mongodb.Option{
 			mongodb.WithLogger(logger),
 		}
-		return mongodb.NewMongoDB(ctx, mdConfig.URL, mdConfig.Database, options...)
-
+		if mdConfig.UsernameFile != "" || mdConfig.PasswordFile != "" {
+			options = append(options, mongodb.WithAuthenticationFile(mdConfig.UsernameFile, mdConfig.PasswordFile))
+		}
+		return mongodb.NewMongoDB(ctx, mdConfig.URL,
+			mdConfig.Database,
+			options...)
 	default:
 		return nil, fmt.Errorf("unknown datastore type %q", cfg.Datastore.Type)
 	}

--- a/pkg/app/ops/cmd/server/server.go
+++ b/pkg/app/ops/cmd/server/server.go
@@ -156,8 +156,13 @@ func (s *server) createDatastore(ctx context.Context, cfg *config.ControlPlaneSp
 		options := []mongodb.Option{
 			mongodb.WithLogger(logger),
 		}
-		return mongodb.NewMongoDB(ctx, mdConfig.URL, mdConfig.Database, options...)
-
+		if mdConfig.UsernameFile != "" || mdConfig.PasswordFile != "" {
+			options = append(options, mongodb.WithAuthenticationFile(mdConfig.UsernameFile, mdConfig.PasswordFile))
+		}
+		return mongodb.NewMongoDB(ctx,
+			mdConfig.URL,
+			mdConfig.Database,
+			options...)
 	default:
 		return nil, fmt.Errorf("unknown datastore type %q", cfg.Datastore.Type)
 	}

--- a/pkg/app/ops/cmd/server/server.go
+++ b/pkg/app/ops/cmd/server/server.go
@@ -159,10 +159,12 @@ func (s *server) createDatastore(ctx context.Context, cfg *config.ControlPlaneSp
 		if mdConfig.UsernameFile != "" || mdConfig.PasswordFile != "" {
 			options = append(options, mongodb.WithAuthenticationFile(mdConfig.UsernameFile, mdConfig.PasswordFile))
 		}
-		return mongodb.NewMongoDB(ctx,
+		return mongodb.NewMongoDB(
+			ctx,
 			mdConfig.URL,
 			mdConfig.Database,
-			options...)
+			options...,
+		)
 	default:
 		return nil, fmt.Errorf("unknown datastore type %q", cfg.Datastore.Type)
 	}

--- a/pkg/config/control_plane.go
+++ b/pkg/config/control_plane.go
@@ -211,6 +211,8 @@ type DataStoreMongoDBConfig struct {
 	// The url of MongoDB. All of credentials can be specified via this field.
 	URL string `json:"url"`
 	// The name of the database.
+	// Also set Database as 'AuthSource' (default as 'admin' or '$external') when UsernameFle || PasswordFile specify
+	// Ref: https://github.com/mongodb/mongo-go-driver/blob/9e2aca8afd8821e6b068cc2f25192bc640d90a0d/mongo/client.go#L390
 	Database string `json:"database"`
 	// The path to the username file.
 	// For those who don't want to include the username in the URL.

--- a/pkg/datastore/mongodb/mongodb.go
+++ b/pkg/datastore/mongodb/mongodb.go
@@ -32,7 +32,7 @@ import (
 const (
 	// Scram type ref https://github.com/mongodb/mongo-go-driver/blob/9e2aca8afd8821e6b068cc2f25192bc640d90a0d/mongo/client_examples_test.go#L119
 	// Default
-	Scram string = "SCRAM"
+	scram string = "SCRAM"
 )
 
 type MongoDB struct {
@@ -80,7 +80,7 @@ func WithAuthenticationFile(usernameFile, passwordFile string) Option {
 	return func(m *MongoDB) {
 		m.usernameFile = usernameFile
 		m.passwordFile = passwordFile
-		m.authMechanism = Scram
+		m.authMechanism = scram
 	}
 }
 
@@ -255,7 +255,7 @@ func makePrimaryKeyFilter(id string) bson.D {
 
 func (m *MongoDB) determineCredential() (*options.Credential, error) {
 	switch m.authMechanism {
-	case Scram:
+	case scram:
 		username, err := ioutil.ReadFile(m.usernameFile)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read username file: %w", err)


### PR DESCRIPTION
**What this PR does / why we need it**:
- Allow input username and password mongodb via file
- Currently support SCRAM for default authMechanism

**Which issue(s) this PR fixes**:

Fixes #683

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Yes, user can input username or password via file from control-plane configs
```
