### PR TITLE
Update site chart template

### DIFF
--- a/manifests/site/templates/service.yaml
+++ b/manifests/site/templates/service.yaml
@@ -4,8 +4,8 @@ metadata:
   name: {{ include "site.fullname" . }}
   labels:
     {{- include "site.labels" . | nindent 4 }}
-  annotations:
   {{- if .Values.backendConfig.enabled }}
+  annotations:
     beta.cloud.google.com/backend-config: '{"ports": {"http": "{{ include "site.fullname" . }}" }}'
   {{- end }}
 spec:


### PR DESCRIPTION
**What this PR does / why we need it**:

The current template lead to `annotations: <invalid Value>` config in case `.Values.backendConfig.enabled` value not set.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
