### PR TITLE
Remove useCredentialsFile field from FireStore struct

### DIFF
--- a/pkg/datastore/firestore/firestore.go
+++ b/pkg/datastore/firestore/firestore.go
@@ -36,9 +36,8 @@ type FireStore struct {
 	namespace   string
 	environment string
 
-	useCredentialsFile bool
-	credentialsFile    string
-	logger             *zap.Logger
+	credentialsFile string
+	logger          *zap.Logger
 }
 
 func NewFireStore(ctx context.Context, projectID, namespace, environment string, opts ...Option) (*FireStore, error) {
@@ -56,7 +55,7 @@ func NewFireStore(ctx context.Context, projectID, namespace, environment string,
 	s.logger = s.logger.Named("firestore")
 
 	var options []option.ClientOption
-	if s.useCredentialsFile {
+	if s.credentialsFile != "" {
 		options = append(options, option.WithCredentialsFile(s.credentialsFile))
 	}
 
@@ -72,7 +71,6 @@ type Option func(*FireStore)
 
 func WithCredentialsFile(path string) Option {
 	return func(s *FireStore) {
-		s.useCredentialsFile = true
 		s.credentialsFile = path
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Remove useCredentialsFile from FireStore struct to simplify NewFireStore implementation.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
