### PR TITLE
Update fields of optional image watcher config

### DIFF
--- a/docs/content/en/docs/operator-manual/piped/configuration-reference.md
+++ b/docs/content/en/docs/operator-manual/piped/configuration-reference.md
@@ -161,14 +161,14 @@ Must be one of the following structs:
 
 | Field | Type | Description | Required |
 |-|-|-|-|
-| repos | []ImageWatcherRepoTarget | List of settings for each git repository | No |
+| checkInterval | duration |  Interval to compare the image in the git repository and one in the images provider. Defaults to `5m`. | No |
+| gitRepos | [][ImageWatcherGitRepo](/docs/operator-manual/piped/configuration-reference/#imagewatchergitrepo) | List of settings for each git repository | No |
 
-### ImageWatcherRepoTarget
+### ImageWatcherGitRepo
 
 | Field | Type | Description | Required |
 |-|-|-|-|
 | repoId | string | Id of the git repository. This must be unique within the repos' elements. | Yes |
-| checkInterval | duration |  Interval to compare the image in the git repository and one in the images provider. Defaults to `5m`. | No |
 | commitMessage | string |  The commit message used to push after updating image. Default message is used if not given. | No |
 | includes | []string | The paths to ImageWatcher files to be included. | No |
 | excludes | []string |  The paths to ImageWatcher files to be excluded. This is prioritized if both includes and this are given. | No |

--- a/docs/content/en/docs/operator-manual/piped/configuring-image-watcher.md
+++ b/docs/content/en/docs/operator-manual/piped/configuring-image-watcher.md
@@ -62,24 +62,25 @@ The full list of ECR fields are [here](/docs/operator-manual/piped/configuration
 >The FAKE container registry is deployed at the control-plane, and you can store the metadata about newly updated images whenever you want to (e.g. on your CI).
 
 
-## [optional] Settings for each git repository
-The `imageWatcher` field allows you to configure the settings for each git repository.
+## [optional] Settings for watcher
+The Piped's behavior can be finely controlled by setting the `imageWatcher` field.
 
 ```yaml
 apiVersion: pipecd.dev/v1beta1
 kind: Piped
 spec:
   imageWatcher:
-    repos:
+    checkInterval: 5m
+    gitRepos:
       - repoId: foo
-        checkInterval: 5m
         commitMessage: Update image
         includes:
           - imagewatcher-dev.yaml
           - imagewatcher-stg.yaml
 ```
 
-If multiple Pipeds handle a single repository, you can prevent conflicts by splitting into the multiple files and specifying `includes/excludes`. `excludes` is prioritized if both `includes` and `excludes` are given.
+If multiple Pipeds handle a single repository, you can prevent conflicts by splitting into the multiple ImageWatcher files and setting `includes/excludes` to specify the files that should be monitored by this Piped.
+`excludes` is prioritized if both `includes` and `excludes` are given.
 
 The full list of configurable fields are [here](/docs/operator-manual/piped/configuration-reference/#imagewatcher).
 

--- a/pkg/app/piped/imagewatcher/watcher.go
+++ b/pkg/app/piped/imagewatcher/watcher.go
@@ -107,20 +107,22 @@ func (w *watcher) run(ctx context.Context, repo git.Repo, repoCfg *config.PipedR
 	defer w.wg.Done()
 
 	var (
-		checkInterval              = defaultCheckInterval
 		commitMsg                  string
 		includedCfgs, excludedCfgs []string
 	)
 	// Use user-defined settings if there is.
-	for _, r := range w.config.ImageWatcher.Repos {
+	for _, r := range w.config.ImageWatcher.GitRepos {
 		if r.RepoID != repoCfg.RepoID {
 			continue
 		}
-		checkInterval = time.Duration(r.CheckInterval)
 		commitMsg = r.CommitMessage
 		includedCfgs = r.Includes
 		excludedCfgs = r.Excludes
 		break
+	}
+	checkInterval := time.Duration(w.config.ImageWatcher.CheckInterval)
+	if checkInterval == 0 {
+		checkInterval = defaultCheckInterval
 	}
 
 	ticker := time.NewTicker(checkInterval)

--- a/pkg/config/image_watcher_test.go
+++ b/pkg/config/image_watcher_test.go
@@ -124,3 +124,74 @@ func TestFilterImageWatcherFiles(t *testing.T) {
 		})
 	}
 }
+
+func TestImageWatcherValidate(t *testing.T) {
+	testcases := []struct {
+		name             string
+		imageWatcherSpec ImageWatcherSpec
+		wantErr          bool
+	}{
+		{
+			name: "empty provider given",
+			imageWatcherSpec: ImageWatcherSpec{Targets: []ImageWatcherTarget{
+				{
+					Image:    "image",
+					FilePath: "filePath",
+					Field:    "field",
+				},
+			}},
+			wantErr: true,
+		},
+		{
+			name: "empty image given",
+			imageWatcherSpec: ImageWatcherSpec{Targets: []ImageWatcherTarget{
+				{
+					Provider: "provider",
+					FilePath: "filePath",
+					Field:    "field",
+				},
+			}},
+			wantErr: true,
+		},
+		{
+			name: "empty file path given",
+			imageWatcherSpec: ImageWatcherSpec{Targets: []ImageWatcherTarget{
+				{
+					Provider: "provider",
+					Image:    "image",
+					Field:    "field",
+				},
+			}},
+			wantErr: true,
+		},
+		{
+			name: "empty field given",
+			imageWatcherSpec: ImageWatcherSpec{Targets: []ImageWatcherTarget{
+				{
+					Provider: "provider",
+					Image:    "image",
+					FilePath: "filePath",
+				},
+			}},
+			wantErr: true,
+		},
+		{
+			name: "all fields given",
+			imageWatcherSpec: ImageWatcherSpec{Targets: []ImageWatcherTarget{
+				{
+					Provider: "provider",
+					Image:    "image",
+					FilePath: "filePath",
+					Field:    "field",
+				},
+			}},
+			wantErr: false,
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.imageWatcherSpec.Validate()
+			assert.Equal(t, tc.wantErr, err != nil)
+		})
+	}
+}

--- a/pkg/config/piped_test.go
+++ b/pkg/config/piped_test.go
@@ -223,11 +223,11 @@ func TestPipedConfig(t *testing.T) {
 					},
 				},
 				ImageWatcher: PipedImageWatcher{
-					Repos: []PipedImageWatcherRepoTarget{
+					CheckInterval: Duration(10 * time.Minute),
+					GitRepos: []PipedImageWatcherGitRepo{
 						{
 							RepoID:        "foo",
-							CheckInterval: Duration(10 * time.Minute),
-							CommitMessage: "foo bar",
+							CommitMessage: "Update image",
 							Includes:      []string{"imagewatcher-dev.yaml", "imagewatcher-stg.yaml"},
 						},
 					},
@@ -257,29 +257,43 @@ func TestPipedImageWatcherValidate(t *testing.T) {
 		wantPipedImageWatcher PipedImageWatcher
 	}{
 		{
-			name:    "duplicated repo exists",
+			name:    "missing repo id",
 			wantErr: true,
 			imageWatcher: PipedImageWatcher{
-				Repos: []PipedImageWatcherRepoTarget{
+				GitRepos: []PipedImageWatcherGitRepo{
 					{
-						RepoID:        "foo",
-						CheckInterval: Duration(time.Minute),
-					},
-					{
-						RepoID:        "foo",
-						CheckInterval: Duration(time.Minute),
+						RepoID: "",
 					},
 				},
 			},
 			wantPipedImageWatcher: PipedImageWatcher{
-				Repos: []PipedImageWatcherRepoTarget{
+				GitRepos: []PipedImageWatcherGitRepo{
 					{
-						RepoID:        "foo",
-						CheckInterval: Duration(time.Minute),
+						RepoID: "",
+					},
+				},
+			},
+		},
+		{
+			name:    "duplicated repo exists",
+			wantErr: true,
+			imageWatcher: PipedImageWatcher{
+				GitRepos: []PipedImageWatcherGitRepo{
+					{
+						RepoID: "foo",
 					},
 					{
-						RepoID:        "foo",
-						CheckInterval: Duration(time.Minute),
+						RepoID: "foo",
+					},
+				},
+			},
+			wantPipedImageWatcher: PipedImageWatcher{
+				GitRepos: []PipedImageWatcherGitRepo{
+					{
+						RepoID: "foo",
+					},
+					{
+						RepoID: "foo",
 					},
 				},
 			},
@@ -288,7 +302,7 @@ func TestPipedImageWatcherValidate(t *testing.T) {
 			name:    "repos are unique",
 			wantErr: false,
 			imageWatcher: PipedImageWatcher{
-				Repos: []PipedImageWatcherRepoTarget{
+				GitRepos: []PipedImageWatcherGitRepo{
 					{
 						RepoID: "foo",
 					},
@@ -298,14 +312,12 @@ func TestPipedImageWatcherValidate(t *testing.T) {
 				},
 			},
 			wantPipedImageWatcher: PipedImageWatcher{
-				Repos: []PipedImageWatcherRepoTarget{
+				GitRepos: []PipedImageWatcherGitRepo{
 					{
-						RepoID:        "foo",
-						CheckInterval: Duration(5 * time.Minute),
+						RepoID: "foo",
 					},
 					{
-						RepoID:        "bar",
-						CheckInterval: Duration(5 * time.Minute),
+						RepoID: "bar",
 					},
 				},
 			},

--- a/pkg/config/testdata/.pipe/image-watcher.yaml
+++ b/pkg/config/testdata/.pipe/image-watcher.yaml
@@ -5,8 +5,8 @@ spec:
     - image: gcr.io/pipecd/foo
       provider: my-gcr
       filePath: foo/deployment.yaml
-      field: $.spec.containers[0].image
+      field: $.spec.template.spec.containers[0].image
     - image: pipecd/bar
       provider: my-dockerhub
       filePath: bar/deployment.yaml
-      field: $.spec.containers[0].image
+      field: $.spec.template.spec.containers[0].image

--- a/pkg/config/testdata/piped/piped-config.yaml
+++ b/pkg/config/testdata/piped/piped-config.yaml
@@ -134,10 +134,10 @@ spec:
     #   encryptServiceAccountFile: /etc/piped-secret/encrypt-service-account.json
 
   imageWatcher:
-    repos:
+    checkInterval: 10m
+    gitRepos:
       - repoId: foo
-        checkInterval: 10m
-        commitMessage: "foo bar"
+        commitMessage: Update image
         includes:
           - imagewatcher-dev.yaml
           - imagewatcher-stg.yaml


### PR DESCRIPTION
**What this PR does / why we need it**:
The three changes are included:
- Rename repos to gitRepos (some people can confuse and mistake it for container repository)
- Make `checkInterval` global (most cases need only global settings. Let's add a field for each repo when really needed)
- Add some validations

The current structure is:
```yaml
apiVersion: pipecd.dev/v1beta1
kind: Piped
spec:
  imageWatcher:
    repos:
      - repoId: foo
        checkInterval: 10m
        commitMessage: Update image
        includes:
          - imagewatcher-dev.yaml
          - imagewatcher-stg.yaml
```

From now:
```yaml
apiVersion: pipecd.dev/v1beta1
kind: Piped
spec:
  imageWatcher:
    checkInterval: 10m
    gitRepos:
      - repoId: foo
        commitMessage: Update image
        includes:
          - imagewatcher-dev.yaml
          - imagewatcher-stg.yaml
```


**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
