### PR TITLE
Remove useCredentialsFile flag field from GCS new client implementation

### DIFF
--- a/pkg/filestore/gcs/gcs.go
+++ b/pkg/filestore/gcs/gcs.go
@@ -29,19 +29,17 @@ import (
 )
 
 type Store struct {
-	client             *storage.Client
-	bucket             string
-	useCredentialsFile bool
-	credentialsFile    string
-	httpClient         *http.Client
-	logger             *zap.Logger
+	client          *storage.Client
+	bucket          string
+	credentialsFile string
+	httpClient      *http.Client
+	logger          *zap.Logger
 }
 
 type Option func(*Store)
 
 func WithCredentialsFile(path string) Option {
 	return func(s *Store) {
-		s.useCredentialsFile = true
 		s.credentialsFile = path
 	}
 }
@@ -68,7 +66,7 @@ func NewStore(ctx context.Context, bucket string, opts ...Option) (*Store, error
 	}
 
 	var options []option.ClientOption
-	if s.useCredentialsFile {
+	if s.credentialsFile != "" {
 		options = append(options, option.WithCredentialsFile(s.credentialsFile))
 	}
 	if s.httpClient != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

I checked the calling side, looks like we could remove this redundant flag field to simplify gcs `NewStore` implementation.

https://github.com/pipe-cd/pipe/blob/82c949857892ae0b29b005deffa5c80db23a4859/cmd/pipecd/server.go#L438-L441

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
