### PR TITLE
Change lambda apply function manifest logic

### DIFF
--- a/pkg/app/piped/cloudprovider/lambda/lambda.go
+++ b/pkg/app/piped/cloudprovider/lambda/lambda.go
@@ -28,7 +28,9 @@ import (
 const DefaultFunctionManifestFilename = "function.yaml"
 
 type Client interface {
-	Apply(ctx context.Context, fm FunctionManifest, role string) error
+	CreateFunction(ctx context.Context, fm FunctionManifest, role string) error
+	AvailableFunctionName(ctx context.Context, name string) (bool, error)
+	DeleteFunction(ctx context.Context, name string) error
 }
 
 type Registry interface {


### PR DESCRIPTION
**What this PR does / why we need it**:

Since the FunctionName is unique across lambda applications, once a Lambda application deployed successfully via the current `client.Apply`, it can not be updated since the second time creating a lambda function with an existed name cause error. 

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
