### PR TITLE
Fix to directly use WAIT_APPROVAL timeout

### DIFF
--- a/docs/content/en/docs/user-guide/adding-a-manual-approval.md
+++ b/docs/content/en/docs/user-guide/adding-a-manual-approval.md
@@ -19,6 +19,7 @@ spec:
       - name: K8S_CANARY_ROLLOUT
       - name: WAIT_APPROVAL
         with:
+          timeout: 6h
           approvers:
             - user-abc
       - name: K8S_PRIMARY_ROLLOUT
@@ -29,6 +30,8 @@ As above example, the deployment requires an approval from `user-abc` before `K8
 The value of user ID in the `approvers` list depends on your [SSO configuration](/docs/operator-manual/control-plane/auth/), it must be GitHub's user ID if your SSO was configured to use GitHub provider, it must be Gmail account if your SSO was configured to use Google provider.
 
 In case the `approvers` field was not configured, anyone in the project who has `Editor` or `Admin` role can approve the deployment pipeline.
+
+Also, it will end with failure when the time specified in `timeout` has elapsed. Default is `6h`.
 
 ![](/images/deployment-wait-approval-stage.png)
 <p style="text-align: center;">

--- a/pkg/app/piped/executor/waitapproval/waitapproval.go
+++ b/pkg/app/piped/executor/waitapproval/waitapproval.go
@@ -54,8 +54,8 @@ func (e *Executor) Execute(sig executor.StopSignal) model.StageStatus {
 		ticker         = time.NewTicker(5 * time.Second)
 	)
 	defer ticker.Stop()
-
-	timer := time.NewTimer(time.Duration(e.StageConfig.WaitApprovalStageOptions.Timeout) * time.Second)
+	timeout := time.Duration(e.StageConfig.WaitApprovalStageOptions.Timeout)
+	timer := time.NewTimer(timeout)
 
 	e.LogPersister.Info("Waiting for an approval...")
 	for {
@@ -76,7 +76,7 @@ func (e *Executor) Execute(sig executor.StopSignal) model.StageStatus {
 				return model.StageStatus_STAGE_FAILURE
 			}
 		case <-timer.C:
-			e.LogPersister.Errorf("Timed out %v", e.StageConfig.WaitApprovalStageOptions.Timeout)
+			e.LogPersister.Errorf("Timed out %v", timeout)
 			return model.StageStatus_STAGE_FAILURE
 		}
 	}

--- a/pkg/app/piped/executor/waitapproval/waitapproval.go
+++ b/pkg/app/piped/executor/waitapproval/waitapproval.go
@@ -54,7 +54,7 @@ func (e *Executor) Execute(sig executor.StopSignal) model.StageStatus {
 		ticker         = time.NewTicker(5 * time.Second)
 	)
 	defer ticker.Stop()
-	timeout := time.Duration(e.StageConfig.WaitApprovalStageOptions.Timeout)
+	timeout := e.StageConfig.WaitApprovalStageOptions.Timeout.Duration()
 	timer := time.NewTimer(timeout)
 
 	e.LogPersister.Info("Waiting for an approval...")

--- a/pkg/config/deployment.go
+++ b/pkg/config/deployment.go
@@ -237,6 +237,7 @@ type WaitStageOptions struct {
 // WaitStageOptions contains all configurable values for a WAIT_APPROVAL stage.
 type WaitApprovalStageOptions struct {
 	// The maximum length of time to wait before giving up.
+	// Defaults to 6h.
 	Timeout   Duration `json:"timeout"`
 	Approvers []string `json:"approvers"`
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
We just need to use it directly. It could overflow.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
