### PR TITLE
Change to spawn image watcher workers for each git repository

### DIFF
--- a/pkg/app/piped/imagewatcher/watcher.go
+++ b/pkg/app/piped/imagewatcher/watcher.go
@@ -36,7 +36,7 @@ import (
 
 const (
 	defaultCommitMessageFormat = "Update image %s to %s defined at %s in %s"
-	defaultPullInterval        = 5 * time.Minute
+	defaultCheckInterval        = 5 * time.Minute
 )
 
 type Watcher interface {
@@ -102,7 +102,7 @@ func (w *watcher) run(ctx context.Context, repo git.Repo, repoCfg *config.PipedR
 	defer w.wg.Done()
 
 	var (
-		pullInterval               = defaultPullInterval
+		checkInterval               = defaultCheckInterval
 		commitMsg                  string
 		includedCfgs, excludedCfgs []string
 	)
@@ -111,14 +111,14 @@ func (w *watcher) run(ctx context.Context, repo git.Repo, repoCfg *config.PipedR
 		if r.RepoID != repoCfg.RepoID {
 			continue
 		}
-		pullInterval = time.Duration(r.CheckInterval)
+		checkInterval = time.Duration(r.CheckInterval)
 		commitMsg = r.CommitMessage
 		includedCfgs = r.Includes
 		excludedCfgs = r.Excludes
 		break
 	}
 
-	ticker := time.NewTicker(pullInterval)
+	ticker := time.NewTicker(checkInterval)
 	defer ticker.Stop()
 	for {
 		select {
@@ -165,9 +165,7 @@ func (w *watcher) updateOutdatedImages(ctx context.Context, repo git.Repo, targe
 	for _, t := range targets {
 		c, err := w.checkOutdatedImage(ctx, &t, repo, commitMsg)
 		if err != nil {
-			w.logger.Error("failed to update image",
-				zap.Error(err),
-			)
+			w.logger.Error("failed to update image", zap.Error(err))
 			continue
 		}
 		if c != nil {

--- a/pkg/app/piped/imagewatcher/watcher.go
+++ b/pkg/app/piped/imagewatcher/watcher.go
@@ -36,7 +36,7 @@ import (
 
 const (
 	defaultCommitMessageFormat = "Update image %s to %s defined at %s in %s"
-	defaultCheckInterval        = 5 * time.Minute
+	defaultCheckInterval       = 5 * time.Minute
 )
 
 type Watcher interface {
@@ -102,7 +102,7 @@ func (w *watcher) run(ctx context.Context, repo git.Repo, repoCfg *config.PipedR
 	defer w.wg.Done()
 
 	var (
-		checkInterval               = defaultCheckInterval
+		checkInterval              = defaultCheckInterval
 		commitMsg                  string
 		includedCfgs, excludedCfgs []string
 	)

--- a/pkg/config/piped.go
+++ b/pkg/config/piped.go
@@ -600,8 +600,8 @@ func (p *PipedImageWatcher) Validate() error {
 		}
 		repos[p.Repos[i].RepoID] = struct{}{}
 
-		if p.Repos[i].PullInterval == 0 {
-			p.Repos[i].PullInterval = defaultImageWatcherPullInterval
+		if p.Repos[i].CheckInterval == 0 {
+			p.Repos[i].CheckInterval = defaultImageWatcherPullInterval
 		}
 	}
 	return nil
@@ -609,10 +609,9 @@ func (p *PipedImageWatcher) Validate() error {
 
 type PipedImageWatcherRepoTarget struct {
 	RepoID string `json:"repoId"`
-	// Interval to pull from git repository and pull images defined
-	// in image watcher file in the repo from image provider.
-	// Default is 5m.
-	PullInterval Duration `json:"pullInterval"`
+	// Interval to compare if the image in the git repository
+	// and one in the images provider. Default is 5m.
+	CheckInterval Duration `json:"checkInterval"`
 	// The commit message used to push after updating image.
 	// Default message is used if not given.
 	CommitMessage string `json:"commitMessage"`

--- a/pkg/config/piped.go
+++ b/pkg/config/piped.go
@@ -22,6 +22,10 @@ import (
 	"github.com/pipe-cd/pipe/pkg/model"
 )
 
+const (
+	defaultImageWatcherPullInterval = Duration(5 * time.Minute)
+)
+
 var DefaultKubernetesCloudProvider = PipedCloudProvider{
 	Name:             "kubernetes-default",
 	Type:             model.CloudProviderKubernetes,
@@ -59,7 +63,7 @@ type PipedSpec struct {
 	Notifications Notifications `json:"notifications"`
 	// How the sealed secret should be managed.
 	SealedSecretManagement *SealedSecretManagement `json:"sealedSecretManagement"`
-	// Configuration for image watcher.
+	// Optional settings for image watcher.
 	ImageWatcher PipedImageWatcher `json:"imageWatcher"`
 }
 
@@ -381,8 +385,6 @@ type AnalysisProviderStackdriverConfig struct {
 type PipedImageProvider struct {
 	Name string                  `json:"name"`
 	Type model.ImageProviderType `json:"type"`
-	// Default is 5m.
-	PullInterval Duration `json:"pullInterval"`
 
 	DockerHubConfig *ImageProviderDockerHubConfig
 	GCRConfig       *ImageProviderGCRConfig
@@ -390,9 +392,8 @@ type PipedImageProvider struct {
 }
 
 type genericPipedImageProvider struct {
-	Name         string                  `json:"name"`
-	Type         model.ImageProviderType `json:"type"`
-	PullInterval Duration                `json:"pullInterval"`
+	Name string                  `json:"name"`
+	Type model.ImageProviderType `json:"type"`
 
 	Config json.RawMessage `json:"config"`
 }
@@ -405,10 +406,6 @@ func (p *PipedImageProvider) UnmarshalJSON(data []byte) error {
 	}
 	p.Name = gp.Name
 	p.Type = gp.Type
-	p.PullInterval = gp.PullInterval
-	if p.PullInterval == 0 {
-		p.PullInterval = Duration(5 * time.Minute)
-	}
 
 	switch p.Type {
 	case model.ImageProviderTypeDockerHub:
@@ -594,19 +591,31 @@ type PipedImageWatcher struct {
 }
 
 // Validate checks if the duplicated repository setting exists.
-func (i *PipedImageWatcher) Validate() error {
-	repos := make(map[string]struct{})
-	for _, repo := range i.Repos {
-		if _, ok := repos[repo.RepoID]; ok {
-			return fmt.Errorf("duplicated repo id (%s) found in the imageWatcher directive", repo.RepoID)
+// And it populates default value if not set.
+func (p *PipedImageWatcher) Validate() error {
+	repos := make(map[string]struct{}, len(p.Repos))
+	for i := 0; i < len(p.Repos); i++ {
+		if _, ok := repos[p.Repos[i].RepoID]; ok {
+			return fmt.Errorf("duplicated repo id (%s) found in the imageWatcher directive", p.Repos[i].RepoID)
 		}
-		repos[repo.RepoID] = struct{}{}
+		repos[p.Repos[i].RepoID] = struct{}{}
+
+		if p.Repos[i].PullInterval == 0 {
+			p.Repos[i].PullInterval = defaultImageWatcherPullInterval
+		}
 	}
 	return nil
 }
 
 type PipedImageWatcherRepoTarget struct {
 	RepoID string `json:"repoId"`
+	// Interval to pull from git repository and pull images defined
+	// in image watcher file in the repo from image provider.
+	// Default is 5m.
+	PullInterval Duration `json:"pullInterval"`
+	// The commit message used to push after updating image.
+	// Default message is used if not given.
+	CommitMessage string `json:"commitMessage"`
 	// The paths to ImageWatcher files to be included.
 	Includes []string `json:"includes"`
 	// The paths to ImageWatcher files to be excluded.

--- a/pkg/config/piped.go
+++ b/pkg/config/piped.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	defaultImageWatcherPullInterval = Duration(5 * time.Minute)
+	defaultImageWatcherCheckInterval = Duration(5 * time.Minute)
 )
 
 var DefaultKubernetesCloudProvider = PipedCloudProvider{

--- a/pkg/config/piped.go
+++ b/pkg/config/piped.go
@@ -601,7 +601,7 @@ func (p *PipedImageWatcher) Validate() error {
 		repos[p.Repos[i].RepoID] = struct{}{}
 
 		if p.Repos[i].CheckInterval == 0 {
-			p.Repos[i].CheckInterval = defaultImageWatcherPullInterval
+			p.Repos[i].CheckInterval = defaultImageWatcherCheckInterval
 		}
 	}
 	return nil

--- a/pkg/config/piped_test.go
+++ b/pkg/config/piped_test.go
@@ -226,7 +226,7 @@ func TestPipedConfig(t *testing.T) {
 					Repos: []PipedImageWatcherRepoTarget{
 						{
 							RepoID:        "foo",
-							PullInterval:  Duration(10 * time.Minute),
+							CheckInterval: Duration(10 * time.Minute),
 							CommitMessage: "foo bar",
 							Includes:      []string{"imagewatcher-dev.yaml", "imagewatcher-stg.yaml"},
 						},
@@ -262,24 +262,24 @@ func TestPipedImageWatcherValidate(t *testing.T) {
 			imageWatcher: PipedImageWatcher{
 				Repos: []PipedImageWatcherRepoTarget{
 					{
-						RepoID:       "foo",
-						PullInterval: Duration(time.Minute),
+						RepoID:        "foo",
+						CheckInterval: Duration(time.Minute),
 					},
 					{
-						RepoID:       "foo",
-						PullInterval: Duration(time.Minute),
+						RepoID:        "foo",
+						CheckInterval: Duration(time.Minute),
 					},
 				},
 			},
 			wantPipedImageWatcher: PipedImageWatcher{
 				Repos: []PipedImageWatcherRepoTarget{
 					{
-						RepoID:       "foo",
-						PullInterval: Duration(time.Minute),
+						RepoID:        "foo",
+						CheckInterval: Duration(time.Minute),
 					},
 					{
-						RepoID:       "foo",
-						PullInterval: Duration(time.Minute),
+						RepoID:        "foo",
+						CheckInterval: Duration(time.Minute),
 					},
 				},
 			},
@@ -300,12 +300,12 @@ func TestPipedImageWatcherValidate(t *testing.T) {
 			wantPipedImageWatcher: PipedImageWatcher{
 				Repos: []PipedImageWatcherRepoTarget{
 					{
-						RepoID:       "foo",
-						PullInterval: Duration(5 * time.Minute),
+						RepoID:        "foo",
+						CheckInterval: Duration(5 * time.Minute),
 					},
 					{
-						RepoID:       "bar",
-						PullInterval: Duration(5 * time.Minute),
+						RepoID:        "bar",
+						CheckInterval: Duration(5 * time.Minute),
 					},
 				},
 			},

--- a/pkg/config/piped_test.go
+++ b/pkg/config/piped_test.go
@@ -150,27 +150,24 @@ func TestPipedConfig(t *testing.T) {
 				},
 				ImageProviders: []PipedImageProvider{
 					{
-						Name:         "my-dockerhub",
-						Type:         "DOCKER_HUB",
-						PullInterval: Duration(time.Minute * 5),
+						Name: "my-dockerhub",
+						Type: "DOCKER_HUB",
 						DockerHubConfig: &ImageProviderDockerHubConfig{
 							Username:     "foo",
 							PasswordFile: "/etc/piped-secret/dockerhub-pass",
 						},
 					},
 					{
-						Name:         "my-gcr",
-						Type:         "GCR",
-						PullInterval: Duration(time.Minute * 5),
+						Name: "my-gcr",
+						Type: "GCR",
 						GCRConfig: &ImageProviderGCRConfig{
 							Address:         "asia.gcr.io",
 							CredentialsFile: "/etc/piped-secret/gcr-service-account",
 						},
 					},
 					{
-						Name:         "my-ecr",
-						Type:         "ECR",
-						PullInterval: Duration(time.Minute * 5),
+						Name: "my-ecr",
+						Type: "ECR",
 						ECRConfig: &ImageProviderECRConfig{
 							Region:          "us-west-2",
 							RegistryID:      "default",
@@ -228,8 +225,10 @@ func TestPipedConfig(t *testing.T) {
 				ImageWatcher: PipedImageWatcher{
 					Repos: []PipedImageWatcherRepoTarget{
 						{
-							RepoID:   "foo",
-							Includes: []string{"imagewatcher-dev.yaml", "imagewatcher-stg.yaml"},
+							RepoID:        "foo",
+							PullInterval:  Duration(10 * time.Minute),
+							CommitMessage: "foo bar",
+							Includes:      []string{"imagewatcher-dev.yaml", "imagewatcher-stg.yaml"},
 						},
 					},
 				},
@@ -252,39 +251,71 @@ func TestPipedConfig(t *testing.T) {
 
 func TestPipedImageWatcherValidate(t *testing.T) {
 	testcases := []struct {
-		name         string
-		imageWatcher PipedImageWatcher
-		wantErr      bool
+		name                  string
+		imageWatcher          PipedImageWatcher
+		wantErr               bool
+		wantPipedImageWatcher PipedImageWatcher
 	}{
 		{
 			name:    "duplicated repo exists",
 			wantErr: true,
-			imageWatcher: PipedImageWatcher{Repos: []PipedImageWatcherRepoTarget{
-				{
-					RepoID: "foo",
+			imageWatcher: PipedImageWatcher{
+				Repos: []PipedImageWatcherRepoTarget{
+					{
+						RepoID:       "foo",
+						PullInterval: Duration(time.Minute),
+					},
+					{
+						RepoID:       "foo",
+						PullInterval: Duration(time.Minute),
+					},
 				},
-				{
-					RepoID: "foo",
+			},
+			wantPipedImageWatcher: PipedImageWatcher{
+				Repos: []PipedImageWatcherRepoTarget{
+					{
+						RepoID:       "foo",
+						PullInterval: Duration(time.Minute),
+					},
+					{
+						RepoID:       "foo",
+						PullInterval: Duration(time.Minute),
+					},
 				},
-			}},
+			},
 		},
 		{
 			name:    "repos are unique",
 			wantErr: false,
-			imageWatcher: PipedImageWatcher{Repos: []PipedImageWatcherRepoTarget{
-				{
-					RepoID: "foo",
+			imageWatcher: PipedImageWatcher{
+				Repos: []PipedImageWatcherRepoTarget{
+					{
+						RepoID: "foo",
+					},
+					{
+						RepoID: "bar",
+					},
 				},
-				{
-					RepoID: "bar",
+			},
+			wantPipedImageWatcher: PipedImageWatcher{
+				Repos: []PipedImageWatcherRepoTarget{
+					{
+						RepoID:       "foo",
+						PullInterval: Duration(5 * time.Minute),
+					},
+					{
+						RepoID:       "bar",
+						PullInterval: Duration(5 * time.Minute),
+					},
 				},
-			}},
+			},
 		},
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			err := tc.imageWatcher.Validate()
 			assert.Equal(t, tc.wantErr, err != nil)
+			assert.Equal(t, tc.wantPipedImageWatcher, tc.imageWatcher)
 		})
 	}
 }

--- a/pkg/config/testdata/piped/piped-config.yaml
+++ b/pkg/config/testdata/piped/piped-config.yaml
@@ -80,19 +80,16 @@ spec:
   imageProviders:
     - name: my-dockerhub
       type: DOCKER_HUB
-      pullInterval: 5m
       config:
         username: foo
         passwordFile: /etc/piped-secret/dockerhub-pass
     - name: my-gcr
       type: GCR
-      pullInterval: 5m
       config:
         address: asia.gcr.io
         credentialsFile: /etc/piped-secret/gcr-service-account
     - name: my-ecr
       type: ECR
-      pullInterval: 5m
       config:
         region: us-west-2
         registryId: default
@@ -139,6 +136,8 @@ spec:
   imageWatcher:
     repos:
       - repoId: foo
+        pullInterval: 10m
+        commitMessage: "foo bar"
         includes:
           - imagewatcher-dev.yaml
           - imagewatcher-stg.yaml

--- a/pkg/config/testdata/piped/piped-config.yaml
+++ b/pkg/config/testdata/piped/piped-config.yaml
@@ -136,7 +136,7 @@ spec:
   imageWatcher:
     repos:
       - repoId: foo
-        pullInterval: 10m
+        checkInterval: 10m
         commitMessage: "foo bar"
         includes:
           - imagewatcher-dev.yaml


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes the worker's unit git repository. Due to this, it changes to use another directory to touch the image.

**Which issue(s) this PR fixes**:

Fixes https://github.com/pipe-cd/pipe/issues/1261
Fixes https://github.com/pipe-cd/pipe/issues/1262
Fixes https://github.com/pipe-cd/pipe/issues/1263

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
