### PR TITLE
Add API key management page

### DIFF
--- a/pkg/app/web/src/components/generate-api-key-dialog.stories.tsx
+++ b/pkg/app/web/src/components/generate-api-key-dialog.stories.tsx
@@ -1,0 +1,16 @@
+import { action } from "@storybook/addon-actions";
+import React from "react";
+import { GenerateAPIKeyDialog } from "./generate-api-key-dialog";
+
+export default {
+  title: "GenerateAPIKeyDialog",
+  component: GenerateAPIKeyDialog,
+};
+
+export const overview: React.FC = () => (
+  <GenerateAPIKeyDialog
+    open
+    onClose={action("onClose")}
+    onSubmit={action("onSubmit")}
+  />
+);

--- a/pkg/app/web/src/components/generate-api-key-dialog.tsx
+++ b/pkg/app/web/src/components/generate-api-key-dialog.tsx
@@ -1,0 +1,101 @@
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  TextField,
+} from "@material-ui/core";
+import { useFormik } from "formik";
+import React, { FC } from "react";
+import * as Yup from "yup";
+import { API_KEY_ROLE_TEXT } from "../constants/api-key-role-text";
+import { APIKeyModel } from "../modules/api-keys";
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  onSubmit: (values: { name: string; role: APIKeyModel.Role }) => void;
+}
+
+const validationSchema = Yup.object({
+  name: Yup.string().min(1).required(),
+  role: Yup.number().required(),
+});
+
+export const GenerateAPIKeyDialog: FC<Props> = ({
+  onClose,
+  onSubmit,
+  open,
+}) => {
+  const formik = useFormik({
+    initialValues: {
+      name: "",
+      role: APIKeyModel.Role.READ_ONLY,
+    },
+    validationSchema,
+    validateOnMount: true,
+    onSubmit: (values, actions) => {
+      onSubmit({
+        name: values.name,
+        role: values.role,
+      });
+      actions.resetForm();
+    },
+    onReset: () => {
+      onClose();
+    },
+  });
+
+  return (
+    <Dialog open={open} onClose={onClose}>
+      <form onSubmit={formik.handleSubmit} onReset={formik.handleReset}>
+        <DialogTitle>Generate API Key</DialogTitle>
+        <DialogContent>
+          <TextField
+            id="name"
+            name="name"
+            label="Name"
+            variant="outlined"
+            margin="dense"
+            autoFocus
+            value={formik.values.name}
+            onChange={formik.handleChange}
+            required
+            fullWidth
+          />
+          <FormControl variant="outlined" margin="dense">
+            <InputLabel id="role">Role</InputLabel>
+            <Select
+              id="role"
+              name="role"
+              value={formik.values.role}
+              label="Role"
+              onChange={formik.handleChange}
+            >
+              <MenuItem value={APIKeyModel.Role.READ_ONLY}>
+                {API_KEY_ROLE_TEXT[APIKeyModel.Role.READ_ONLY]}
+              </MenuItem>
+              <MenuItem value={APIKeyModel.Role.READ_WRITE}>
+                {API_KEY_ROLE_TEXT[APIKeyModel.Role.READ_WRITE]}
+              </MenuItem>
+            </Select>
+          </FormControl>
+        </DialogContent>
+        <DialogActions>
+          <Button type="reset">Close</Button>
+          <Button
+            type="submit"
+            color="primary"
+            disabled={formik.isValid === false || formik.dirty === false}
+          >
+            Generate
+          </Button>
+        </DialogActions>
+      </form>
+    </Dialog>
+  );
+};

--- a/pkg/app/web/src/components/generated-api-key-dialog.stories.tsx
+++ b/pkg/app/web/src/components/generated-api-key-dialog.stories.tsx
@@ -1,0 +1,18 @@
+import { action } from "@storybook/addon-actions";
+import React from "react";
+import { createDecoratorRedux } from "../../.storybook/redux-decorator";
+import { GeneratedApiKeyDialog } from "./generated-api-key-dialog";
+
+export default {
+  title: "GeneratedApiKeyDialog",
+  component: GeneratedApiKeyDialog,
+  decorators: [createDecoratorRedux({})],
+};
+
+export const overview: React.FC = () => (
+  <GeneratedApiKeyDialog
+    open
+    generatedKey="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx.bspmf2xvt74area19iaxl0yh33jzwelq493vzil0orgzylrdb1"
+    onClose={action("onClose")}
+  />
+);

