### PR TITLE
Ensure to load image watcher config

### DIFF
--- a/pkg/app/piped/imagewatcher/watcher.go
+++ b/pkg/app/piped/imagewatcher/watcher.go
@@ -114,11 +114,16 @@ func (w *watcher) run(ctx context.Context, provider imageprovider.Provider, inte
 				updates = append(updates, u...)
 			}
 			if len(updates) == 0 {
-				w.logger.Info("no image to be updated")
+				w.logger.Info("no image to be updated",
+					zap.String("image-provider", provider.Name()),
+				)
 				continue
 			}
 			if err := update(updates); err != nil {
-				w.logger.Error("failed to update image", zap.Error(err))
+				w.logger.Error("failed to update image", zap.String("image-provider",
+					provider.Name()),
+					zap.Error(err),
+				)
 				continue
 			}
 		}
@@ -136,14 +141,13 @@ func (w *watcher) determineUpdates(ctx context.Context, repoID string, repo git.
 	}
 
 	// Load Image Watcher Config for the given repo.
-	includes := make([]string, 0)
-	excludes := make([]string, 0)
+	var includes, excludes []string
 	for _, target := range w.config.ImageWatcher.Repos {
-		if target.RepoID != repoID {
-			continue
+		if target.RepoID == repoID {
+			includes = target.Includes
+			excludes = target.Excludes
+			break
 		}
-		includes = append(includes, target.Includes...)
-		excludes = append(excludes, target.Excludes...)
 	}
 	cfg, ok, err := config.LoadImageWatcher(repo.GetPath(), includes, excludes)
 	if err != nil {

--- a/pkg/app/piped/imagewatcher/watcher.go
+++ b/pkg/app/piped/imagewatcher/watcher.go
@@ -120,8 +120,8 @@ func (w *watcher) run(ctx context.Context, provider imageprovider.Provider, inte
 				continue
 			}
 			if err := update(updates); err != nil {
-				w.logger.Error("failed to update image", zap.String("image-provider",
-					provider.Name()),
+				w.logger.Error("failed to update image",
+					zap.String("image-provider", provider.Name()),
 					zap.Error(err),
 				)
 				continue

--- a/pkg/config/BUILD.bazel
+++ b/pkg/config/BUILD.bazel
@@ -38,6 +38,7 @@ go_test(
         "deployment_kubernetes_test.go",
         "deployment_terraform_test.go",
         "deployment_test.go",
+        "image_watcher_test.go",
         "piped_test.go",
         "replicas_test.go",
         "sealed_secret_test.go",
@@ -47,6 +48,7 @@ go_test(
     deps = [
         "//pkg/model:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",
+        "@com_github_magiconair_properties//assert:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",
         "@com_github_stretchr_testify//require:go_default_library",
     ],

--- a/pkg/config/image_watcher.go
+++ b/pkg/config/image_watcher.go
@@ -39,8 +39,11 @@ type ImageWatcherTarget struct {
 func LoadImageWatcher(repoRoot string, includes, excludes []string) (*ImageWatcherSpec, bool, error) {
 	dir := filepath.Join(repoRoot, SharedConfigurationDirName)
 	files, err := ioutil.ReadDir(dir)
-	if err != nil {
+	if os.IsNotExist(err) {
 		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to read %s: %w", dir, err)
 	}
 
 	spec := &ImageWatcherSpec{

--- a/pkg/config/image_watcher_test.go
+++ b/pkg/config/image_watcher_test.go
@@ -1,0 +1,125 @@
+// Copyright 2020 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type fakeFileInfo struct {
+	name string
+}
+
+func (f *fakeFileInfo) Name() string { return f.name }
+
+// Below methods are required to meet the interface.
+func (f *fakeFileInfo) Size() int64        { return 0 }
+func (f *fakeFileInfo) Mode() os.FileMode  { return 0 }
+func (f *fakeFileInfo) ModTime() time.Time { return time.Now() }
+func (f *fakeFileInfo) IsDir() bool        { return false }
+func (f *fakeFileInfo) Sys() interface{}   { return nil }
+
+func TestFilterImageWatcherFiles(t *testing.T) {
+	testcases := []struct {
+		name     string
+		files    []os.FileInfo
+		includes []string
+		excludes []string
+		want     []os.FileInfo
+		wantErr  bool
+	}{
+		{
+			name: "both includes and excludes aren't given",
+			files: []os.FileInfo{
+				&fakeFileInfo{
+					name: "file-1",
+				},
+			},
+			want: []os.FileInfo{
+				&fakeFileInfo{
+					name: "file-1",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "both includes and excludes aren given",
+			files: []os.FileInfo{
+				&fakeFileInfo{
+					name: "file-1",
+				},
+			},
+			includes: []string{"file-1"},
+			excludes: []string{"file-1"},
+			wantErr:  true,
+		},
+		{
+			name: "includes given",
+			files: []os.FileInfo{
+				&fakeFileInfo{
+					name: "file-1",
+				},
+				&fakeFileInfo{
+					name: "file-2",
+				},
+				&fakeFileInfo{
+					name: "file-3",
+				},
+			},
+			includes: []string{"file-1", "file-3"},
+			want: []os.FileInfo{
+				&fakeFileInfo{
+					name: "file-1",
+				},
+				&fakeFileInfo{
+					name: "file-3",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "excludes given",
+			files: []os.FileInfo{
+				&fakeFileInfo{
+					name: "file-1",
+				},
+				&fakeFileInfo{
+					name: "file-2",
+				},
+				&fakeFileInfo{
+					name: "file-3",
+				},
+			},
+			excludes: []string{"file-1", "file-3"},
+			want: []os.FileInfo{
+				&fakeFileInfo{
+					name: "file-2",
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := filterImageWatcherFiles(tc.files, tc.includes, tc.excludes)
+			assert.Equal(t, tc.wantErr, err != nil)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/pkg/config/image_watcher_test.go
+++ b/pkg/config/image_watcher_test.go
@@ -59,15 +59,16 @@ func TestFilterImageWatcherFiles(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "both includes and excludes aren given",
+			name: "both includes and excludes are given",
 			files: []os.FileInfo{
 				&fakeFileInfo{
 					name: "file-1",
 				},
 			},
+			want:     []os.FileInfo{},
 			includes: []string{"file-1"},
 			excludes: []string{"file-1"},
-			wantErr:  true,
+			wantErr:  false,
 		},
 		{
 			name: "includes given",

--- a/pkg/config/piped.go
+++ b/pkg/config/piped.go
@@ -593,7 +593,8 @@ type PipedImageWatcher struct {
 	Repos []PipedImageWatcherRepoTarget `json:"repos"`
 }
 
-// Validate checks if the duplicated repository setting exists.
+// Validate checks if the duplicated repository setting exists,
+// and if both includes and excludes are given in each repo.
 func (i *PipedImageWatcher) Validate() error {
 	repos := make(map[string]struct{})
 	for _, repo := range i.Repos {

--- a/pkg/config/piped.go
+++ b/pkg/config/piped.go
@@ -593,8 +593,7 @@ type PipedImageWatcher struct {
 	Repos []PipedImageWatcherRepoTarget `json:"repos"`
 }
 
-// Validate checks if the duplicated repository setting exists,
-// and if both includes and excludes are given in each repo.
+// Validate checks if the duplicated repository setting exists.
 func (i *PipedImageWatcher) Validate() error {
 	repos := make(map[string]struct{})
 	for _, repo := range i.Repos {
@@ -602,10 +601,6 @@ func (i *PipedImageWatcher) Validate() error {
 			return fmt.Errorf("duplicated repo id (%s) found in the imageWatcher directive", repo.RepoID)
 		}
 		repos[repo.RepoID] = struct{}{}
-
-		if len(repo.Includes) != 0 && len(repo.Excludes) != 0 {
-			return fmt.Errorf("both includes and excludes are given in %s", repo.RepoID)
-		}
 	}
 	return nil
 }
@@ -615,5 +610,6 @@ type PipedImageWatcherRepoTarget struct {
 	// The paths to ImageWatcher files to be included.
 	Includes []string `json:"includes"`
 	// The paths to ImageWatcher files to be excluded.
+	// This is prioritized if both includes and this are given.
 	Excludes []string `json:"excludes"`
 }

--- a/pkg/config/piped_test.go
+++ b/pkg/config/piped_test.go
@@ -280,17 +280,6 @@ func TestPipedImageWatcherValidate(t *testing.T) {
 				},
 			}},
 		},
-		{
-			name:    "both includes and excludes are given",
-			wantErr: true,
-			imageWatcher: PipedImageWatcher{Repos: []PipedImageWatcherRepoTarget{
-				{
-					RepoID:   "foo",
-					Includes: []string{"imagewatcher-dev.yaml"},
-					Excludes: []string{"imagewatcher-prod.yaml"},
-				},
-			}},
-		},
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/config/testdata/piped/piped-config.yaml
+++ b/pkg/config/testdata/piped/piped-config.yaml
@@ -140,4 +140,5 @@ spec:
     repos:
       - repoId: foo
         includes:
-          - .pipe/imagewatcher-dev.yaml
+          - imagewatcher-dev.yaml
+          - imagewatcher-stg.yaml


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR allows piped to load image watcher files after filtering those based on includes and excludes.

**Which issue(s) this PR fixes**:

Fixes https://github.com/pipe-cd/pipe/issues/1211

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
