### PR TITLE
Update log message for prepare deployment configuration step

### DIFF
--- a/pkg/app/piped/controller/scheduler.go
+++ b/pkg/app/piped/controller/scheduler.go
@@ -257,7 +257,7 @@ func (s *scheduler) Run(ctx context.Context) error {
 	ds, err := configDSP.GetReadOnly(ctx, ioutil.Discard)
 	if err != nil {
 		s.doneDeploymentStatus = model.DeploymentStatus_DEPLOYMENT_FAILURE
-		statusReason = fmt.Sprintf("Unable to prepare deploy source data at target commit (%v)", err)
+		statusReason = fmt.Sprintf("Unable to prepare deployment configuration source data at target commit (%v)", err)
 		s.reportDeploymentCompleted(ctx, s.doneDeploymentStatus, statusReason, "")
 		return err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Make the log message for prepare deployment configuration different from the log message for prepare deploy source data.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
