### PR TITLE
Change deployment strategy of ops to Recreate

### DIFF
--- a/manifests/pipecd/templates/deployment.yaml
+++ b/manifests/pipecd/templates/deployment.yaml
@@ -196,6 +196,8 @@ metadata:
     app.kubernetes.io/component: ops
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       {{- include "pipecd.selectorLabels" . | nindent 6 }}


### PR DESCRIPTION
**What this PR does / why we need it**:

To ensure that only one "ops" pod is running at a time.

**Which issue(s) this PR fixes**:

Fixes #1318

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
