### PR TITLE
Update chart-releaser to fix cache-control when storing index file

### DIFF
--- a/dockers/chart-releaser/DOCKER_BUILD
+++ b/dockers/chart-releaser/DOCKER_BUILD
@@ -1,2 +1,2 @@
-version: 1.0.0
+version: 1.1.0
 registry: gcr.io/pipecd/chart-releaser

--- a/dockers/chart-releaser/main.go
+++ b/dockers/chart-releaser/main.go
@@ -132,6 +132,7 @@ func main() {
 			return nil
 		}
 		log.Printf("Start uploading package %s...", info.Name())
+		// We do not disable cache in this case because Helm packages are immutable.
 		return storeFile(ctx, client, path, false)
 	})
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #1477

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
