### PR TITLE
Fix schema mistake in the document of SealedSecret

### DIFF
--- a/docs/content/en/docs/user-guide/sealed-secrets.md
+++ b/docs/content/en/docs/user-guide/sealed-secrets.md
@@ -78,7 +78,7 @@ spec:
     metadata:
         name: simple-sealed-secret
     data:
-      password={{ .encryptedItems.password }}
+      password: {{ .encryptedItems.password }}
   encryptedItems:
     password: encrypted-data
 ```


### PR DESCRIPTION
**What this PR does / why we need it**:

The `data` parameter of Secret should be a map type.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
