### PR TITLE
Avoid rerun bazel on switch terminal

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,8 +1,8 @@
 common --color=yes
 
 # Show us more details
-build --show_timestamps --verbose_failures
-test --test_output=errors --test_verbose_timeout_warnings
+build --show_timestamps --verbose_failures --incompatible_strict_action_env
+test --test_output=errors --test_verbose_timeout_warnings --incompatible_strict_action_env
 
 # Enable stamping workspace variables to binary.
 build:stamping --stamp --workspace_status_command hack/print-workspace-status.sh

--- a/Makefile
+++ b/Makefile
@@ -31,10 +31,6 @@ test:
 test-debug:
 	bazelisk ${BAZEL_FLAGS} test ${BAZEL_COMMAND_FLAGS} --test_output=all -- //pkg/...
 
-.PHONY: test-mod
-test-mod:
-	bazelisk ${BAZEL_FLAGS} test ${BAZEL_COMMAND_FLAGS} -- //${DIR}/...
-
 .PHONY: test-integration
 test-integration:
 	bazelisk ${BAZEL_FLAGS} test ${BAZEL_COMMAND_FLAGS} --action_env=CLOUDSDK_PYTHON=${CLOUDSDK_PYTHON} -- //test/integration/...


### PR DESCRIPTION
**What this PR does / why we need it**:

Switching between terminals ( `$PATH` change ) causes unnecessary rerun/rebuild. This PR fixes that issue by adding `--incompatible_strict_action_env` flag. 
ref: https://github.com/bazelbuild/intellij/issues/789

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
