### PR TITLE
Unify the SSO config for both GitHub and GitHub Enterprise

### DIFF
--- a/docs/content/en/docs/operator-manual/control-plane/configuration-reference.md
+++ b/docs/content/en/docs/operator-manual/control-plane/configuration-reference.md
@@ -122,7 +122,7 @@ Must be one of the following objects:
 | Field | Type | Description | Required |
 |-|-|-|-|
 | name | string | The unique name of the configuration. | Yes |
-| provider | string | The SSO service provider. Can be one of the following values<br>`GITHUB`, `GITHUB_ENTERPRISE`, `GOOGLE`... | Yes |
+| provider | string | The SSO service provider. Can be one of the following values<br>`GITHUB`, `GOOGLE`... | Yes |
 | github | [SSOConfigGitHub](/docs/operator-manual/control-plane/configuration-reference/#ssoconfiggithub) | GitHub sso configuration. | No |
 | google | [SSOConfigGoogle](/docs/operator-manual/control-plane/configuration-reference/#ssoconfiggoogle) | Google sso configuration. | No |
 
@@ -133,7 +133,8 @@ Must be one of the following objects:
 | clientId | string | The client id string of GitHub oauth app. | Yes |
 | clientSecret | string | The client secret string of GitHub oauth app. | Yes |
 | baseUrl | string | The address of GitHub service. Required if enterprise. | No |
-| uploadUrl | string | The upload url of GitHub service. Required if enterprise. | No |
+| uploadUrl | string | The upload url of GitHub service. | No |
+| proxyUrl | string | The address of the proxy used while communicating with the GitHub service. | No |
 
 ## SSOConfigGoogle
 

--- a/pkg/app/api/authhandler/callback.go
+++ b/pkg/app/api/authhandler/callback.go
@@ -133,21 +133,11 @@ func checkState(r *http.Request, key string) error {
 
 func getUser(ctx context.Context, sso *model.ProjectSSOConfig, rbac *model.ProjectRBACConfig, projectID, code string) (*model.User, error) {
 	switch sso.Provider {
-	case model.ProjectSSOConfig_GITHUB:
+	case model.ProjectSSOConfig_GITHUB, model.ProjectSSOConfig_GITHUB_ENTERPRISE:
 		if sso.Github == nil {
 			return nil, fmt.Errorf("missing GitHub oauth in the SSO configuration")
 		}
-		cli, err := github.NewOAuthClient(ctx, sso.Github, rbac, projectID, code, false)
-		if err != nil {
-			return nil, err
-		}
-		return cli.GetUser(ctx)
-
-	case model.ProjectSSOConfig_GITHUB_ENTERPRISE:
-		if sso.Github == nil {
-			return nil, fmt.Errorf("missing GitHub oauth in the SSO configuration")
-		}
-		cli, err := github.NewOAuthClient(ctx, sso.Github, rbac, projectID, code, true)
+		cli, err := github.NewOAuthClient(ctx, sso.Github, rbac, projectID, code)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/model/project.go
+++ b/pkg/model/project.go
@@ -148,17 +148,11 @@ func (p *ProjectSSOConfig) Decrypt(decrypter decrypter) error {
 // GenerateAuthCodeURL generates an auth URL for the specified configuration.
 func (p *ProjectSSOConfig) GenerateAuthCodeURL(project, callbackURL, state string) (string, error) {
 	switch p.Provider {
-	case ProjectSSOConfig_GITHUB:
+	case ProjectSSOConfig_GITHUB, ProjectSSOConfig_GITHUB_ENTERPRISE:
 		if p.Github == nil {
 			return "", fmt.Errorf("missing GitHub oauth in the SSO configuration")
 		}
-		return p.Github.GenerateAuthCodeURL(project, callbackURL, state, false)
-
-	case ProjectSSOConfig_GITHUB_ENTERPRISE:
-		if p.Github == nil {
-			return "", fmt.Errorf("missing GitHub oauth in the SSO configuration")
-		}
-		return p.Github.GenerateAuthCodeURL(project, callbackURL, state, true)
+		return p.Github.GenerateAuthCodeURL(project, callbackURL, state)
 
 	default:
 		return "", fmt.Errorf("not implemented")
@@ -227,12 +221,12 @@ func (p *ProjectSSOConfig_GitHub) Decrypt(decrypter decrypter) error {
 }
 
 // GenerateAuthCodeURL generates an auth URL for the specified configuration.
-func (p *ProjectSSOConfig_GitHub) GenerateAuthCodeURL(project, callbackURL, state string, enterprise bool) (string, error) {
+func (p *ProjectSSOConfig_GitHub) GenerateAuthCodeURL(project, callbackURL, state string) (string, error) {
 	cfg := oauth2.Config{
 		ClientID: p.ClientId,
 		Endpoint: github.Endpoint,
 	}
-	if enterprise {
+	if p.BaseUrl != "" {
 		u, err := url.Parse(p.BaseUrl)
 		if err != nil {
 			return "", err

--- a/pkg/model/project.proto
+++ b/pkg/model/project.proto
@@ -59,24 +59,33 @@ message ProjectStaticUser {
 message ProjectSSOConfig {
     enum Provider {
         GITHUB = 0;
-        GITHUB_ENTERPRISE = 1;
+        // This was deprecated.
+        // For GitHub Enterprise, use GITHUB provider and specify the baseUrl in the config.
+        GITHUB_ENTERPRISE = 1 [deprecated = true];
         GOOGLE = 2;
     }
-    Provider provider = 1 [(validate.rules).enum.defined_only = true];
 
     message GitHub {
+        // The client id string of GitHub oauth app.
         string client_id = 1 [(validate.rules).string.min_len = 1];
+        // The client secret string of GitHub oauth app.
         string client_secret = 2 [(validate.rules).string.min_len = 1];
+        // The address of GitHub service. Required if enterprise.
         string base_url = 3;
+        // The upload url of GitHub service.
         string upload_url = 4;
+        // The address of the proxy used while communicating with the GitHub service.
         string proxy_url = 5;
     }
 
     message Google {
+        // The client id string of Google oauth app.
         string client_id = 1 [(validate.rules).string.min_len = 1];
+        // The client secret string of Google oauth app.
         string client_secret = 2 [(validate.rules).string.min_len = 1];
     }
 
+    Provider provider = 1 [(validate.rules).enum.defined_only = true];
     GitHub github = 10;
     Google google = 11;
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Unify the SSO config for both GitHub and GitHub Enterprise. GITHUB_ENTERPRISE provider name was deprecated.
```