--- a/pkg/app/web/src/components/generated-api-key-dialog.tsx
+++ b/pkg/app/web/src/components/generated-api-key-dialog.tsx
@@ -1,0 +1,70 @@
+import React, { FC, useRef } from "react";
+import {
+  makeStyles,
+  Dialog,
+  DialogActions,
+  DialogTitle,
+  DialogContent,
+  Typography,
+  IconButton,
+  Button,
+} from "@material-ui/core";
+import CopyIcon from "@material-ui/icons/FileCopyOutlined";
+import copy from "copy-to-clipboard";
+import { addToast } from "../modules/toasts";
+import { useDispatch } from "react-redux";
+
+const useStyles = makeStyles(() => ({
+  key: {
+    wordBreak: "break-all",
+  },
+}));
+
+interface Props {
+  open: boolean;
+  generatedKey: string | null;
+  onClose: () => void;
+}
+
+const DIALOG_TITLE = "Generated API Key";
+const VALUE_CAPTION = "API Key";
+
+export const GeneratedApiKeyDialog: FC<Props> = ({
+  open,
+  onClose,
+  generatedKey,
+}) => {
+  const classes = useStyles();
+  const dispatch = useDispatch();
+  const keyRef = useRef<HTMLDivElement>(null);
+
+  const handleOnClickCopy = (): void => {
+    if (generatedKey) {
+      copy(generatedKey);
+      dispatch(addToast({ message: "API Key copied to clipboard" }));
+    }
+  };
+
+  return (
+    <Dialog open={open}>
+      <DialogTitle>{DIALOG_TITLE}</DialogTitle>
+      <DialogContent>
+        <Typography variant="caption">{VALUE_CAPTION}</Typography>
+        <Typography variant="body2" className={classes.key} ref={keyRef}>
+          {generatedKey}
+          <IconButton
+            size="small"
+            style={{ marginLeft: 8 }}
+            aria-label="Copy API Key"
+            onClick={handleOnClickCopy}
+          >
+            <CopyIcon style={{ fontSize: 20 }} />
+          </IconButton>
+        </Typography>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Close</Button>
+      </DialogActions>
+    </Dialog>
+  );
+};

--- a/pkg/app/web/src/constants/api-key-role-text.ts
+++ b/pkg/app/web/src/constants/api-key-role-text.ts
@@ -1,0 +1,6 @@
+import { APIKeyModel } from "../modules/api-keys";
+
+export const API_KEY_ROLE_TEXT: Record<APIKeyModel.Role, string> = {
+  [APIKeyModel.Role.READ_ONLY]: "Read Only",
+  [APIKeyModel.Role.READ_WRITE]: "Read/Write",
+};

--- a/pkg/app/web/src/constants/path.ts
+++ b/pkg/app/web/src/constants/path.ts
@@ -7,6 +7,7 @@ export const PAGE_PATH_SETTINGS = "/settings";
 export const PAGE_PATH_SETTINGS_PIPED = "/settings/piped";
 export const PAGE_PATH_SETTINGS_ENV = "/settings/environment";
 export const PAGE_PATH_SETTINGS_PROJECT = "/settings/project";
+export const PAGE_PATH_SETTINGS_API_KEY = "/settings/api-key";
 
 export const STATIC_LOGIN_ENDPOINT = "/auth/login/static";
 export const LOGIN_ENDPOINT = "/auth/login";

--- a/pkg/app/web/src/modules/api-keys.test.ts
+++ b/pkg/app/web/src/modules/api-keys.test.ts
@@ -5,6 +5,7 @@ import {
   disableAPIKey,
   generateAPIKey,
   fetchAPIKeys,
+  clearGeneratedKey,
 } from "./api-keys";
 
 const baseState = {
@@ -22,6 +23,21 @@ describe("apiKeysSlice reducer", () => {
       apiKeysSlice.reducer(undefined, {
         type: "TEST_ACTION",
       })
+    ).toEqual(baseState);
+  });
+
+  it("should handle clearGeneratedKey", () => {
+    expect(
+      apiKeysSlice.reducer(
+        {
+          ...baseState,
+          generatedKey:
+            "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx.bspmf2xvt74area19iaxl0yh33jzwelq493vzil0orgzylrdb1",
+        },
+        {
+          type: clearGeneratedKey.type,
+        }
+      )
     ).toEqual(baseState);
   });
 

