### PR TITLE
Fix document in control-plane/architecture-overview: "api" > "server"

### DIFF
--- a/docs/content/en/docs/operator-manual/control-plane/architecture-overview.md
+++ b/docs/content/en/docs/operator-manual/control-plane/architecture-overview.md
@@ -21,7 +21,7 @@ This service can be easily scaled by updating the pod number.
 
 ##### Cache
 
-`cache` is a single pod service for caching internal data used by `api` service. Currently, this `cache` service is using the `redis` docker image.
+`cache` is a single pod service for caching internal data used by `server` service. Currently, this `cache` service is using the `redis` docker image.
 You can configure the control plane to use a fully-managed redis cache service instead of launching a cache pod in your cluster.
 
 ##### Ops


### PR DESCRIPTION
**What this PR does / why we need it**:

fix document: 
In architecture overview of control-plane, written as `cache` used by `api`. I think `cache` use by `server` is correct after PipeCD v0.8.0.

If I am wrong, please close this PR.

**Which issue(s) this PR fixes**:

None

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
