### PR TITLE
Add an option to do base64 encoding before encrypting the secret

### DIFF
--- a/pkg/app/api/grpcapi/web_api.go
+++ b/pkg/app/api/grpcapi/web_api.go
@@ -16,6 +16,7 @@ package grpcapi
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"time"
@@ -653,8 +654,12 @@ func (a *WebAPI) GenerateApplicationSealedSecret(ctx context.Context, req *webse
 		return nil, status.Error(codes.FailedPrecondition, "The piped does not contain the encryption configuration")
 	}
 
-	var enc encrypter
+	data := req.Data
+	if req.Base64Encoding {
+		data = base64.StdEncoding.EncodeToString([]byte(data))
+	}
 
+	var enc encrypter
 	switch model.SealedSecretManagementType(sse.Type) {
 	case model.SealedSecretManagementSealingKey:
 		if sse.PublicKey == "" {

--- a/pkg/app/api/grpcapi/web_api.go
+++ b/pkg/app/api/grpcapi/web_api.go
@@ -675,7 +675,7 @@ func (a *WebAPI) GenerateApplicationSealedSecret(ctx context.Context, req *webse
 		return nil, status.Error(codes.FailedPrecondition, "The piped does not contain a valid encryption type")
 	}
 
-	encryptedText, err := enc.Encrypt(req.Data)
+	encryptedText, err := enc.Encrypt(data)
 	if err != nil {
 		a.logger.Error("failed to encrypt the secret", zap.Error(err))
 		return nil, status.Error(codes.FailedPrecondition, "Failed to encrypt the secret")

--- a/pkg/app/api/service/webservice/service.proto
+++ b/pkg/app/api/service/webservice/service.proto
@@ -252,6 +252,8 @@ message GetApplicationResponse {
 message GenerateApplicationSealedSecretRequest {
     string piped_id = 1 [(validate.rules).string.min_len = 1];
     string data = 2 [(validate.rules).string.min_len = 1];
+    // Whether the data should be base64 encoded before encrypting or not.
+    bool base64_encoding = 3;
 }
 
 message GenerateApplicationSealedSecretResponse {

--- a/pkg/app/web/src/api/piped.ts
+++ b/pkg/app/web/src/api/piped.ts
@@ -65,12 +65,14 @@ export const recreatePipedKey = ({
 export const generateApplicationSealedSecret = ({
   pipedId,
   data,
+  base64Encoding,
 }: GenerateApplicationSealedSecretRequest.AsObject): Promise<
   GenerateApplicationSealedSecretResponse.AsObject
 > => {
   const req = new GenerateApplicationSealedSecretRequest();
   req.setPipedId(pipedId);
   req.setData(data);
+  req.setBase64Encoding(base64Encoding);
   return apiRequest(req, apiClient.generateApplicationSealedSecret);
 };
 

--- a/pkg/app/web/src/components/sealed-secret-dialog.tsx
+++ b/pkg/app/web/src/components/sealed-secret-dialog.tsx
@@ -64,7 +64,7 @@ export const SealedSecretDialog: FC<Props> = ({
   const handleGenerate = (e: React.FormEvent<HTMLFormElement>): void => {
     e.preventDefault();
     if (application) {
-      dispatch(generateSealedSecret({ data, pipedId: application.pipedId }));
+      dispatch(generateSealedSecret({ data, pipedId: application.pipedId, base64Encoding: false }));
     }
   };
 

--- a/pkg/app/web/src/modules/sealed-secret.ts
+++ b/pkg/app/web/src/modules/sealed-secret.ts
@@ -13,7 +13,7 @@ const initialState: SealedSecret = {
 
 export const generateSealedSecret = createAsyncThunk<
   string,
-  { pipedId: string; data: string }
+  { pipedId: string; data: string, base64Encoding: boolean }
 >("sealedSecret/generate", async (params) => {
   const res = await generateApplicationSealedSecret(params);
   return res.data;


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #1273

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Add an option to do base64 encoding before encrypting the secret
```
