### PR TITLE
Use alpine as a pipectl base image

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -144,6 +144,14 @@ container_pull(
     tag = "0.0.1",
 )
 
+container_pull(
+    name = "alpine",
+    digest = "sha256:d0710affa17fad5f466a70159cc458227bd25d4afb39514ef662ead3e6c99515",
+    registry = "index.docker.io",
+    repository = "alpine",
+    tag = "3.13",
+)
+
 ### Protoc-gen-validate
 git_repository(
     name = "com_github_envoyproxy_protoc_gen_validate",

--- a/cmd/pipectl/BUILD.bazel
+++ b/cmd/pipectl/BUILD.bazel
@@ -22,6 +22,7 @@ go_binary(
 
 app_image(
     name = "pipectl_app",
+    base = "@alpine//image",
     binary = ":pipectl",
     repository = "pipectl",
     visibility = ["//visibility:public"],


### PR DESCRIPTION
**What this PR does / why we need it**:
The `go_image` rule uses `distroless` base runtime images, which makes Kapetanios runner unavailable because they lack even a basic shell for exploring the filesystem.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
