### PR TITLE
Fix broken URL in the documentation

### DIFF
--- a/docs/content/en/docs/examples/_index.md
+++ b/docs/content/en/docs/examples/_index.md
@@ -44,7 +44,7 @@ https://github.com/pipe-cd/examples
 | [simple](https://github.com/pipe-cd/examples/tree/master/terraform/simple) |  Automatically applies when any changes were detected.  |
 | [local-module](https://github.com/pipe-cd/examples/tree/master/terraform/local-module) | Deploy application that using local terraform modules from the same Git repository. |
 | [remote-module](https://github.com/pipe-cd/examples/tree/master/terraform/remote-module) | Deploy application that using remote terraform modules from other Git repositories. |
-| [wait-approval](https://github.com/pipe-cd/examples/tree/master/terraform/wait-approval) | Deployment pipeline that contains a manual approval stage. |
+| [waitapproval](https://github.com/pipe-cd/examples/tree/master/terraform/waitapproval) | Deployment pipeline that contains a manual approval stage. |
 | [autorollback](https://github.com/pipe-cd/examples/tree/master/terraform/auto-rollback) |  Automatically rollback the changes when deployment was failed.  |
 
 ### CloudRun Applications


### PR DESCRIPTION

**What this PR does / why we need it**:

Fix broken URL in the documentation: wait-approval -> waitapproval

**Which issue(s) this PR fixes**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
