### PR TITLE
Hide header navigations when the user is not logged in

### DIFF
--- a/pkg/app/web/src/components/header.tsx
+++ b/pkg/app/web/src/components/header.tsx
@@ -105,43 +105,45 @@ export const Header: FC = memo(function Header() {
           )}
         </div>
         <div className={classes.right}>
-          <Link
-            component={RouterLink}
-            className={classes.link}
-            activeClassName={classes.activeLink}
-            color="inherit"
-            to={PAGE_PATH_APPLICATIONS}
-          >
-            Applications
-          </Link>
-          <Link
-            component={RouterLink}
-            className={classes.link}
-            activeClassName={classes.activeLink}
-            color="inherit"
-            to={PAGE_PATH_DEPLOYMENTS}
-          >
-            Deployments
-          </Link>
-          {/** TODO: Restore a link to the insights in the v1 release */}
-          <Link
-            component={RouterLink}
-            className={classes.link}
-            activeClassName={classes.activeLink}
-            color="inherit"
-            to={PAGE_PATH_SETTINGS}
-          >
-            Settings
-          </Link>
           {me?.isLogin ? (
-            <IconButton
-              aria-label="User Menu"
-              aria-controls="user-menu"
-              aria-haspopup="true"
-              onClick={(e) => setAnchorEl(e.currentTarget)}
-            >
-              <Avatar className={classes.userAvatar} src={me.avatarUrl} />
-            </IconButton>
+            <>
+              <Link
+                component={RouterLink}
+                className={classes.link}
+                activeClassName={classes.activeLink}
+                color="inherit"
+                to={PAGE_PATH_APPLICATIONS}
+              >
+                Applications
+              </Link>
+              <Link
+                component={RouterLink}
+                className={classes.link}
+                activeClassName={classes.activeLink}
+                color="inherit"
+                to={PAGE_PATH_DEPLOYMENTS}
+              >
+                Deployments
+              </Link>
+              {/** TODO: Restore a link to the insights in the v1 release */}
+              <Link
+                component={RouterLink}
+                className={classes.link}
+                activeClassName={classes.activeLink}
+                color="inherit"
+                to={PAGE_PATH_SETTINGS}
+              >
+                Settings
+              </Link>
+              <IconButton
+                aria-label="User Menu"
+                aria-controls="user-menu"
+                aria-haspopup="true"
+                onClick={(e) => setAnchorEl(e.currentTarget)}
+              >
+                <Avatar className={classes.userAvatar} src={me.avatarUrl} />
+              </IconButton>
+            </>
           ) : (
             <Link
               color="inherit"


### PR DESCRIPTION
**What this PR does / why we need it**:

![image](https://user-images.githubusercontent.com/6136383/102754478-656ed700-43b0-11eb-83c8-0c62fab8a83c.png)

**Which issue(s) this PR fixes**:

Fixes #1171

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Hide header navigations when the user is not logged in
```
