### PR TITLE
Use nodejs scripts instead of sed to modify some imports

### DIFF
--- a/pkg/app/web/BUILD.bazel
+++ b/pkg/app/web/BUILD.bazel
@@ -21,9 +21,7 @@ nodejs_binary(
 
 genrule(
     name = "build_api",
-    srcs = [
-        ":api_proto",
-    ],
+    srcs = [":api_proto"],
     outs = ["api_client"],
     cmd = "$(locations strip_imports) $(OUTS) $(SRCS)",
     output_to_bindir = True,
@@ -32,9 +30,7 @@ genrule(
 
 genrule(
     name = "build_model",
-    srcs = [
-        ":model_proto_ts",
-    ],
+    srcs = [":model_proto_ts"],
     outs = ["model"],
     cmd = "$(locations strip_imports) $(OUTS) $(SRCS)",
     output_to_bindir = True,

--- a/pkg/app/web/BUILD.bazel
+++ b/pkg/app/web/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@npm//webpack-cli:index.bzl", webpack = "webpack_cli")
 load("@npm//typescript:index.bzl", "tsc")
 load("@npm_bazel_labs//:index.bzl", "ts_proto_library")
+load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_binary")
 load(":jest.bzl", "jest_test")
 
 ts_proto_library(
@@ -13,42 +14,31 @@ ts_proto_library(
     proto = "//pkg/model:model_proto",
 )
 
+nodejs_binary(
+    name = "strip_imports",
+    entry_point = ":strip-imports.js",
+)
+
 genrule(
     name = "build_api",
-    srcs = [":api_proto"],
+    srcs = [
+        ":api_proto",
+    ],
     outs = ["api_client"],
-    cmd = """
-    mkdir $(OUTS)
-    for f in $(SRCS)
-    do
-        sed -ie "s|.*validate_pb.*||g" $$f
-        sed -ie "s|'.*pkg|'pipe/pkg|g" $$f
-        sed -ie "s|.*github_com_gogo_protobuf_gogoproto_gogo_pb.*||g" $$f
-        sed -ie "s|pipe/pkg/model|pipe/pkg/app/web/model|g" $$f
-        cp $$f $(OUTS)/
-    done
-    """,
-    output_to_bindir = 1,
-    visibility = ["//visibility:public"],
+    cmd = "$(locations strip_imports) $(OUTS) $(SRCS)",
+    output_to_bindir = True,
+    tools = [":strip_imports"],
 )
 
 genrule(
     name = "build_model",
-    srcs = [":model_proto_ts"],
+    srcs = [
+        ":model_proto_ts",
+    ],
     outs = ["model"],
-    cmd = """
-    mkdir $(OUTS)
-    for f in $(SRCS)
-    do
-        sed -ie "s|.*validate_pb.*||g" $$f
-        sed -ie "s|'.*pkg|'pipe/pkg|g" $$f
-        sed -ie "s|.*github_com_gogo_protobuf_gogoproto_gogo_pb.*||g" $$f
-        sed -ie "s|pipe/pkg/model|pipe/pkg/app/web/model|g" $$f
-        cp $$f $(OUTS)/
-    done
-    """,
-    output_to_bindir = 1,
-    visibility = ["//visibility:public"],
+    cmd = "$(locations strip_imports) $(OUTS) $(SRCS)",
+    output_to_bindir = True,
+    tools = [":strip_imports"],
 )
 
 tsc(

--- a/pkg/app/web/strip-imports.js
+++ b/pkg/app/web/strip-imports.js
@@ -1,0 +1,18 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+const fs = require("fs");
+const path = require("path");
+const OUTPUT_DIR = process.argv[2];
+const files = process.argv.slice(3);
+
+fs.mkdirSync(OUTPUT_DIR);
+files.forEach((file) => {
+  const basename = path.basename(file);
+  const f = fs.readFileSync(file, {
+    encoding: "utf-8",
+  });
+
+  fs.writeFileSync(
+    `${OUTPUT_DIR}/${basename}`,
+    f.replace(/.*validate_pb.*/g, "").replace(/'.*pkg/g, "'pipe/pkg/app/web")
+  );
+});

--- a/pkg/app/web/strip-imports.js
+++ b/pkg/app/web/strip-imports.js
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
 const fs = require("fs");
 const path = require("path");
 const OUTPUT_DIR = process.argv[2];


### PR DESCRIPTION
**What this PR does / why we need it**:

Use JS to strip unnecessary imports from generated files(`:api_client`, `:models`).
I think it's better than using `sed` because `nodejs_binary` is added as Bazel dependency(`sed` is not).

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
