### PR TITLE
Fix no namespace resource found on delete resource k8s

### DIFF
--- a/pkg/app/piped/cloudprovider/kubernetes/kubernetes.go
+++ b/pkg/app/piped/cloudprovider/kubernetes/kubernetes.go
@@ -234,7 +234,7 @@ func (p *provider) ApplyManifest(ctx context.Context, manifest Manifest) error {
 		return p.initErr
 	}
 
-	return p.kubectl.Apply(ctx, p.input.Namespace, manifest)
+	return p.kubectl.Apply(ctx, p.getNamespaceForRun(manifest.Key), manifest)
 }
 
 // Delete deletes the given resource from Kubernetes cluster.
@@ -244,7 +244,16 @@ func (p *provider) Delete(ctx context.Context, k ResourceKey) (err error) {
 		return p.initErr
 	}
 
-	return p.kubectl.Delete(ctx, p.input.Namespace, k)
+	return p.kubectl.Delete(ctx, p.getNamespaceForRun(k), k)
+}
+
+// getNamespaceForRun returns namespace used on kubectl apply/delete commands
+// priority: config.KubernetesDeploymentInput > kubernetes.ResourceKey
+func (p *provider) getNamespaceForRun(k ResourceKey) string {
+	if p.input.Namespace != "" {
+		return p.input.Namespace
+	}
+	return k.Namespace
 }
 
 func (p *provider) findKubectl(ctx context.Context, version string) (*Kubectl, error) {

--- a/pkg/app/piped/cloudprovider/kubernetes/kubernetes.go
+++ b/pkg/app/piped/cloudprovider/kubernetes/kubernetes.go
@@ -234,7 +234,7 @@ func (p *provider) ApplyManifest(ctx context.Context, manifest Manifest) error {
 		return p.initErr
 	}
 
-	return p.kubectl.Apply(ctx, p.getNamespaceForRun(manifest.Key), manifest)
+	return p.kubectl.Apply(ctx, p.getNamespaceToRun(manifest.Key), manifest)
 }
 
 // Delete deletes the given resource from Kubernetes cluster.
@@ -244,12 +244,12 @@ func (p *provider) Delete(ctx context.Context, k ResourceKey) (err error) {
 		return p.initErr
 	}
 
-	return p.kubectl.Delete(ctx, p.getNamespaceForRun(k), k)
+	return p.kubectl.Delete(ctx, p.getNamespaceToRun(k), k)
 }
 
-// getNamespaceForRun returns namespace used on kubectl apply/delete commands
+// getNamespaceToRun returns namespace used on kubectl apply/delete commands
 // priority: config.KubernetesDeploymentInput > kubernetes.ResourceKey
-func (p *provider) getNamespaceForRun(k ResourceKey) string {
+func (p *provider) getNamespaceToRun(k ResourceKey) string {
 	if p.input.Namespace != "" {
 		return p.input.Namespace
 	}

--- a/pkg/app/piped/cloudprovider/kubernetes/kubernetes.go
+++ b/pkg/app/piped/cloudprovider/kubernetes/kubernetes.go
@@ -247,7 +247,7 @@ func (p *provider) Delete(ctx context.Context, k ResourceKey) (err error) {
 	return p.kubectl.Delete(ctx, p.getNamespaceToRun(k), k)
 }
 
-// getNamespaceToRun returns namespace used on kubectl apply/delete commands
+// getNamespaceToRun returns namespace used on kubectl apply/delete commands.
 // priority: config.KubernetesDeploymentInput > kubernetes.ResourceKey
 func (p *provider) getNamespaceToRun(k ResourceKey) string {
 	if p.input.Namespace != "" {


### PR DESCRIPTION
**What this PR does / why we need it**:

The `namespace` in KubernetesDeploymentInput config currently is not a required field. In case of delete resource on unset that namespace field, namespace default will be used ( as a default namespace of k8s ) leads to `not found resources to delete` bug.

**Which issue(s) this PR fixes**:

Fixes https://github.com/pipe-cd/pipe/issues/1275

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
