### PR TITLE
[RFC] Update bazel template

### DIFF
--- a/BUILD.bazel.tpl
+++ b/BUILD.bazel.tpl
@@ -35,7 +35,7 @@ buildifier(
 
 genrule(
     name = "copy_piped",
-    srcs = ["//cmd/piped:piped"],
+    srcs = ["//cmd/piped"],
     outs = ["piped"],
     cmd = "cp $< $@",
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, run `make expose-generated-go` makes change on `BUILD.bazel file as bellow 
```diff
-    srcs = ["//cmd/piped"],
+    srcs = ["//cmd/piped:piped"],
```
If I guess correctly, we did not want that change, please correct me if I'm wrong 🙏 

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
