### PR TITLE
Using aws.StringValue and destructuring map with key value pair

### DIFF
--- a/pkg/app/piped/cloudprovider/lambda/client.go
+++ b/pkg/app/piped/cloudprovider/lambda/client.go
@@ -263,7 +263,7 @@ func (c *client) GetTrafficConfig(ctx context.Context, fm FunctionManifest) (rou
 	// RoutingConfig.AdditionalVersionWeights key represents the secondary version.
 	var secondaryVersionTraffic float64
 	for version, weight := range cfg.RoutingConfig.AdditionalVersionWeights {
-		secondaryVersionTraffic = percentageToPercent(weight)
+		secondaryVersionTraffic = percentageToPercent(aws.Float64Value(weight))
 		routingTrafficCfg["secondary"] = VersionTraffic{
 			Version: version,
 			Percent: secondaryVersionTraffic,

--- a/pkg/app/piped/cloudprovider/lambda/client.go
+++ b/pkg/app/piped/cloudprovider/lambda/client.go
@@ -190,7 +190,7 @@ func (c *client) PublishFunction(ctx context.Context, fm FunctionManifest) (vers
 		}
 		return
 	}
-	version = *cfg.Version
+	version = aws.StringValue(cfg.Version)
 	return
 }
 
@@ -254,24 +254,24 @@ func (c *client) GetTrafficConfig(ctx context.Context, fm FunctionManifest) (rou
 	// In case RoutingConfig is nil, 100 percent of current traffic is handled by FunctionVersion version.
 	if cfg.RoutingConfig == nil {
 		routingTrafficCfg["primary"] = VersionTraffic{
-			Version: *cfg.FunctionVersion,
+			Version: aws.StringValue(cfg.FunctionVersion),
 			Percent: 100,
 		}
 		return
 	}
 	// In case RoutingConfig is provided, FunctionVersion value represents the primary version while
 	// RoutingConfig.AdditionalVersionWeights key represents the secondary version.
-	var newerVersionTraffic float64
-	for version := range cfg.RoutingConfig.AdditionalVersionWeights {
-		newerVersionTraffic = percentageToPercent(*cfg.RoutingConfig.AdditionalVersionWeights[version])
+	var secondaryVersionTraffic float64
+	for version, weight := range cfg.RoutingConfig.AdditionalVersionWeights {
+		secondaryVersionTraffic = percentageToPercent(weight)
 		routingTrafficCfg["secondary"] = VersionTraffic{
 			Version: version,
-			Percent: newerVersionTraffic,
+			Percent: secondaryVersionTraffic,
 		}
 	}
 	routingTrafficCfg["primary"] = VersionTraffic{
-		Version: *cfg.FunctionVersion,
-		Percent: 100 - newerVersionTraffic,
+		Version: aws.StringValue(cfg.FunctionVersion),
+		Percent: 100 - secondaryVersionTraffic,
 	}
 
 	return


### PR DESCRIPTION
**What this PR does / why we need it**:

Some minor fix on implementation of `lambda cloud provider`.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
