### PR TITLE
Add mono font to the theme

### DIFF
--- a/pkg/app/web/src/components/approval-stage/approval-stage.tsx
+++ b/pkg/app/web/src/components/approval-stage/approval-stage.tsx
@@ -23,7 +23,7 @@ const useStyles = makeStyles((theme) => ({
     marginLeft: theme.spacing(1),
   },
   stageName: {
-    fontFamily: "Roboto Mono",
+    fontFamily: theme.typography.fontFamilyMono,
   },
   main: {
     display: "flex",

--- a/pkg/app/web/src/components/deployment-config-form/deployment-config-form.tsx
+++ b/pkg/app/web/src/components/deployment-config-form/deployment-config-form.tsx
@@ -28,11 +28,11 @@ const useStyles = makeStyles((theme) => ({
   },
   filename: {
     marginTop: theme.spacing(2),
-    fontFamily: "Roboto Mono",
+    fontFamily: theme.typography.fontFamilyMono,
     color: theme.palette.text.secondary,
   },
   templateContent: {
-    fontFamily: "Roboto Mono",
+    fontFamily: theme.typography.fontFamilyMono,
     fontSize: 14,
   },
   linkIcon: {

--- a/pkg/app/web/src/components/diff-view/diff-view.tsx
+++ b/pkg/app/web/src/components/diff-view/diff-view.tsx
@@ -5,7 +5,7 @@ import green from "@material-ui/core/colors/green";
 
 const useStyles = makeStyles((theme) => ({
   root: {
-    fontFamily: "Roboto Mono",
+    fontFamily: theme.typography.fontFamilyMono,
     wordBreak: "break-all",
     whiteSpace: "pre-wrap",
   },

--- a/pkg/app/web/src/components/log-viewer/log-viewer.tsx
+++ b/pkg/app/web/src/components/log-viewer/log-viewer.tsx
@@ -67,7 +67,7 @@ const useStyles = makeStyles((theme) => ({
     display: "flex",
   },
   stageName: {
-    fontFamily: "Roboto Mono",
+    fontFamily: theme.typography.fontFamilyMono,
   },
   stageDescription: {
     marginLeft: theme.spacing(2),

--- a/pkg/app/web/src/components/log/log.tsx
+++ b/pkg/app/web/src/components/log/log.tsx
@@ -6,7 +6,7 @@ import { LogBlock } from "../../modules/stage-logs";
 
 const useStyles = makeStyles((theme) => ({
   container: {
-    fontFamily: "Roboto Mono",
+    fontFamily: theme.typography.fontFamilyMono,
     backgroundColor: DEFAULT_BACKGROUND_COLOR,
     paddingTop: theme.spacing(1),
     paddingBottom: theme.spacing(1),

--- a/pkg/app/web/src/components/pipeline-stage/pipeline-stage.tsx
+++ b/pkg/app/web/src/components/pipeline-stage/pipeline-stage.tsx
@@ -34,7 +34,7 @@ const useStyles = makeStyles((theme) => ({
     overflow: "hidden",
   },
   stageName: {
-    fontFamily: "Roboto Mono",
+    fontFamily: theme.typography.fontFamilyMono,
   },
   main: {
     display: "flex",

--- a/pkg/app/web/src/components/sync-state-reason/sync-state-reason.tsx
+++ b/pkg/app/web/src/components/sync-state-reason/sync-state-reason.tsx
@@ -9,7 +9,7 @@ const useStyles = makeStyles((theme) => ({
   },
   detail: {
     padding: theme.spacing(2),
-    fontFamily: "Roboto Mono",
+    fontFamily: theme.typography.fontFamilyMono,
     marginTop: theme.spacing(1),
     wordBreak: "break-all",
     overflow: "auto",

--- a/pkg/app/web/src/pages/settings/piped/piped-table-row.tsx
+++ b/pkg/app/web/src/pages/settings/piped/piped-table-row.tsx
@@ -123,7 +123,7 @@ export const PipedTableRow: FC<Props> = memo(function PipedTableRow({
           <Typography variant="subtitle2">{piped.name}</Typography>
         </TableCell>
         <TableCell title={piped.id}>
-          <Box display="flex" alignItems="center" fontFamily="Roboto Mono">
+          <Box display="flex" alignItems="center" fontFamily="fontFamilyMono">
             {piped.id}
             <IconButton
               className={classes.copyButton}

--- a/pkg/app/web/src/theme.ts
+++ b/pkg/app/web/src/theme.ts
@@ -1,6 +1,16 @@
 import { createMuiTheme } from "@material-ui/core/styles";
 import cyan from "@material-ui/core/colors/cyan";
 
+declare module "@material-ui/core/styles/createTypography" {
+  interface FontStyle {
+    fontFamilyMono: string;
+  }
+
+  interface FontStyleOptions {
+    fontFamilyMono: string;
+  }
+}
+
 export const theme = createMuiTheme({
   props: {
     MuiButtonBase: {
@@ -59,5 +69,7 @@ export const theme = createMuiTheme({
     subtitle2: {
       fontWeight: 600,
     },
+    fontFamilyMono:
+      '"Roboto Mono",SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace',
   },
 });


### PR DESCRIPTION
**What this PR does / why we need it**:

We used to use `Roboto Mono` directly, but now we can use it via `theme`.

### Before

```ts
const useStyles = makeStyles((theme => ({
  module: {
    fontFamily: 'Roboto Mono'
  }
});
```

### After

```ts
const useStyles = makeStyles((theme => ({
  module: {
    fontFamily: theme.typography.fontFamilyMono
  }
});
```

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
