### PR TITLE
Use default username and email for git config

### DIFF
--- a/docs/content/en/docs/operator-manual/piped/configuration-reference.md
+++ b/docs/content/en/docs/operator-manual/piped/configuration-reference.md
@@ -36,8 +36,8 @@ spec:
 
 | Field | Type | Description | Required |
 |-|-|-|-|
-| username | string | The username that will be configured for `git` user. | No |
-| email | string | The email that will be configured for `git` user. | No |
+| username | string | The username that will be configured for `git` user. Default is `piped`. | No |
+| email | string | The email that will be configured for `git` user. Default is `pipecd.dev@gmail.com`. | No |
 | sshConfigFilePath | string | Where to write ssh config file. Default is `/home/pipecd/.ssh/config`. | No |
 | host | string | The host name. Default is `github.com`. | No |
 | hostName | string | The hostname or IP address of the remote git server. Default is the same value with Host. | No |

--- a/pkg/config/piped.go
+++ b/pkg/config/piped.go
@@ -167,8 +167,10 @@ func (s *PipedSpec) GetAnalysisProvider(name string) (PipedAnalysisProvider, boo
 
 type PipedGit struct {
 	// The username that will be configured for `git` user.
+	// Default is "piped".
 	Username string `json:"username"`
 	// The email that will be configured for `git` user.
+	// Default is "pipecd.dev@gmail.com".
 	Email string `json:"email"`
 	// Where to write ssh config file.
 	// Default is "/home/pipecd/.ssh/config".

--- a/pkg/git/client.go
+++ b/pkg/git/client.go
@@ -28,6 +28,11 @@ import (
 	"go.uber.org/zap"
 )
 
+const (
+	defaultUsername = "piped"
+	defaultEmail    = "pipecd.dev@gmail.com"
+)
+
 // Client is a git client for cloning/fetching git repo.
 // It keeps a local cache for faster future cloning.
 type Client interface {
@@ -58,6 +63,13 @@ func NewClient(username, email string, logger *zap.Logger) (Client, error) {
 	cacheDir, err := ioutil.TempDir("", "gitcache")
 	if err != nil {
 		return nil, fmt.Errorf("unable to create a temporary directory for git cache: %v", err)
+	}
+
+	if username == "" {
+		username = defaultUsername
+	}
+	if email == "" {
+		email = defaultEmail
 	}
 
 	return &client{

--- a/pkg/git/ssh_config.go
+++ b/pkg/git/ssh_config.go
@@ -24,7 +24,11 @@ import (
 	"github.com/pipe-cd/pipe/pkg/config"
 )
 
-const sshConfigTemplate = `
+const (
+	defaultSSHConfigFilePath = "/home/pipecd/.ssh/config"
+	defaultHost              = "github.com"
+
+	sshConfigTemplate = `
 Host {{ .Host }}
     Hostname {{ .HostName }}
     User git
@@ -32,10 +36,10 @@ Host {{ .Host }}
     UserKnownHostsFile /dev/null
     StrictHostKeyChecking no
 `
+)
 
 var (
-	sshConfigTmpl            = template.Must(template.New("ssh-config").Parse(sshConfigTemplate))
-	defaultSSHConfigFilePath = "/home/pipecd/.ssh/config"
+	sshConfigTmpl = template.Must(template.New("ssh-config").Parse(sshConfigTemplate))
 )
 
 type sshConfig struct {
@@ -82,7 +86,7 @@ func generateSSHConfig(cfg config.PipedGit) (string, error) {
 	var (
 		buffer bytes.Buffer
 		data   = sshConfig{
-			Host:         "github.com",
+			Host:         defaultHost,
 			IdentityFile: cfg.SSHKeyFile,
 		}
 	)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR aims to reduce the need to set username and email so that Piped can commit.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
