### PR TITLE
Fixed the type of set-files for helm in the document

### DIFF
--- a/docs/content/en/docs/user-guide/configuration-reference.md
+++ b/docs/content/en/docs/user-guide/configuration-reference.md
@@ -196,7 +196,7 @@ spec:
 |-|-|-|-|
 | releaseName | string | The release name of helm deployment. By default, the release name is equal to the application name. | No |
 | valueFiles | []string | List of value files should be loaded. | No |
-| setFiles | []string | List of file path for values. | No |
+| setFiles | map[string]string | List of file path for values. | No |
 
 ## KubernetesQuickSync
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The type of `SetFiles` is a map.

https://github.com/pipe-cd/pipe/blob/98977685aa688cef282e92d4958b956c6a43ce3b/pkg/config/deployment_kubernetes.go#L97

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
