### PR TITLE
Remove setTimeout from closing menu and dialog

### DIFF
--- a/pkg/app/web/src/components/application-list/application-list.tsx
+++ b/pkg/app/web/src/components/application-list/application-list.tsx
@@ -56,9 +56,7 @@ export const ApplicationList: FC = memo(function ApplicationList() {
   );
 
   const closeMenu = useCallback(() => {
-    setTimeout(() => {
-      setActionTarget(null);
-    }, 200);
+    setActionTarget(null);
   }, []);
 
   const handleOnCloseGenerateDialog = (): void => {

--- a/pkg/app/web/src/components/sealed-secret-dialog/sealed-secret-dialog.tsx
+++ b/pkg/app/web/src/components/sealed-secret-dialog/sealed-secret-dialog.tsx
@@ -98,12 +98,9 @@ export const SealedSecretDialog: FC<Props> = memo(function SealedSecretDialog({
     formik.resetForm();
   }, [formik]);
 
-  const handleOnExited = (): void => {
-    // Clear state after closed dialog
-    setTimeout(() => {
-      dispatch(clearSealedSecret());
-    }, 200);
-  };
+  const handleOnExited = useCallback(() => {
+    dispatch(clearSealedSecret());
+  }, [dispatch]);
 
   const handleOnClickCopy = useCallback(() => {
     dispatch(addToast({ message: "Secret copied to clipboard" }));


### PR DESCRIPTION
**What this PR does / why we need it**:

* `setTimeout` was no longer necessary.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
