### PR TITLE
Remove a link to the insights page on the application header

### DIFF
--- a/pkg/app/web/src/components/header.tsx
+++ b/pkg/app/web/src/components/header.tsx
@@ -14,7 +14,6 @@ import {
 import {
   PAGE_PATH_APPLICATIONS,
   PAGE_PATH_DEPLOYMENTS,
-  PAGE_PATH_INSIGHTS,
   PAGE_PATH_SETTINGS,
   PAGE_PATH_LOGIN,
   LOGOUT_ENDPOINT,
@@ -124,15 +123,7 @@ export const Header: FC = memo(function Header() {
           >
             Deployments
           </Link>
-          <Link
-            component={RouterLink}
-            className={classes.link}
-            activeClassName={classes.activeLink}
-            color="inherit"
-            to={PAGE_PATH_INSIGHTS}
-          >
-            Insights
-          </Link>
+          {/** TODO: Restore a link to the insights in the v1 release */}
           <Link
             component={RouterLink}
             className={classes.link}


### PR DESCRIPTION
**What this PR does / why we need it**:

* Remove a link to the insights page because the insights feature is not ready
  * You can access it by opening the link directly

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Remove a link to the insights page 
```
