### PR TITLE
Remove TODO comment about merging events

### DIFF
--- a/pkg/config/event_watcher.go
+++ b/pkg/config/event_watcher.go
@@ -130,7 +130,6 @@ func (s *EventWatcherSpec) Validate() error {
 		if len(e.Replacements) == 0 {
 			return fmt.Errorf("there must be at least one replacement to an event")
 		}
-		// TODO: Consider merging events if there are events whose combination of name and labels is the same
 	}
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Just removed a TODO comment. 

We just settled that we don't have to merge events when committing, on this discussion: https://github.com/pipe-cd/pipe/pull/1429#discussion_r557089641

**Which issue(s) this PR fixes**:

Fixes https://github.com/pipe-cd/pipe/issues/1406

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
