### PR TITLE
Add pipecd-base image

### DIFF
--- a/dockers/pipecd-base/DOCKER_BUILD
+++ b/dockers/pipecd-base/DOCKER_BUILD
@@ -1,0 +1,2 @@
+version: 0.1.0
+registry: gcr.io/pipecd/pipecd-base

--- a/dockers/pipecd-base/Dockerfile
+++ b/dockers/pipecd-base/Dockerfile
@@ -7,7 +7,7 @@ RUN \
         python3 \
         curl && \
     curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${GOOGLE_CLOUD_SDK_VERSION}-linux-x86.tar.gz && \
-    tar -zxvf ./google-cloud-sdk-324.0.0-linux-x86.tar.gz && \
+    tar -zxvf ./google-cloud-sdk-${GOOGLE_CLOUD_SDK_VERSION}-linux-x86.tar.gz && \
     ./google-cloud-sdk/install.sh --quiet
 
 ENV PATH="/google-cloud-sdk/bin:${PATH}"

--- a/dockers/pipecd-base/Dockerfile
+++ b/dockers/pipecd-base/Dockerfile
@@ -1,9 +1,12 @@
-FROM python:alpine3.13
+FROM alpine:3.13
+
+ARG GOOGLE_CLOUD_SDK_VERSION=324.0.0
 
 RUN \
     apk add --no-cache \
+        python3 \
         curl && \
-    curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-324.0.0-linux-x86.tar.gz && \
+    curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${GOOGLE_CLOUD_SDK_VERSION}-linux-x86.tar.gz && \
     tar -zxvf ./google-cloud-sdk-324.0.0-linux-x86.tar.gz && \
     ./google-cloud-sdk/install.sh --quiet
 

--- a/dockers/pipecd-base/Dockerfile
+++ b/dockers/pipecd-base/Dockerfile
@@ -1,1 +1,10 @@
-FROM gcr.io/google.com/cloudsdktool/cloud-sdk:326.0.0-alpine
+FROM python:alpine3.13
+
+RUN \
+    apk add --no-cache \
+        curl && \
+    curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-324.0.0-linux-x86.tar.gz && \
+    tar -zxvf ./google-cloud-sdk-324.0.0-linux-x86.tar.gz && \
+    ./google-cloud-sdk/install.sh --quiet
+
+ENV PATH="/google-cloud-sdk/bin:${PATH}"

--- a/dockers/pipecd-base/Dockerfile
+++ b/dockers/pipecd-base/Dockerfile
@@ -1,0 +1,1 @@
+FROM gcr.io/google.com/cloudsdktool/cloud-sdk:326.0.0-alpine


### PR DESCRIPTION
**What this PR does / why we need it**:
To run the gcloud command in an Ops process, pre-installed Google SDK is definitely needed.

**Which issue(s) this PR fixes**:

Ref https://github.com/pipe-cd/pipe/issues/1471

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
