### PR TITLE
Add pipectl to PATH for pipetcl-base image

### DIFF
--- a/dockers/pipectl-base/DOCKER_BUILD
+++ b/dockers/pipectl-base/DOCKER_BUILD
@@ -1,2 +1,2 @@
-version: 0.1.0
+version: 0.2.0
 registry: gcr.io/pipecd/pipectl-base

--- a/dockers/pipectl-base/Dockerfile
+++ b/dockers/pipectl-base/Dockerfile
@@ -1,3 +1,5 @@
 FROM alpine:3.13
 
+
+ENV PATH $PATH:/app/cmd/pipectl
 RUN apk add --no-cache git


### PR DESCRIPTION
**What this PR does / why we need it**:

This enables calling pipectl just by its name instead of its full path.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
