### PR TITLE
Enable to give aws credentials file via value

### DIFF
--- a/manifests/piped/templates/secret.yaml
+++ b/manifests/piped/templates/secret.yaml
@@ -23,4 +23,7 @@ data:
 {{- if .Values.secret.sealedSecretGCPKMS.decryptServiceAccount.data }}
   {{ .Values.secret.sealedSecretGCPKMS.decryptServiceAccount.fileName }}: {{ .Values.secret.sealedSecretGCPKMS.decryptServiceAccount.data | b64enc | quote }}
 {{- end }}
+{{- if .Values.secret.awsCredentials.data }}
+  {{ .Values.secret.awsCredentials.fileName }}: {{ .Values.secret.awsCredentials.data | b64enc | quote }}
+{{- end }}
 {{- end }}

--- a/manifests/piped/values.yaml
+++ b/manifests/piped/values.yaml
@@ -65,6 +65,9 @@ secret:
     decryptServiceAccount:
       fileName: sealed-secret-gcpkms-decrypt-service-account
       data: ""
+  awsCredentials:
+    fileName: aws-credentials
+    data: ""
 
 nodeSelector: {}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
With it we can set the credentials with `--set-file secret.awsCredentials.data=/path/to`

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
