### PR TITLE
Rename `range_to` to `data_point_count`

### DIFF
--- a/pkg/app/api/service/webservice/service.proto
+++ b/pkg/app/api/service/webservice/service.proto
@@ -410,7 +410,7 @@ message GetInsightDataRequest {
     pipe.model.InsightMetricsKind metrics_kind = 1 [(validate.rules).enum.defined_only = true];
     pipe.model.InsightStep step = 2 [(validate.rules).enum.defined_only = true];
     int64 range_from = 3 [(validate.rules).int64.gt = 0];
-    int64 range_to = 4 [(validate.rules).int64.gt = 0];
+    int64 data_point_count = 4 [(validate.rules).int64.gt = 0];
     string application_id = 5;
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

rename `range_to` to `data_point_count`to simplify handling time on the server side.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
