### PR TITLE
Add test module target on Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,10 @@ test:
 test-debug:
 	bazelisk ${BAZEL_FLAGS} test ${BAZEL_COMMAND_FLAGS} --test_output=all -- //pkg/...
 
+.PHONY: test-mod
+test-mod:
+	bazelisk ${BAZEL_FLAGS} test ${BAZEL_COMMAND_FLAGS} -- //${DIR}/...
+
 .PHONY: test-integration
 test-integration:
 	bazelisk ${BAZEL_FLAGS} test ${BAZEL_COMMAND_FLAGS} --action_env=CLOUDSDK_PYTHON=${CLOUDSDK_PYTHON} -- //test/integration/...


### PR DESCRIPTION
**What this PR does / why we need it**:

Add `test-mod` target on Makefile in case run test for specific modules/dirs.
Test with `DIR=pkg/app/api make test-mod` command.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
