### PR TITLE
Add ops the ability to clean orphan commands

### DIFF
--- a/cmd/pipecd/BUILD.bazel
+++ b/cmd/pipecd/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//pkg/app/api/stagelogstore:go_default_library",
         "//pkg/app/ops/handler:go_default_library",
         "//pkg/app/ops/insightcollector:go_default_library",
+        "//pkg/app/ops/orphancommandcleaner:go_default_library",
         "//pkg/backoff:go_default_library",
         "//pkg/cache/rediscache:go_default_library",
         "//pkg/cli:go_default_library",

--- a/cmd/pipecd/ops.go
+++ b/cmd/pipecd/ops.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pipe-cd/pipe/pkg/admin"
 	"github.com/pipe-cd/pipe/pkg/app/ops/handler"
 	"github.com/pipe-cd/pipe/pkg/app/ops/insightcollector"
+	"github.com/pipe-cd/pipe/pkg/app/ops/orphancommandcleaner"
 	"github.com/pipe-cd/pipe/pkg/backoff"
 	"github.com/pipe-cd/pipe/pkg/cli"
 	"github.com/pipe-cd/pipe/pkg/datastore"
@@ -97,6 +98,10 @@ func (s *ops) run(ctx context.Context, t cli.Telemetry) error {
 			t.Logger.Error("failed to close filestore client", zap.Error(err))
 		}
 	}()
+
+	// Starting orphan commands cleaner
+	cleaner := orphancommandcleaner.NewOrphanCommandCleaner(ds, t.Logger)
+	cleaner.Run(ctx)
 
 	// Starting a cron job for insight collector.
 	if s.enableInsightCollector {

--- a/cmd/pipecd/ops.go
+++ b/cmd/pipecd/ops.go
@@ -101,7 +101,9 @@ func (s *ops) run(ctx context.Context, t cli.Telemetry) error {
 
 	// Starting orphan commands cleaner
 	cleaner := orphancommandcleaner.NewOrphanCommandCleaner(ds, t.Logger)
-	cleaner.Run(ctx)
+	group.Go(func() error {
+		return cleaner.Run(ctx)
+	})
 
 	// Starting a cron job for insight collector.
 	if s.enableInsightCollector {

--- a/pkg/app/api/grpcapi/piped_api.go
+++ b/pkg/app/api/grpcapi/piped_api.go
@@ -220,6 +220,10 @@ func (a *PipedAPI) ReportApplicationDeployingStatus(ctx context.Context, req *pi
 		app.Deploying = req.Deploying
 		return nil
 	})
+	if err == nil {
+		return &pipedservice.ReportApplicationDeployingStatusResponse{}, nil
+	}
+
 	switch err {
 	case datastore.ErrNotFound:
 		return nil, status.Error(codes.InvalidArgument, "application is not found")
@@ -232,8 +236,6 @@ func (a *PipedAPI) ReportApplicationDeployingStatus(ctx context.Context, req *pi
 		)
 		return nil, status.Error(codes.Internal, "failed to update deploying status of application")
 	}
-
-	return &pipedservice.ReportApplicationDeployingStatusResponse{}, nil
 }
 
 // ReportApplicationMostRecentDeployment is used to update the basic information about

--- a/pkg/app/ops/orphancommandcleaner/BUILD.bazel
+++ b/pkg/app/ops/orphancommandcleaner/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["orphancommandcleaner.go"],
+    importpath = "github.com/pipe-cd/pipe/pkg/app/ops/orphancommandcleaner",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/datastore:go_default_library",
+        "//pkg/model:go_default_library",
+        "@org_uber_go_zap//:go_default_library",
+    ],
+)

