### PR TITLE
Add navigation to #pipecd channel in docs

### DIFF
--- a/docs/content/en/_index.html
+++ b/docs/content/en/_index.html
@@ -66,7 +66,7 @@ linkTitle = "PipeCD"
 {{% blocks/feature icon="fab fa-slack" title="Join the conversation!" url="https://join.slack.com/t/cloud-native/shared_invite/zt-fyy3b8up-qHeDNVqbz1j8HDY6g1cY4w" %}}
 Have a question?
 
-Learn more by talking with other contributors.
+Learn more by talking with other contributors in [Cloud Native Slack](https://join.slack.com/t/cloud-native/shared_invite/zt-fyy3b8up-qHeDNVqbz1j8HDY6g1cY4w) via [#pipecd](https://app.slack.com/client/T08PSQ7BQ/C01B27F9T0X) channel.
 {{% /blocks/feature %}}
 
 

--- a/docs/content/en/docs/faq/_index.md
+++ b/docs/content/en/docs/faq/_index.md
@@ -6,7 +6,7 @@ description: >
   List of frequently asked questions.
 ---
 
-If you have any other questions, please feel free to create the issue in the [pipe-cd/pipe](https://github.com/pipe-cd/pipe/issues/new/choose) repository or contact us on [Slack](https://join.slack.com/t/cloud-native/shared_invite/zt-fyy3b8up-qHeDNVqbz1j8HDY6g1cY4w).
+If you have any other questions, please feel free to create the issue in the [pipe-cd/pipe](https://github.com/pipe-cd/pipe/issues/new/choose) repository or contact us on [Cloud Native Slack](https://join.slack.com/t/cloud-native/shared_invite/zt-fyy3b8up-qHeDNVqbz1j8HDY6g1cY4w) (channel [#pipecd](https://app.slack.com/client/T08PSQ7BQ/C01B27F9T0X)).
 
 ### 1. What kind of application (cloud provider) will be supported?
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The current invitation link does not automatically add new members to our channels (#pipecd or #pipecd-jp). This PR adds link to pipecd channel.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
