### PR TITLE
Add copy button for piped id

### DIFF
--- a/pkg/app/web/src/constants/toast-text.ts
+++ b/pkg/app/web/src/constants/toast-text.ts
@@ -11,6 +11,7 @@ export const COPY_API_KEY = "API Key copied to clipboard.";
 // Piped
 export const ADD_PIPED_SUCCESS = "Successfully added Piped.";
 export const UPDATE_PIPED_SUCCESS = "Successfully updated Piped.";
+export const COPY_PIPED_ID = "Piped ID copied to clipboard.";
 
 // Application
 export const DELETE_APPLICATION_SUCCESS = "Successfully deleted Application.";

--- a/pkg/app/web/src/pages/settings/piped/index.tsx
+++ b/pkg/app/web/src/pages/settings/piped/index.tsx
@@ -150,7 +150,8 @@ export const SettingsPipedPage: FC = memo(function SettingsPipedPage() {
           <Table aria-label="piped list" size="small" stickyHeader>
             <TableHead>
               <TableRow>
-                <TableCell colSpan={2}>Name</TableCell>
+                <TableCell>Name</TableCell>
+                <TableCell />
                 <TableCell>Version</TableCell>
                 <TableCell>Description</TableCell>
                 <TableCell>Started At</TableCell>

--- a/pkg/app/web/src/pages/settings/piped/index.tsx
+++ b/pkg/app/web/src/pages/settings/piped/index.tsx
@@ -151,7 +151,7 @@ export const SettingsPipedPage: FC = memo(function SettingsPipedPage() {
             <TableHead>
               <TableRow>
                 <TableCell>Name</TableCell>
-                <TableCell />
+                <TableCell>ID</TableCell>
                 <TableCell>Version</TableCell>
                 <TableCell>Description</TableCell>
                 <TableCell>Started At</TableCell>

--- a/pkg/app/web/src/pages/settings/piped/index.tsx
+++ b/pkg/app/web/src/pages/settings/piped/index.tsx
@@ -150,7 +150,7 @@ export const SettingsPipedPage: FC = memo(function SettingsPipedPage() {
           <Table aria-label="piped list" size="small" stickyHeader>
             <TableHead>
               <TableRow>
-                <TableCell>Name</TableCell>
+                <TableCell colSpan={2}>Name</TableCell>
                 <TableCell>Version</TableCell>
                 <TableCell>Description</TableCell>
                 <TableCell>Started At</TableCell>

--- a/pkg/app/web/src/pages/settings/piped/piped-table-row.tsx
+++ b/pkg/app/web/src/pages/settings/piped/piped-table-row.tsx
@@ -7,23 +7,35 @@ import {
   TableRow,
   Typography,
 } from "@material-ui/core";
-import { MoreVert as MoreVertIcon } from "@material-ui/icons";
+import {
+  FileCopyOutlined as CopyIcon,
+  MoreVert as MoreVertIcon,
+} from "@material-ui/icons";
 import clsx from "clsx";
+import copy from "copy-to-clipboard";
 import dayjs from "dayjs";
 import React, { FC, memo, useCallback, useState } from "react";
-import { useSelector } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
+import { COPY_PIPED_ID } from "../../../constants/toast-text";
 import {
-  UI_TEXT_EDIT,
   UI_TEXT_DISABLE,
+  UI_TEXT_EDIT,
   UI_TEXT_ENABLE,
   UI_TEXT_RECREATE_KEY,
 } from "../../../constants/ui-text";
 import { AppState } from "../../../modules";
 import { Piped, selectById } from "../../../modules/pipeds";
+import { addToast } from "../../../modules/toasts";
 
 const useStyles = makeStyles((theme) => ({
   disabledItem: {
     background: theme.palette.grey[200],
+  },
+  copyButton: {
+    visibility: "hidden",
+    "tr:hover &": {
+      visibility: "visible",
+    },
   },
 }));
 
@@ -54,6 +66,7 @@ export const PipedTableRow: FC<Props> = memo(function PipedTableRow({
   const piped = useSelector<AppState, Piped.AsObject | undefined>((state) =>
     selectById(state.pipeds, pipedId)
   );
+  const dispatch = useDispatch();
   const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
 
   const handleMenuOpen = useCallback(
@@ -87,6 +100,13 @@ export const PipedTableRow: FC<Props> = memo(function PipedTableRow({
     onDisable(pipedId);
   }, [pipedId, onDisable]);
 
+  const handleCopy = useCallback(() => {
+    if (piped) {
+      copy(piped.id);
+      dispatch(addToast({ message: COPY_PIPED_ID }));
+    }
+  }, [piped]);
+
   if (!piped) {
     return null;
   }
@@ -102,6 +122,15 @@ export const PipedTableRow: FC<Props> = memo(function PipedTableRow({
           <Typography variant="subtitle2">
             {`${piped.name} (${piped.id.slice(0, 8)})`}
           </Typography>
+        </TableCell>
+        <TableCell>
+          <IconButton
+            className={classes.copyButton}
+            aria-label="Copy piped id"
+            onClick={handleCopy}
+          >
+            <CopyIcon />
+          </IconButton>
         </TableCell>
         <TableCell>{piped.version}</TableCell>
         <TableCell>

--- a/pkg/app/web/src/pages/settings/piped/piped-table-row.tsx
+++ b/pkg/app/web/src/pages/settings/piped/piped-table-row.tsx
@@ -105,7 +105,7 @@ export const PipedTableRow: FC<Props> = memo(function PipedTableRow({
       copy(piped.id);
       dispatch(addToast({ message: COPY_PIPED_ID }));
     }
-  }, [piped]);
+  }, [dispatch, piped]);
 
   if (!piped) {
     return null;
@@ -116,10 +116,9 @@ export const PipedTableRow: FC<Props> = memo(function PipedTableRow({
       <TableRow
         key={`pipe-${piped.id}`}
         className={clsx({ [classes.disabledItem]: piped.disabled })}
-        title={piped.id}
       >
         <TableCell>
-          <Typography variant="subtitle2">
+          <Typography variant="subtitle2" title={piped.id}>
             {`${piped.name} (${piped.id.slice(0, 8)})`}
           </Typography>
         </TableCell>

--- a/pkg/app/web/src/pages/settings/piped/piped-table-row.tsx
+++ b/pkg/app/web/src/pages/settings/piped/piped-table-row.tsx
@@ -1,4 +1,5 @@
 import {
+  Box,
   IconButton,
   makeStyles,
   Menu,
@@ -32,6 +33,7 @@ const useStyles = makeStyles((theme) => ({
     background: theme.palette.grey[200],
   },
   copyButton: {
+    marginLeft: theme.spacing(1),
     visibility: "hidden",
     "tr:hover &": {
       visibility: "visible",
@@ -118,18 +120,19 @@ export const PipedTableRow: FC<Props> = memo(function PipedTableRow({
         className={clsx({ [classes.disabledItem]: piped.disabled })}
       >
         <TableCell>
-          <Typography variant="subtitle2" title={piped.id}>
-            {`${piped.name} (${piped.id.slice(0, 8)})`}
-          </Typography>
+          <Typography variant="subtitle2">{piped.name}</Typography>
         </TableCell>
-        <TableCell>
-          <IconButton
-            className={classes.copyButton}
-            aria-label="Copy piped id"
-            onClick={handleCopy}
-          >
-            <CopyIcon />
-          </IconButton>
+        <TableCell title={piped.id}>
+          <Box display="flex" alignItems="center" fontFamily="Roboto Mono">
+            {piped.id}
+            <IconButton
+              className={classes.copyButton}
+              aria-label="Copy piped id"
+              onClick={handleCopy}
+            >
+              <CopyIcon />
+            </IconButton>
+          </Box>
         </TableCell>
         <TableCell>{piped.version}</TableCell>
         <TableCell>


### PR DESCRIPTION
**What this PR does / why we need it**:



https://user-images.githubusercontent.com/6136383/105983239-c68a7880-60db-11eb-9e4a-1e739e4cbbdf.mp4


**Show toast after copied id**

https://user-images.githubusercontent.com/6136383/105983236-c5594b80-60db-11eb-9452-3df9f0207a04.mp4


**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
The full ID of piped is shown and a new button was added to copy the ID
```
