### PR TITLE
Automatically recreate piped pods when executing helm upgrade

### DIFF
--- a/manifests/piped/templates/deployment.yaml
+++ b/manifests/piped/templates/deployment.yaml
@@ -17,6 +17,7 @@ spec:
         {{- include "piped.selectorLabels" . | nindent 8 }}
       annotations:
         sidecar.istio.io/inject: "false"
+        rollme: {{ randAlphaNum 5 | quote }}
     spec:
       serviceAccountName: {{ include "piped.fullname" . }}
       containers:


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR does:

- Add ability to automatically recreate piped pods when executing `helm upgrade` to update a piped configuration.

**Which issue(s) this PR fixes**:

Fixes #1216 

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
