### PR TITLE
Update protobuf definitions for insights rpc

### DIFF
--- a/pkg/app/api/service/webservice/service.proto
+++ b/pkg/app/api/service/webservice/service.proto
@@ -452,5 +452,8 @@ message GetInsightDataRequest {
 
 message GetInsightDataResponse {
     int64 updated_at = 1;
-    repeated pipe.model.InsightDataPoint data_points = 2;
+    repeated pipe.model.InsightDataPoint data_points = 2 [deprecated = true];
+    pipe.model.InsightResultType type = 3;
+    repeated model.InsightSample vector = 4;
+    repeated model.InsightSampleStream matrix = 5;
 }

--- a/pkg/model/insight.proto
+++ b/pkg/model/insight.proto
@@ -19,6 +19,21 @@ option go_package = "github.com/pipe-cd/pipe/pkg/model";
 
 import "validate/validate.proto";
 
+enum InsightResultType {
+  MATRIX = 0;
+  VECTOR = 1;
+}
+
+message InsightSample {
+  map<string,string> labels = 1;
+  InsightDataPoint data_point = 2;
+}
+
+message InsightSampleStream {
+  map<string,string> labels = 1;
+  repeated InsightDataPoint data_points = 2;
+}
+
 message InsightDataPoint {
   int64 timestamp = 1 [(validate.rules).int64.gt = 0];
   float value = 2 [(validate.rules).float.gt = 0];
@@ -29,6 +44,7 @@ enum InsightMetricsKind {
   CHANGE_FAILURE_RATE = 1;
   MTTR = 2;
   LEAD_TIME = 3;
+  APPLICATIONS_COUNT = 4;
 }
 
 enum InsightStep {


### PR DESCRIPTION
**What this PR does / why we need it**:

- Add GetInsightPieChartData definition.
- Rename GetInsightData to GetInsightMetricsData.
- Propose to determine the type of response by the type of graph. This is because the processing of the request may differ depending on the content of the graph, but the format of the response is the same for the same graph type
  - So I named `GetInsightDataPointsResponse `, not `GetInsightMetricsDataResponse`
  
**Which issue(s) this PR fixes**:

Ref #1436 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
