### PR TITLE
Use goccy/go-yaml.Read instead of parsing ourselves

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/envoyproxy/protoc-gen-validate v0.1.0
 	github.com/fsnotify/fsnotify v1.4.9 // indirect
 	github.com/fsouza/fake-gcs-server v1.21.0
-	github.com/goccy/go-yaml v1.8.4
+	github.com/goccy/go-yaml v1.8.7
 	github.com/golang/mock v1.4.4
 	github.com/golang/protobuf v1.4.2
 	github.com/gomodule/redigo v2.0.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -188,8 +188,8 @@ github.com/gobuffalo/packd v0.1.0/go.mod h1:M2Juc+hhDXf/PnmBANFCqx4DM3wRbgDvnVWe
 github.com/gobuffalo/packr/v2 v2.0.9/go.mod h1:emmyGweYTm6Kdper+iywB6YK5YzuKchGtJQZ0Odn4pQ=
 github.com/gobuffalo/packr/v2 v2.2.0/go.mod h1:CaAwI0GPIAv+5wKLtv8Afwl+Cm78K/I/VCm/3ptBN+0=
 github.com/gobuffalo/syncx v0.0.0-20190224160051-33c29581e754/go.mod h1:HhnNqWY95UYwwW3uSASeV7vtgYkT2t16hJgV3AEPUpw=
-github.com/goccy/go-yaml v1.8.4 h1:AOEdR7aQgbgwHznGe3BLkDQVujxCPUpHOZZcQcp8Y3M=
-github.com/goccy/go-yaml v1.8.4/go.mod h1:U/jl18uSupI5rdI2jmuCswEA2htH9eXfferR3KfscvA=
+github.com/goccy/go-yaml v1.8.7 h1:IAGui0h0QUFuI7hZ3wiJGuUpgKqiM7IqMarccnpXzdc=
+github.com/goccy/go-yaml v1.8.7/go.mod h1:U/jl18uSupI5rdI2jmuCswEA2htH9eXfferR3KfscvA=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/gogo/protobuf v1.3.0/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=

--- a/pkg/yamlprocessor/yamlprocessor.go
+++ b/pkg/yamlprocessor/yamlprocessor.go
@@ -48,21 +48,10 @@ func GetValue(yml []byte, path string) (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	// Build an AST node based on the given path.
-	node, err := p.ReadNode(bytes.NewReader(yml))
-	if err != nil {
-		return nil, err
-	}
-	if node == nil {
-		return nil, fmt.Errorf("wrong path (%s) given", path)
-	}
 
-	// TODO: Disallow yamlprocessor panic if the value is -0
-	// TODO: Use goyaml.Read() upon merging our patch
-	// https://github.com/goccy/go-yaml/pull/194
 	var value interface{}
-	if err := goyaml.Unmarshal([]byte(node.String()), &value); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal the node placed at the given path: %w", err)
+	if err := p.Read(bytes.NewReader(yml), &value); err != nil {
+		return nil, err
 	}
 	return value, nil
 }

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -465,8 +465,8 @@ def go_repositories():
     go_repository(
         name = "com_github_goccy_go_yaml",
         importpath = "github.com/goccy/go-yaml",
-        sum = "h1:AOEdR7aQgbgwHznGe3BLkDQVujxCPUpHOZZcQcp8Y3M=",
-        version = "v1.8.4",
+        sum = "h1:IAGui0h0QUFuI7hZ3wiJGuUpgKqiM7IqMarccnpXzdc=",
+        version = "v1.8.7",
     )
 
     go_repository(


### PR DESCRIPTION
**What this PR does / why we need it**:
Since https://github.com/goccy/go-yaml/pull/194 has been merged and released, we can close https://github.com/pipe-cd/pipe/issues/1531.

Besides, https://github.com/goccy/go-yaml/pull/196 is soon-to-be-released, hence we can also close https://github.com/pipe-cd/pipe/issues/1530.

**Which issue(s) this PR fixes**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