--- a/pkg/app/web/src/modules/api-keys.ts
+++ b/pkg/app/web/src/modules/api-keys.ts
@@ -53,7 +53,11 @@ export const disableAPIKey = createAsyncThunk<void, { id: string }>(
 export const apiKeysSlice = createSlice({
   name: "apiKeys",
   initialState,
-  reducers: {},
+  reducers: {
+    clearGeneratedKey(state) {
+      state.generatedKey = null;
+    },
+  },
   extraReducers: (builder) => {
     builder
       // generateAPIKey
@@ -95,5 +99,7 @@ export const apiKeysSlice = createSlice({
       });
   },
 });
+
+export const { clearGeneratedKey } = apiKeysSlice.actions;
 
 export { APIKey as APIKeyModel } from "pipe/pkg/app/web/model/apikey_pb";

--- a/pkg/app/web/src/modules/index.ts
+++ b/pkg/app/web/src/modules/index.ts
@@ -16,6 +16,7 @@ import { loginSlice } from "./login";
 import { projectSlice } from "./project";
 import { deploymentConfigsSlice } from "./deployment-configs";
 import { sealedSecretSlice } from "./sealed-secret";
+import { apiKeysSlice } from "./api-keys";
 
 export const reducers = combineReducers({
   deployments: deploymentsSlice.reducer,
@@ -34,6 +35,7 @@ export const reducers = combineReducers({
   project: projectSlice.reducer,
   deploymentConfigs: deploymentConfigsSlice.reducer,
   sealedSecret: sealedSecretSlice.reducer,
+  apiKeys: apiKeysSlice.reducer,
 });
 
 export type AppState = ReturnType<typeof reducers>;

--- a/pkg/app/web/src/pages/settings/api-key.tsx
+++ b/pkg/app/web/src/pages/settings/api-key.tsx
@@ -65,7 +65,7 @@ export const APIKeyPage: FC = memo(function APIKeyPage() {
       <Divider />
 
       <TableContainer component={Paper}>
-        <Table>
+        <Table size="small">
           <TableHead>
             <TableRow>
               <TableCell colSpan={2}>Name</TableCell>

--- a/pkg/app/web/src/pages/settings/api-key.tsx
+++ b/pkg/app/web/src/pages/settings/api-key.tsx
@@ -1,0 +1,128 @@
+import {
+  Button,
+  Divider,
+  IconButton,
+  Menu,
+  MenuItem,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Toolbar,
+  Typography,
+} from "@material-ui/core";
+import { Add as AddIcon, MoreVert as MenuIcon } from "@material-ui/icons";
+import React, { FC, memo, useCallback, useEffect, useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { GenerateAPIKeyDialog } from "../../components/generate-api-key-dialog";
+import { GeneratedApiKeyDialog } from "../../components/generated-api-key-dialog";
+import { API_KEY_ROLE_TEXT } from "../../constants/api-key-role-text";
+import { AppState } from "../../modules";
+import {
+  APIKey,
+  APIKeyModel,
+  generateAPIKey,
+  fetchAPIKeys,
+  clearGeneratedKey,
+} from "../../modules/api-keys";
+
+export const APIKeyPage: FC = memo(function APIKeyPage() {
+  const dispatch = useDispatch();
+  const keys = useSelector<AppState, APIKey[]>((state) => state.apiKeys.items);
+  const generatedKey = useSelector<AppState, string | null>(
+    (state) => state.apiKeys.generatedKey
+  );
+  const [isOpenAddForm, setIsOpenAddForm] = useState(false);
+  const [anchorEl, setAnchorEl] = React.useState<HTMLButtonElement | null>(
+    null
+  );
+
+  useEffect(() => {
+    dispatch(fetchAPIKeys({ enabled: true }));
+  }, [dispatch]);
+
+  const handleSubmit = useCallback(
+    (values: { name: string; role: APIKeyModel.Role }) => {
+      dispatch(generateAPIKey(values));
+    },
+    [dispatch]
+  );
+
+  return (
+    <>
+      <Toolbar variant="dense">
+        <Button
+          color="primary"
+          startIcon={<AddIcon />}
+          onClick={() => setIsOpenAddForm(true)}
+        >
+          ADD
+        </Button>
+      </Toolbar>
+      <Divider />
+
+      <TableContainer component={Paper}>
+        <Table>
+          <TableHead>
+            <TableRow>
+              <TableCell colSpan={2}>Name</TableCell>
+              <TableCell>Role</TableCell>
+              <TableCell align="right" />
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {keys.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={2}>
+                  <Typography>No API Keys</Typography>
+                </TableCell>
+              </TableRow>
+            ) : (
+              keys.map((key) => (
+                <TableRow key={key.id}>
+                  <TableCell colSpan={2}>{key.name}</TableCell>
+                  <TableCell>{API_KEY_ROLE_TEXT[key.role]}</TableCell>
+                  <TableCell align="right">
+                    <IconButton
+                      onClick={(e) => {
+                        setAnchorEl(e.currentTarget);
+                      }}
+                    >
+                      <MenuIcon />
+                    </IconButton>
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </TableContainer>
+
+      <Menu
+        id="api-key-menu"
+        open={Boolean(anchorEl)}
+        anchorEl={anchorEl}
+        onClose={() => setAnchorEl(null)}
+      >
+        <MenuItem>Disable API Key</MenuItem>
+      </Menu>
+
+      <GenerateAPIKeyDialog
+        open={isOpenAddForm}
+        onClose={() => setIsOpenAddForm(false)}
+        onSubmit={handleSubmit}
+      />
+
+      <GeneratedApiKeyDialog
+        open={Boolean(generatedKey)}
+        generatedKey={generatedKey}
+        onClose={() => {
+          dispatch(clearGeneratedKey());
+        }}
+      />
+    </>
+  );
+});

--- a/pkg/app/web/src/pages/settings/index.tsx
+++ b/pkg/app/web/src/pages/settings/index.tsx
@@ -13,10 +13,12 @@ import {
   PAGE_PATH_SETTINGS_PIPED,
   PAGE_PATH_SETTINGS_ENV,
   PAGE_PATH_SETTINGS_PROJECT,
+  PAGE_PATH_SETTINGS_API_KEY,
 } from "../../constants/path";
 import { SettingsPipedPage } from "./piped";
 import { SettingsEnvironmentPage } from "./environment";
 import { SettingsProjectPage } from "./project";
+import { APIKeyPage } from "./api-key";
 
 const drawerWidth = 240;
 
@@ -50,6 +52,7 @@ const MENU_ITEMS = [
   ["Piped", PAGE_PATH_SETTINGS_PIPED],
   ["Environment", PAGE_PATH_SETTINGS_ENV],
   ["Project", PAGE_PATH_SETTINGS_PROJECT],
+  ["API Key", PAGE_PATH_SETTINGS_API_KEY],
 ];
 
 export const SettingsIndexPage: FC = memo(function SettingsIndexPage() {
@@ -99,6 +102,11 @@ export const SettingsIndexPage: FC = memo(function SettingsIndexPage() {
             exact
             path={PAGE_PATH_SETTINGS_PROJECT}
             component={SettingsProjectPage}
+          />
+          <Route
+            exact
+            path={PAGE_PATH_SETTINGS_API_KEY}
+            component={APIKeyPage}
           />
         </Switch>
       </main>


### PR DESCRIPTION
**What this PR does / why we need it**:

* Implement some features(generate a key, list keys)
  * Disabling key is not implemented yet(I will create a PR to implement this after merged)

Ref: https://github.com/pipe-cd/pipe/issues/1146

<details>
<summary>screenshots</summary>

![image](https://user-images.githubusercontent.com/6136383/100970850-1d128500-3579-11eb-89ee-33b84585a37b.png)


![image](https://user-images.githubusercontent.com/6136383/100969712-e0de2500-3576-11eb-96eb-e06777c2d6e8.png)

![image](https://user-images.githubusercontent.com/6136383/100969719-e63b6f80-3576-11eb-94c5-7cf4e03c0101.png)

</details>

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Add API Key management page for generating/displaying API keys to use for external services
```
