### PR TITLE
Fix to use config's timeout on Prometheus

### DIFF
--- a/pkg/app/piped/analysisprovider/metrics/factory.go
+++ b/pkg/app/piped/analysisprovider/metrics/factory.go
@@ -35,10 +35,10 @@ func NewFactory(logger *zap.Logger) *Factory {
 }
 
 // NewProvider generates an appropriate provider according to analysis provider config.
-func (f *Factory) NewProvider(providerCfg *config.PipedAnalysisProvider) (provider Provider, err error) {
+func (f *Factory) NewProvider(analysisTempCfg *config.TemplatableAnalysisMetrics, providerCfg *config.PipedAnalysisProvider) (provider Provider, err error) {
 	switch providerCfg.Type {
 	case model.AnalysisProviderPrometheus:
-		provider, err = prometheus.NewProvider(providerCfg.PrometheusConfig.Address, f.logger)
+		provider, err = prometheus.NewProvider(providerCfg.PrometheusConfig.Address, analysisTempCfg.Timeout.Duration(), f.logger)
 		if err != nil {
 			return
 		}

--- a/pkg/app/piped/analysisprovider/metrics/prometheus/prometheus.go
+++ b/pkg/app/piped/analysisprovider/metrics/prometheus/prometheus.go
@@ -43,7 +43,7 @@ type Provider struct {
 	logger  *zap.Logger
 }
 
-func NewProvider(address string, logger *zap.Logger) (*Provider, error) {
+func NewProvider(address string, timeout time.Duration, logger *zap.Logger) (*Provider, error) {
 	client, err := api.NewClient(api.Config{
 		Address: address,
 	})
@@ -53,7 +53,7 @@ func NewProvider(address string, logger *zap.Logger) (*Provider, error) {
 
 	return &Provider{
 		api:     v1.NewAPI(client),
-		timeout: defaultTimeout,
+		timeout: timeout,
 		logger:  logger.With(zap.String("analysis-provider", ProviderType)),
 	}, nil
 }

--- a/pkg/app/piped/analysisprovider/metrics/prometheus/prometheus.go
+++ b/pkg/app/piped/analysisprovider/metrics/prometheus/prometheus.go
@@ -51,6 +51,10 @@ func NewProvider(address string, timeout time.Duration, logger *zap.Logger) (*Pr
 		return nil, err
 	}
 
+	if timeout == 0 {
+		timeout = defaultTimeout
+	}
+
 	return &Provider{
 		api:     v1.NewAPI(client),
 		timeout: timeout,

--- a/pkg/app/piped/executor/analysis/analysis.go
+++ b/pkg/app/piped/executor/analysis/analysis.go
@@ -197,7 +197,7 @@ func (e *Executor) newAnalyzerForMetrics(i int, templatable *config.TemplatableA
 	if err != nil {
 		return nil, err
 	}
-	provider, err := e.newMetricsProvider(cfg.Provider, factory)
+	provider, err := e.newMetricsProvider(cfg.Provider, templatable, factory)
 	if err != nil {
 		return nil, err
 	}
@@ -237,12 +237,12 @@ func (e *Executor) newAnalyzerForHTTP(i int, templatable *config.TemplatableAnal
 	}, time.Duration(cfg.Interval), cfg.FailureLimit, e.Logger, e.LogPersister), nil
 }
 
-func (e *Executor) newMetricsProvider(providerName string, factory *metrics.Factory) (metrics.Provider, error) {
+func (e *Executor) newMetricsProvider(providerName string, templatable *config.TemplatableAnalysisMetrics, factory *metrics.Factory) (metrics.Provider, error) {
 	cfg, ok := e.PipedConfig.GetAnalysisProvider(providerName)
 	if !ok {
 		return nil, fmt.Errorf("unknown provider name %s", providerName)
 	}
-	provider, err := factory.NewProvider(&cfg)
+	provider, err := factory.NewProvider(templatable, &cfg)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, Always used the default timeout value, so, changed to use the value in the configuration.

**Which issue(s) this PR fixes**:

Fixes #1244

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
