### PR TITLE
Enable to retrieve credentials from EC2 Instance Role

### DIFF
--- a/pkg/app/piped/imageprovider/ecr/BUILD.bazel
+++ b/pkg/app/piped/imageprovider/ecr/BUILD.bazel
@@ -10,6 +10,8 @@ go_library(
         "@com_github_aws_aws_sdk_go//aws:go_default_library",
         "@com_github_aws_aws_sdk_go//aws/awserr:go_default_library",
         "@com_github_aws_aws_sdk_go//aws/credentials:go_default_library",
+        "@com_github_aws_aws_sdk_go//aws/credentials/ec2rolecreds:go_default_library",
+        "@com_github_aws_aws_sdk_go//aws/ec2metadata:go_default_library",
         "@com_github_aws_aws_sdk_go//aws/session:go_default_library",
         "@com_github_aws_aws_sdk_go//service/ecr:go_default_library",
         "@org_uber_go_zap//:go_default_library",

--- a/pkg/config/piped.go
+++ b/pkg/config/piped.go
@@ -449,11 +449,12 @@ type ImageProviderECRConfig struct {
 	RegistryID string `json:"registryId"`
 	// Path to the shared credentials file.
 	//
-	// If you do not specify this field, piped attempts to retrieve credentials
-	// from the environment variables by default.
-	// These environment variables are used:
+	// Piped attempts to retrieve credentials in the following order:
+	// 1. from the environment variables. Available environment variables are:
 	//   - AWS_ACCESS_KEY_ID or AWS_ACCESS_KEY
 	//   - AWS_SECRET_ACCESS_KEY or AWS_SECRET_KEY
+	// 2. from the given credentials file.
+	// 3. from the EC2 Instance Role
 	CredentialsFile string `json:"credentialsFile"`
 	// AWS Profile to extract credentials from the shared credentials file.
 	// If empty, the environment variable "AWS_PROFILE" is used.


### PR DESCRIPTION
**What this PR does / why we need it**:
With this PR, credentials will be loaded in the following order:
1. from the environment variables
2. from the given credentials file.
3. from the EC2 Instance Role

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
