### PR TITLE
Fix the diffs on Istio's VirtualService always appear after deploying

### DIFF
--- a/pkg/app/piped/executor/kubernetes/testdata/generated-virtual-service-for-editable-routes.yaml
+++ b/pkg/app/piped/executor/kubernetes/testdata/generated-virtual-service-for-editable-routes.yaml
@@ -19,6 +19,12 @@ spec:
     - destination:
         host: helloworld
         subset: baseline
+  - name: zero-weights-were-not-specified
+    route:
+    - destination:
+        host: helloworld
+        subset: primary
+      weight: 100
   - match:
     - headers:
         end-user:

--- a/pkg/app/piped/executor/kubernetes/testdata/generated-virtual-service.yaml
+++ b/pkg/app/piped/executor/kubernetes/testdata/generated-virtual-service.yaml
@@ -34,6 +34,20 @@ spec:
         host: helloworld
         subset: baseline
       weight: 20
+  - name: zero-weights-were-not-specified
+    route:
+    - destination:
+        host: helloworld
+        subset: primary
+      weight: 50
+    - destination:
+        host: helloworld
+        subset: canary
+      weight: 30
+    - destination:
+        host: helloworld
+        subset: baseline
+      weight: 20
   - match:
     - headers:
         end-user:

--- a/pkg/app/piped/executor/kubernetes/testdata/virtual-service.yaml
+++ b/pkg/app/piped/executor/kubernetes/testdata/virtual-service.yaml
@@ -21,6 +21,12 @@ spec:
         host: helloworld
         subset: baseline
       weight: 0
+  - name: zero-weights-were-not-specified
+    route:
+    - destination:
+        host: helloworld
+        subset: primary
+      weight: 100
   - name: only-primary-destination
     match:
     - headers:

--- a/pkg/app/piped/executor/kubernetes/traffic_test.go
+++ b/pkg/app/piped/executor/kubernetes/traffic_test.go
@@ -32,12 +32,12 @@ func TestGenerateVirtualServiceManifest(t *testing.T) {
 		expectedFile   string
 	}{
 		{
-			name:         "generated correct manifest",
+			name:         "apply all routes",
 			manifestFile: "testdata/virtual-service.yaml",
 			expectedFile: "testdata/generated-virtual-service.yaml",
 		},
 		{
-			name:           "generated correct manifest",
+			name:           "apply only speficied routes",
 			manifestFile:   "testdata/virtual-service.yaml",
 			editableRoutes: []string{"only-primary-destination"},
 			expectedFile:   "testdata/generated-virtual-service-for-editable-routes.yaml",
@@ -61,7 +61,7 @@ func TestGenerateVirtualServiceManifest(t *testing.T) {
 			got, err := generatedManifest.YamlBytes()
 			require.NoError(t, err)
 
-			assert.EqualValues(t, expected, got)
+			assert.EqualValues(t, string(expected), string(got))
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

With the current implementation of K8S_TRAFFIC_ROUTING stage, it is also appending the zero-weight destinations into the VirtualService manifest. That causes the diffs after deploying when those destinations were not specified by users.

This pull request switches to directly use the manifest defined in the target commit when the primary weight is 100% to avoid those diffs.

**Which issue(s) this PR fixes**:

Fixes #1492

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
