### PR TITLE
Only trigger CodeQL analysis on the schedule event

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -12,11 +12,11 @@
 name: "CodeQL"
 
 on:
-  push:
-    branches: [ master ]
-  pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ master ]
+#   push:
+#     branches: [ master ]
+#   pull_request:
+#     # The branches below must be a subset of the branches above
+#     branches: [ master ]
   schedule:
     - cron: '00 5 * * 1'
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The analysis process of CodeQL is too slow to be run during the `push` or `pull_request` events.
So this PR fixed the workflow to only trigger the analysis on the `schedule` event.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
