### PR TITLE
Move role config to Function manifest instead of Piped manifest

### DIFF
--- a/examples/lambda/analysis/function.yaml
+++ b/examples/lambda/analysis/function.yaml
@@ -2,6 +2,7 @@ apiVersion: pipecd.dev/v1beta1
 kind: LambdaFunction
 spec:
   name: SimpleFunction
+  role: arn:aws:iam::76xxxxxxx:role/lambda-role
   image: ecr.ap-northeast-1.amazonaws.com/lambda-test:v0.0.1
   tags:
     app: simple

--- a/examples/lambda/canary/function.yaml
+++ b/examples/lambda/canary/function.yaml
@@ -2,6 +2,7 @@ apiVersion: pipecd.dev/v1beta1
 kind: LambdaFunction
 spec:
   name: SimpleFunction
+  role: arn:aws:iam::76xxxxxxx:role/lambda-role
   image: ecr.ap-northeast-1.amazonaws.com/lambda-test:v0.0.1
   tags:
     app: simple

--- a/examples/lambda/simple/function.yaml
+++ b/examples/lambda/simple/function.yaml
@@ -2,6 +2,7 @@ apiVersion: pipecd.dev/v1beta1
 kind: LambdaFunction
 spec:
   name: SimpleFunction
+  role: arn:aws:iam::76xxxxxxx:role/lambda-role
   image: ecr.ap-northeast-1.amazonaws.com/lambda-test:v0.0.1
   tags:
     app: simple

--- a/pkg/app/piped/cloudprovider/lambda/client.go
+++ b/pkg/app/piped/cloudprovider/lambda/client.go
@@ -66,16 +66,13 @@ func newClient(region, profile, credentialsFile string, logger *zap.Logger) (*cl
 	return c, nil
 }
 
-func (c *client) Apply(ctx context.Context, fm FunctionManifest, role string) error {
-	if role == "" {
-		return fmt.Errorf("role arn is required")
-	}
+func (c *client) Apply(ctx context.Context, fm FunctionManifest) error {
 	input := &lambda.CreateFunctionInput{
 		Code: &lambda.FunctionCode{
 			ImageUri: aws.String(fm.Spec.ImageURI),
 		},
 		PackageType:  aws.String("Image"),
-		Role:         aws.String(role),
+		Role:         aws.String(fm.Spec.Role),
 		FunctionName: aws.String(fm.Spec.Name),
 	}
 	_, err := c.client.CreateFunctionWithContext(ctx, input)

--- a/pkg/app/piped/cloudprovider/lambda/function.go
+++ b/pkg/app/piped/cloudprovider/lambda/function.go
@@ -49,6 +49,7 @@ func (fm *FunctionManifest) validate() error {
 // FunctionManifestSpec contains configuration for LambdaFunction.
 type FunctionManifestSpec struct {
 	Name     string            `json:"name"`
+	Role     string            `json:"role"`
 	ImageURI string            `json:"image"`
 	Tags     map[string]string `json:"tags,omitempty"`
 }
@@ -59,6 +60,9 @@ func (fmp FunctionManifestSpec) validate() error {
 	}
 	if len(fmp.ImageURI) == 0 {
 		return fmt.Errorf("image uri is missing")
+	}
+	if len(fmp.Role) == 0 {
+		return fmt.Errorf("role is missing")
 	}
 	return nil
 }

--- a/pkg/app/piped/cloudprovider/lambda/function_test.go
+++ b/pkg/app/piped/cloudprovider/lambda/function_test.go
@@ -34,6 +34,7 @@ func TestparseFunctionManifest(t *testing.T) {
   "kind": "LambdaFunction",
   "spec": {
 	  "name": "SimpleFunction",
+	  "role": "arn:aws:iam::xxxxx:role/lambda-role",
 	  "image": "ecr.region.amazonaws.com/lambda-simple-function:v0.0.1"
   }
 }`,
@@ -42,6 +43,7 @@ func TestparseFunctionManifest(t *testing.T) {
 				APIVersion: "pipecd.dev/v1beta1",
 				Spec: FunctionManifestSpec{
 					Name:     "SimpleFunction",
+					Role:     "arn:aws:iam::xxxxx:role/lambda-role",
 					ImageURI: "ecr.region.amazonaws.com/lambda-simple-function:v0.0.1",
 				},
 			},

--- a/pkg/app/piped/cloudprovider/lambda/lambda.go
+++ b/pkg/app/piped/cloudprovider/lambda/lambda.go
@@ -28,7 +28,7 @@ import (
 const DefaultFunctionManifestFilename = "function.yaml"
 
 type Client interface {
-	Apply(ctx context.Context, fm FunctionManifest, role string) error
+	Apply(ctx context.Context, fm FunctionManifest) error
 }
 
 type Registry interface {

--- a/pkg/app/piped/executor/lambda/lambda.go
+++ b/pkg/app/piped/executor/lambda/lambda.go
@@ -90,7 +90,7 @@ func apply(ctx context.Context, in *executor.Input, cloudProviderName string, cl
 		return false
 	}
 
-	if err := client.Apply(ctx, fm, cloudProviderCfg.Role); err != nil {
+	if err := client.Apply(ctx, fm); err != nil {
 		in.LogPersister.Errorf("Failed to apply the lambda function manifest (%v)", err)
 		return false
 	}

--- a/pkg/config/piped.go
+++ b/pkg/config/piped.go
@@ -316,8 +316,6 @@ type CloudProviderLambdaConfig struct {
 	// e.g. "us-west-2"
 	// A full list of regions is: https://docs.aws.amazon.com/general/latest/gr/rande.html
 	Region string `json:"region"`
-	// The Amazon Resource Name (ARN) of the function's execution role.
-	Role string `json:"role"`
 	// Path to the shared credentials file.
 	//
 	// Piped attempts to retrieve credentials in the following order:


### PR DESCRIPTION
**What this PR does / why we need it**:

The role parameter passed to Create/Update Lambda application is the role set for the deploying lambda function (service role), not for the running agent (user role) to deploy it. So, I think it should be a part of FunctionManifest instead of CloudProviderConfig as the current design.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