--- a/pkg/app/ops/orphancommandcleaner/orphancommandcleaner.go
+++ b/pkg/app/ops/orphancommandcleaner/orphancommandcleaner.go
@@ -1,0 +1,70 @@
+package orphancommandcleaner
+
+import (
+	"context"
+	"time"
+
+	"github.com/pipe-cd/pipe/pkg/datastore"
+	"github.com/pipe-cd/pipe/pkg/model"
+	"go.uber.org/zap"
+)
+
+var (
+	commandTimeOut = 7 * 24 * time.Hour
+	interval       = 24 * time.Hour
+)
+
+type OrphanCommandCleaner struct {
+	commandstore datastore.CommandStore
+	logger       *zap.Logger
+}
+
+func NewOrphanCommandCleaner(
+	ds datastore.DataStore,
+	logger *zap.Logger,
+) *OrphanCommandCleaner {
+	return &OrphanCommandCleaner{
+		commandstore: datastore.NewCommandStore(ds),
+		logger:       logger.Named("orphan-command-finder"),
+	}
+}
+
+func (o *OrphanCommandCleaner) Run(ctx context.Context) {
+	for {
+		if err := o.updateOrphanCommandsStatus(ctx); err != nil {
+			o.logger.Error("failed to update orphan commands", zap.Error(err))
+		}
+		time.Sleep(interval)
+	}
+}
+
+func (o *OrphanCommandCleaner) updateOrphanCommandsStatus(ctx context.Context) error {
+	timeoutedTime := time.Now().Add(-commandTimeOut).Unix()
+	opts := datastore.ListOptions{
+		Filters: []datastore.ListFilter{
+			{
+				Field:    "Status",
+				Operator: "==",
+				Value:    model.CommandStatus_COMMAND_NOT_HANDLED_YET,
+			},
+			{
+				Field:    "CreatedAt",
+				Operator: "<=",
+				Value:    timeoutedTime,
+			},
+		},
+	}
+	commands, err := o.commandstore.ListCommands(ctx, opts)
+	if err != nil {
+		return err
+	}
+
+	for _, c := range commands {
+		o.commandstore.UpdateCommand(ctx, c.Id, func(c *model.Command) error {
+			c.Status = model.CommandStatus_COMMAND_TIMEOUT
+			return nil
+		})
+	}
+
+	return nil
+}

--- a/pkg/app/ops/orphancommandcleaner/orphancommandcleaner.go
+++ b/pkg/app/ops/orphancommandcleaner/orphancommandcleaner.go
@@ -26,7 +26,7 @@ func NewOrphanCommandCleaner(
 ) *OrphanCommandCleaner {
 	return &OrphanCommandCleaner{
 		commandstore: datastore.NewCommandStore(ds),
-		logger:       logger.Named("orphan-command-finder"),
+		logger:       logger.Named("orphan-command-cleaner"),
 	}
 }
 

--- a/pkg/app/ops/orphancommandcleaner/orphancommandcleaner.go
+++ b/pkg/app/ops/orphancommandcleaner/orphancommandcleaner.go
@@ -37,6 +37,8 @@ func (c *OrphanCommandCleaner) Run(ctx context.Context) error {
 	t := time.NewTicker(interval)
 	for {
 		select {
+		case <-ctx.Done():
+			return nil
 		case <-t.C:
 			if err := c.updateOrphanCommandsStatus(ctx); err != nil {
 				c.logger.Error("failed to update orphan commands", zap.Error(err))

--- a/pkg/app/ops/orphancommandcleaner/orphancommandcleaner.go
+++ b/pkg/app/ops/orphancommandcleaner/orphancommandcleaner.go
@@ -79,7 +79,7 @@ func (c *OrphanCommandCleaner) updateOrphanCommandsStatus(ctx context.Context) e
 			cmd.Status = model.CommandStatus_COMMAND_TIMEOUT
 			return nil
 		}); err != nil {
-			c.logger.Error("failed to update orphan commands", zap.Error(err))
+			c.logger.Error("failed to update orphan command", zap.Error(err), zap.String("id", command.Id), zap.String("type", command.Type.String()))
 		}
 	}
 

--- a/pkg/app/ops/orphancommandcleaner/orphancommandcleaner.go
+++ b/pkg/app/ops/orphancommandcleaner/orphancommandcleaner.go
@@ -11,8 +11,8 @@ import (
 )
 
 var (
-	commandTimeOut = 7 * 24 * time.Hour
-	interval       = 24 * time.Hour
+	commandTimeOut = 24 * time.Hour
+	interval       = 6 * time.Hour
 )
 
 type OrphanCommandCleaner struct {


### PR DESCRIPTION
**What this PR does / why we need it**:

Create orphan commands cleaner. It periodically find orphan commands and mark them with TIMEOUT status

**Which issue(s) this PR fixes**:

Fixes #1397 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
