### PR TITLE
Update eslintrc

### DIFF
--- a/pkg/app/web/.eslintrc.js
+++ b/pkg/app/web/.eslintrc.js
@@ -26,4 +26,12 @@ module.exports = {
       version: "detect",
     },
   },
+  overrides: [
+    {
+      files: ["*.js"],
+      rules: {
+        "@typescript-eslint/no-var-requires": "off",
+      },
+    },
+  ],
 };


### PR DESCRIPTION
**What this PR does / why we need it**:

* exclude js files from `@typescript-eslint/no-var-requires`

Ref: https://github.com/pipe-cd/pipe/pull/1181#discussion_r534046805

**Which issue(s) this PR fixes**:



**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
