### PR TITLE
Rename spec.sync to spec.quickSync

### DIFF
--- a/examples/kubernetes/analysis-by-metrics/.pipe.yaml
+++ b/examples/kubernetes/analysis-by-metrics/.pipe.yaml
@@ -1,7 +1,7 @@
 apiVersion: pipecd.dev/v1beta1
 kind: KubernetesApp
 spec:
-  sync:
+  quickSync:
     prune: true
   pipeline:
     stages:


### PR DESCRIPTION
**What this PR does / why we need it**:

sync field has been changed to a quickSync field

- https://pipecd.dev/docs/user-guide/configuration-reference/#kubernetesquicksync

**Which issue(s) this PR fixes**:

- https://github.com/pipe-cd/pipe/pull/572

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
