### PR TITLE
Refactor error handling for rc.Close in GetObject function GCS storage

### DIFF
--- a/test/integration/filestore/gcs/gcs_test.go
+++ b/test/integration/filestore/gcs/gcs_test.go
@@ -73,11 +73,9 @@ func TestGetObject(t *testing.T) {
 			wantErr: nil,
 		},
 		{
-			name: "not found",
-			path: "path/to/wrong.txt",
-			want: filestore.Object{
-				Path: "path/to/wrong.txt",
-			},
+			name:    "not found",
+			path:    "path/to/wrong.txt",
+			want:    filestore.Object{},
 			wantErr: filestore.ErrNotFound,
 		},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Unify error handling for `rc.Close()` in GetObject function of GCS storage.
ref: https://github.com/pipe-cd/pipe/pull/1485#discussion_r564272156

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
