### PR TITLE
Skip creating Firestore indexes if already added

### DIFF
--- a/pkg/app/ops/firestoreindexensurer/indexes.json
+++ b/pkg/app/ops/firestoreindexensurer/indexes.json
@@ -1,209 +1,306 @@
-{
-  "indexes": [
-    {
-      "collectionGroup": "Application",
-      "queryScope": "COLLECTION",
-      "fields": [
-        {
-          "fieldPath": "Deleted",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "CreatedAt",
-          "order": "ASCENDING"
-        }
-      ]
-    },
-    {
-      "collectionGroup": "Application",
-      "queryScope": "COLLECTION",
-      "fields": [
-        {
-          "fieldPath": "Disabled",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "UpdatedAt",
-          "order": "DESCENDING"
-        }
-      ]
-    },
-    {
-      "collectionGroup": "Application",
-      "queryScope": "COLLECTION",
-      "fields": [
-        {
-          "fieldPath": "EnvId",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "UpdatedAt",
-          "order": "DESCENDING"
-        }
-      ]
-    },
-    {
-      "collectionGroup": "Application",
-      "queryScope": "COLLECTION",
-      "fields": [
-        {
-          "fieldPath": "Kind",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "UpdatedAt",
-          "order": "DESCENDING"
-        }
-      ]
-    },
-    {
-      "collectionGroup": "Application",
-      "queryScope": "COLLECTION",
-      "fields": [
-        {
-          "fieldPath": "ProjectId",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "UpdatedAt",
-          "order": "DESCENDING"
-        }
-      ]
-    },
-    {
-      "collectionGroup": "Application",
-      "queryScope": "COLLECTION",
-      "fields": [
-        {
-          "fieldPath": "SyncState.Status",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "UpdatedAt",
-          "order": "DESCENDING"
-        }
-      ]
-    },
-    {
-      "collectionGroup": "Command",
-      "queryScope": "COLLECTION",
-      "fields": [
-        {
-          "fieldPath": "Status",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "CreatedAt",
-          "order": "ASCENDING"
-        }
-      ]
-    },
-    {
-      "collectionGroup": "Deployment",
-      "queryScope": "COLLECTION",
-      "fields": [
-        {
-          "fieldPath": "ApplicationId",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "UpdatedAt",
-          "order": "DESCENDING"
-        }
-      ]
-    },
-    {
-      "collectionGroup": "Deployment",
-      "queryScope": "COLLECTION",
-      "fields": [
-        {
-          "fieldPath": "EnvId",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "UpdatedAt",
-          "order": "DESCENDING"
-        }
-      ]
-    },
-    {
-      "collectionGroup": "Deployment",
-      "queryScope": "COLLECTION",
-      "fields": [
-        {
-          "fieldPath": "Kind",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "UpdatedAt",
-          "order": "DESCENDING"
-        }
-      ]
-    },
-    {
-      "collectionGroup": "Deployment",
-      "queryScope": "COLLECTION",
-      "fields": [
-        {
-          "fieldPath": "ProjectId",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "UpdatedAt",
-          "order": "DESCENDING"
-        }
-      ]
-    },
-    {
-      "collectionGroup": "Deployment",
-      "queryScope": "COLLECTION",
-      "fields": [
-        {
-          "fieldPath": "Status",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "UpdatedAt",
-          "order": "DESCENDING"
-        }
-      ]
-    },
-    {
-      "collectionGroup": "Event",
-      "queryScope": "COLLECTION",
-      "fields": [
-        {
-          "fieldPath": "EventKey",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "Name",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "ProjectId",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "CreatedAt",
-          "order": "DESCENDING"
-        }
-      ]
-    },
-    {
-      "collectionGroup": "Event",
-      "queryScope": "COLLECTION",
-      "fields": [
-        {
-          "fieldPath": "ProjectId",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "CreatedAt",
-          "order": "ASCENDING"
-        }
-      ]
-    }
-  ],
-  "fieldOverrides": []
-}
+[
+  {
+    "collectionGroup": "Application",
+    "queryScope": "COLLECTION",
+    "fields": [
+      {
+        "fieldPath": "Disabled",
+        "order": "ASCENDING",
+        "arrayConfig": ""
+      },
+      {
+        "fieldPath": "UpdatedAt",
+        "order": "DESCENDING",
+        "arrayConfig": ""
+      },
+      {
+        "fieldPath": "__name__",
+        "order": "DESCENDING",
+        "arrayConfig": ""
+      }
+    ]
+  },
+  {
+    "collectionGroup": "Application",
+    "queryScope": "COLLECTION",
+    "fields": [
+      {
+        "fieldPath": "EnvId",
+        "order": "ASCENDING",
+        "arrayConfig": ""
+      },
+      {
+        "fieldPath": "UpdatedAt",
+        "order": "DESCENDING",
+        "arrayConfig": ""
+      },
+      {
+        "fieldPath": "__name__",
+        "order": "DESCENDING",
+        "arrayConfig": ""
+      }
+    ]
+  },
+  {
+    "collectionGroup": "Application",
+    "queryScope": "COLLECTION",
+    "fields": [
+      {
+        "fieldPath": "Deleted",
+        "order": "ASCENDING",
+        "arrayConfig": ""
+      },
+      {
+        "fieldPath": "CreatedAt",
+        "order": "ASCENDING",
+        "arrayConfig": ""
+      },
+      {
+        "fieldPath": "__name__",
+        "order": "ASCENDING",
+        "arrayConfig": ""
+      }
+    ]
+  },
+  {
+    "collectionGroup": "Application",
+    "queryScope": "COLLECTION",
+    "fields": [
+      {
+        "fieldPath": "Kind",
+        "order": "ASCENDING",
+        "arrayConfig": ""
+      },
+      {
+        "fieldPath": "UpdatedAt",
+        "order": "DESCENDING",
+        "arrayConfig": ""
+      },
+      {
+        "fieldPath": "__name__",
+        "order": "DESCENDING",
+        "arrayConfig": ""
+      }
+    ]
+  },
+  {
+    "collectionGroup": "Application",
+    "queryScope": "COLLECTION",
+    "fields": [
+      {
+        "fieldPath": "SyncState.Status",
+        "order": "ASCENDING",
+        "arrayConfig": ""
+      },
+      {
+        "fieldPath": "UpdatedAt",
+        "order": "DESCENDING",
+        "arrayConfig": ""
+      },
+      {
+        "fieldPath": "__name__",
+        "order": "DESCENDING",
+        "arrayConfig": ""
+      }
+    ]
+  },
+  {
+    "collectionGroup": "Application",
+    "queryScope": "COLLECTION",
+    "fields": [
+      {
+        "fieldPath": "ProjectId",
+        "order": "ASCENDING",
+        "arrayConfig": ""
+      },
+      {
+        "fieldPath": "UpdatedAt",
+        "order": "DESCENDING",
+        "arrayConfig": ""
+      },
+      {
+        "fieldPath": "__name__",
+        "order": "DESCENDING",
+        "arrayConfig": ""
+      }
+    ]
+  },
+  {
+    "collectionGroup": "Command",
+    "queryScope": "COLLECTION",
+    "fields": [
+      {
+        "fieldPath": "Status",
+        "order": "ASCENDING",
+        "arrayConfig": ""
+      },
+      {
+        "fieldPath": "CreatedAt",
+        "order": "ASCENDING",
+        "arrayConfig": ""
+      },
+      {
+        "fieldPath": "__name__",
+        "order": "ASCENDING",
+        "arrayConfig": ""
+      }
+    ]
+  },
+  {
+    "collectionGroup": "Deployment",
+    "queryScope": "COLLECTION",
+    "fields": [
+      {
+        "fieldPath": "ApplicationId",
+        "order": "ASCENDING",
+        "arrayConfig": ""
+      },
+      {
+        "fieldPath": "UpdatedAt",
+        "order": "DESCENDING",
+        "arrayConfig": ""
+      },
+      {
+        "fieldPath": "__name__",
+        "order": "DESCENDING",
+        "arrayConfig": ""
+      }
+    ]
+  },
+  {
+    "collectionGroup": "Deployment",
+    "queryScope": "COLLECTION",
+    "fields": [
+      {
+        "fieldPath": "ProjectId",
+        "order": "ASCENDING",
+        "arrayConfig": ""
+      },
+      {
+        "fieldPath": "UpdatedAt",
+        "order": "DESCENDING",
+        "arrayConfig": ""
+      },
+      {
+        "fieldPath": "__name__",
+        "order": "DESCENDING",
+        "arrayConfig": ""
+      }
+    ]
+  },
+  {
+    "collectionGroup": "Deployment",
+    "queryScope": "COLLECTION",
+    "fields": [
+      {
+        "fieldPath": "EnvId",
+        "order": "ASCENDING",
+        "arrayConfig": ""
+      },
+      {
+        "fieldPath": "UpdatedAt",
+        "order": "DESCENDING",
+        "arrayConfig": ""
+      },
+      {
+        "fieldPath": "__name__",
+        "order": "DESCENDING",
+        "arrayConfig": ""
+      }
+    ]
+  },
+  {
+    "collectionGroup": "Deployment",
+    "queryScope": "COLLECTION",
+    "fields": [
+      {
+        "fieldPath": "Kind",
+        "order": "ASCENDING",
+        "arrayConfig": ""
+      },
+      {
+        "fieldPath": "UpdatedAt",
+        "order": "DESCENDING",
+        "arrayConfig": ""
+      },
+      {
+        "fieldPath": "__name__",
+        "order": "DESCENDING",
+        "arrayConfig": ""
+      }
+    ]
+  },
+  {
+    "collectionGroup": "Deployment",
+    "queryScope": "COLLECTION",
+    "fields": [
+      {
+        "fieldPath": "Status",
+        "order": "ASCENDING",
+        "arrayConfig": ""
+      },
+      {
+        "fieldPath": "UpdatedAt",
+        "order": "DESCENDING",
+        "arrayConfig": ""
+      },
+      {
+        "fieldPath": "__name__",
+        "order": "DESCENDING",
+        "arrayConfig": ""
+      }
+    ]
+  },
+  {
+    "collectionGroup": "Event",
+    "queryScope": "COLLECTION",
+    "fields": [
+      {
+        "fieldPath": "ProjectId",
+        "order": "ASCENDING",
+        "arrayConfig": ""
+      },
+      {
+        "fieldPath": "CreatedAt",
+        "order": "ASCENDING",
+        "arrayConfig": ""
+      },
+      {
+        "fieldPath": "__name__",
+        "order": "ASCENDING",
+        "arrayConfig": ""
+      }
+    ]
+  },
+  {
+    "collectionGroup": "Event",
+    "queryScope": "COLLECTION",
+    "fields": [
+      {
+        "fieldPath": "EventKey",
+        "order": "ASCENDING",
+        "arrayConfig": ""
+      },
+      {
+        "fieldPath": "Name",
+        "order": "ASCENDING",
+        "arrayConfig": ""
+      },
+      {
+        "fieldPath": "ProjectId",
+        "order": "ASCENDING",
+        "arrayConfig": ""
+      },
+      {
+        "fieldPath": "CreatedAt",
+        "order": "DESCENDING",
+        "arrayConfig": ""
+      },
+      {
+        "fieldPath": "__name__",
+        "order": "DESCENDING",
+        "arrayConfig": ""
+      }
+    ]
+  }
+]

--- a/pkg/app/ops/firestoreindexensurer/indexes_test.go
+++ b/pkg/app/ops/firestoreindexensurer/indexes_test.go
@@ -433,16 +433,38 @@ func TestIndexID(t *testing.T) {
 				QueryScope:      "COLLECTION",
 				Fields: []field{
 					{
-						FieldPath: "field-path1",
-						Order:     "ASCENDING",
-					},
-					{
 						FieldPath:   "field-path2",
 						ArrayConfig: "contains",
+					},
+					{
+						FieldPath: "field-path1",
+						Order:     "ASCENDING",
 					},
 				},
 			},
 			want: "collection-group/COLLECTION/field-path:field-path1/order:ASCENDING/field-path:field-path2/array-config:contains",
+		},
+		{
+			name: "ensure it's always sorted",
+			idx: index{
+				CollectionGroup: "collection-group",
+				QueryScope:      "COLLECTION",
+				Fields: []field{
+					{
+						FieldPath:   "field-path2",
+						ArrayConfig: "contains",
+					},
+					{
+						FieldPath: "field-path3",
+						Order:     "ASCENDING",
+					},
+					{
+						FieldPath: "field-path1",
+						Order:     "ASCENDING",
+					},
+				},
+			},
+			want: "collection-group/COLLECTION/field-path:field-path1/order:ASCENDING/field-path:field-path2/array-config:contains/field-path:field-path3/order:ASCENDING",
 		},
 	}
 	for _, tc := range testcases {

--- a/pkg/app/ops/firestoreindexensurer/indexes_test.go
+++ b/pkg/app/ops/firestoreindexensurer/indexes_test.go
@@ -23,304 +23,304 @@ import (
 
 func TestParseIndexes(t *testing.T) {
 	want := []index{
-		index{
+		{
 			CollectionGroup: "Application",
 			QueryScope:      "COLLECTION",
 			Fields: []field{
-				field{
+				{
 					FieldPath:   "Disabled",
 					Order:       "ASCENDING",
 					ArrayConfig: "",
 				},
-				field{
+				{
 					FieldPath:   "UpdatedAt",
 					Order:       "DESCENDING",
 					ArrayConfig: "",
 				},
-				field{
+				{
 					FieldPath:   "__name__",
 					Order:       "DESCENDING",
 					ArrayConfig: "",
 				},
 			},
 		},
-		index{
+		{
 			CollectionGroup: "Application",
 			QueryScope:      "COLLECTION",
 			Fields: []field{
-				field{
+				{
 					FieldPath:   "EnvId",
 					Order:       "ASCENDING",
 					ArrayConfig: "",
 				},
-				field{
+				{
 					FieldPath:   "UpdatedAt",
 					Order:       "DESCENDING",
 					ArrayConfig: "",
 				},
-				field{
+				{
 					FieldPath:   "__name__",
 					Order:       "DESCENDING",
 					ArrayConfig: "",
 				},
 			},
 		},
-		index{
+		{
 			CollectionGroup: "Application",
 			QueryScope:      "COLLECTION",
 			Fields: []field{
-				field{
+				{
 					FieldPath:   "Deleted",
 					Order:       "ASCENDING",
 					ArrayConfig: "",
 				},
-				field{
+				{
 					FieldPath:   "CreatedAt",
 					Order:       "ASCENDING",
 					ArrayConfig: "",
 				},
-				field{
+				{
 					FieldPath:   "__name__",
 					Order:       "ASCENDING",
 					ArrayConfig: "",
 				},
 			},
 		},
-		index{
+		{
 			CollectionGroup: "Application",
 			QueryScope:      "COLLECTION",
 			Fields: []field{
-				field{
+				{
 					FieldPath:   "Kind",
 					Order:       "ASCENDING",
 					ArrayConfig: "",
 				},
-				field{
+				{
 					FieldPath:   "UpdatedAt",
 					Order:       "DESCENDING",
 					ArrayConfig: "",
 				},
-				field{
+				{
 					FieldPath:   "__name__",
 					Order:       "DESCENDING",
 					ArrayConfig: "",
 				},
 			},
 		},
-		index{
+		{
 			CollectionGroup: "Application",
 			QueryScope:      "COLLECTION",
 			Fields: []field{
-				field{
+				{
 					FieldPath:   "SyncState.Status",
 					Order:       "ASCENDING",
 					ArrayConfig: "",
 				},
-				field{
+				{
 					FieldPath:   "UpdatedAt",
 					Order:       "DESCENDING",
 					ArrayConfig: "",
 				},
-				field{
+				{
 					FieldPath:   "__name__",
 					Order:       "DESCENDING",
 					ArrayConfig: "",
 				},
 			},
 		},
-		index{
+		{
 			CollectionGroup: "Application",
 			QueryScope:      "COLLECTION",
 			Fields: []field{
-				field{
+				{
 					FieldPath:   "ProjectId",
 					Order:       "ASCENDING",
 					ArrayConfig: "",
 				},
-				field{
+				{
 					FieldPath:   "UpdatedAt",
 					Order:       "DESCENDING",
 					ArrayConfig: "",
 				},
-				field{
+				{
 					FieldPath:   "__name__",
 					Order:       "DESCENDING",
 					ArrayConfig: "",
 				},
 			},
 		},
-		index{
+		{
 			CollectionGroup: "Command",
 			QueryScope:      "COLLECTION",
 			Fields: []field{
-				field{
+				{
 					FieldPath:   "Status",
 					Order:       "ASCENDING",
 					ArrayConfig: "",
 				},
-				field{
+				{
 					FieldPath:   "CreatedAt",
 					Order:       "ASCENDING",
 					ArrayConfig: "",
 				},
-				field{
+				{
 					FieldPath:   "__name__",
 					Order:       "ASCENDING",
 					ArrayConfig: "",
 				},
 			},
 		},
-		index{
+		{
 			CollectionGroup: "Deployment",
 			QueryScope:      "COLLECTION",
 			Fields: []field{
-				field{
+				{
 					FieldPath:   "ApplicationId",
 					Order:       "ASCENDING",
 					ArrayConfig: "",
 				},
-				field{
+				{
 					FieldPath:   "UpdatedAt",
 					Order:       "DESCENDING",
 					ArrayConfig: "",
 				},
-				field{
+				{
 					FieldPath:   "__name__",
 					Order:       "DESCENDING",
 					ArrayConfig: "",
 				},
 			},
 		},
-		index{
+		{
 			CollectionGroup: "Deployment",
 			QueryScope:      "COLLECTION",
 			Fields: []field{
-				field{
+				{
 					FieldPath:   "ProjectId",
 					Order:       "ASCENDING",
 					ArrayConfig: "",
 				},
-				field{
+				{
 					FieldPath:   "UpdatedAt",
 					Order:       "DESCENDING",
 					ArrayConfig: "",
 				},
-				field{
+				{
 					FieldPath:   "__name__",
 					Order:       "DESCENDING",
 					ArrayConfig: "",
 				},
 			},
 		},
-		index{
+		{
 			CollectionGroup: "Deployment",
 			QueryScope:      "COLLECTION",
 			Fields: []field{
-				field{
+				{
 					FieldPath:   "EnvId",
 					Order:       "ASCENDING",
 					ArrayConfig: "",
 				},
-				field{
+				{
 					FieldPath:   "UpdatedAt",
 					Order:       "DESCENDING",
 					ArrayConfig: "",
 				},
-				field{
+				{
 					FieldPath:   "__name__",
 					Order:       "DESCENDING",
 					ArrayConfig: "",
 				},
 			},
 		},
-		index{
+		{
 			CollectionGroup: "Deployment",
 			QueryScope:      "COLLECTION",
 			Fields: []field{
-				field{
+				{
 					FieldPath:   "Kind",
 					Order:       "ASCENDING",
 					ArrayConfig: "",
 				},
-				field{
+				{
 					FieldPath:   "UpdatedAt",
 					Order:       "DESCENDING",
 					ArrayConfig: "",
 				},
-				field{
+				{
 					FieldPath:   "__name__",
 					Order:       "DESCENDING",
 					ArrayConfig: "",
 				},
 			},
 		},
-		index{
+		{
 			CollectionGroup: "Deployment",
 			QueryScope:      "COLLECTION",
 			Fields: []field{
-				field{
+				{
 					FieldPath:   "Status",
 					Order:       "ASCENDING",
 					ArrayConfig: "",
 				},
-				field{
+				{
 					FieldPath:   "UpdatedAt",
 					Order:       "DESCENDING",
 					ArrayConfig: "",
 				},
-				field{
+				{
 					FieldPath:   "__name__",
 					Order:       "DESCENDING",
 					ArrayConfig: "",
 				},
 			},
 		},
-		index{
+		{
 			CollectionGroup: "Event",
 			QueryScope:      "COLLECTION",
 			Fields: []field{
-				field{
+				{
 					FieldPath:   "ProjectId",
 					Order:       "ASCENDING",
 					ArrayConfig: "",
 				},
-				field{
+				{
 					FieldPath:   "CreatedAt",
 					Order:       "ASCENDING",
 					ArrayConfig: "",
 				},
-				field{
+				{
 					FieldPath:   "__name__",
 					Order:       "ASCENDING",
 					ArrayConfig: "",
 				},
 			},
 		},
-		index{
+		{
 			CollectionGroup: "Event",
 			QueryScope:      "COLLECTION",
 			Fields: []field{
-				field{
+				{
 					FieldPath:   "EventKey",
 					Order:       "ASCENDING",
 					ArrayConfig: "",
 				},
-				field{
+				{
 					FieldPath:   "Name",
 					Order:       "ASCENDING",
 					ArrayConfig: "",
 				},
-				field{
+				{
 					FieldPath:   "ProjectId",
 					Order:       "ASCENDING",
 					ArrayConfig: "",
 				},
-				field{
+				{
 					FieldPath:   "CreatedAt",
 					Order:       "DESCENDING",
 					ArrayConfig: "",
 				},
-				field{
+				{
 					FieldPath:   "__name__",
 					Order:       "DESCENDING",
 					ArrayConfig: "",

--- a/pkg/app/ops/firestoreindexensurer/indexes_test.go
+++ b/pkg/app/ops/firestoreindexensurer/indexes_test.go
@@ -22,196 +22,308 @@ import (
 )
 
 func TestParseIndexes(t *testing.T) {
-	want := &indexes{
-		Indexes: []index{
-			{
-				CollectionGroup: "Application",
-				Fields: []field{
-					{
-						FieldPath: "Deleted",
-						Order:     "ASCENDING",
-					},
-					{
-						FieldPath: "CreatedAt",
-						Order:     "ASCENDING",
-					},
+	want := []index{
+		index{
+			CollectionGroup: "Application",
+			QueryScope:      "COLLECTION",
+			Fields: []field{
+				field{
+					FieldPath:   "Disabled",
+					Order:       "ASCENDING",
+					ArrayConfig: "",
+				},
+				field{
+					FieldPath:   "UpdatedAt",
+					Order:       "DESCENDING",
+					ArrayConfig: "",
+				},
+				field{
+					FieldPath:   "__name__",
+					Order:       "DESCENDING",
+					ArrayConfig: "",
 				},
 			},
-			{
-				CollectionGroup: "Application",
-				Fields: []field{
-					{
-						FieldPath: "Disabled",
-						Order:     "ASCENDING",
-					},
-					{
-						FieldPath: "UpdatedAt",
-						Order:     "DESCENDING",
-					},
+		},
+		index{
+			CollectionGroup: "Application",
+			QueryScope:      "COLLECTION",
+			Fields: []field{
+				field{
+					FieldPath:   "EnvId",
+					Order:       "ASCENDING",
+					ArrayConfig: "",
+				},
+				field{
+					FieldPath:   "UpdatedAt",
+					Order:       "DESCENDING",
+					ArrayConfig: "",
+				},
+				field{
+					FieldPath:   "__name__",
+					Order:       "DESCENDING",
+					ArrayConfig: "",
 				},
 			},
-			{
-				CollectionGroup: "Application",
-				Fields: []field{
-					{
-						FieldPath: "EnvId",
-						Order:     "ASCENDING",
-					},
-					{
-						FieldPath: "UpdatedAt",
-						Order:     "DESCENDING",
-					},
+		},
+		index{
+			CollectionGroup: "Application",
+			QueryScope:      "COLLECTION",
+			Fields: []field{
+				field{
+					FieldPath:   "Deleted",
+					Order:       "ASCENDING",
+					ArrayConfig: "",
+				},
+				field{
+					FieldPath:   "CreatedAt",
+					Order:       "ASCENDING",
+					ArrayConfig: "",
+				},
+				field{
+					FieldPath:   "__name__",
+					Order:       "ASCENDING",
+					ArrayConfig: "",
 				},
 			},
-			{
-				CollectionGroup: "Application",
-				Fields: []field{
-					{
-						FieldPath: "Kind",
-						Order:     "ASCENDING",
-					},
-					{
-						FieldPath: "UpdatedAt",
-						Order:     "DESCENDING",
-					},
+		},
+		index{
+			CollectionGroup: "Application",
+			QueryScope:      "COLLECTION",
+			Fields: []field{
+				field{
+					FieldPath:   "Kind",
+					Order:       "ASCENDING",
+					ArrayConfig: "",
+				},
+				field{
+					FieldPath:   "UpdatedAt",
+					Order:       "DESCENDING",
+					ArrayConfig: "",
+				},
+				field{
+					FieldPath:   "__name__",
+					Order:       "DESCENDING",
+					ArrayConfig: "",
 				},
 			},
-			{
-				CollectionGroup: "Application",
-				Fields: []field{
-					{
-						FieldPath: "ProjectId",
-						Order:     "ASCENDING",
-					},
-					{
-						FieldPath: "UpdatedAt",
-						Order:     "DESCENDING",
-					},
+		},
+		index{
+			CollectionGroup: "Application",
+			QueryScope:      "COLLECTION",
+			Fields: []field{
+				field{
+					FieldPath:   "SyncState.Status",
+					Order:       "ASCENDING",
+					ArrayConfig: "",
+				},
+				field{
+					FieldPath:   "UpdatedAt",
+					Order:       "DESCENDING",
+					ArrayConfig: "",
+				},
+				field{
+					FieldPath:   "__name__",
+					Order:       "DESCENDING",
+					ArrayConfig: "",
 				},
 			},
-			{
-				CollectionGroup: "Application",
-				Fields: []field{
-					{
-						FieldPath: "SyncState.Status",
-						Order:     "ASCENDING",
-					},
-					{
-						FieldPath: "UpdatedAt",
-						Order:     "DESCENDING",
-					},
+		},
+		index{
+			CollectionGroup: "Application",
+			QueryScope:      "COLLECTION",
+			Fields: []field{
+				field{
+					FieldPath:   "ProjectId",
+					Order:       "ASCENDING",
+					ArrayConfig: "",
+				},
+				field{
+					FieldPath:   "UpdatedAt",
+					Order:       "DESCENDING",
+					ArrayConfig: "",
+				},
+				field{
+					FieldPath:   "__name__",
+					Order:       "DESCENDING",
+					ArrayConfig: "",
 				},
 			},
-			{
-				CollectionGroup: "Command",
-				Fields: []field{
-					{
-						FieldPath: "Status",
-						Order:     "ASCENDING",
-					},
-					{
-						FieldPath: "CreatedAt",
-						Order:     "ASCENDING",
-					},
+		},
+		index{
+			CollectionGroup: "Command",
+			QueryScope:      "COLLECTION",
+			Fields: []field{
+				field{
+					FieldPath:   "Status",
+					Order:       "ASCENDING",
+					ArrayConfig: "",
+				},
+				field{
+					FieldPath:   "CreatedAt",
+					Order:       "ASCENDING",
+					ArrayConfig: "",
+				},
+				field{
+					FieldPath:   "__name__",
+					Order:       "ASCENDING",
+					ArrayConfig: "",
 				},
 			},
-			{
-				CollectionGroup: "Deployment",
-				Fields: []field{
-					{
-						FieldPath: "ApplicationId",
-						Order:     "ASCENDING",
-					},
-					{
-						FieldPath: "UpdatedAt",
-						Order:     "DESCENDING",
-					},
+		},
+		index{
+			CollectionGroup: "Deployment",
+			QueryScope:      "COLLECTION",
+			Fields: []field{
+				field{
+					FieldPath:   "ApplicationId",
+					Order:       "ASCENDING",
+					ArrayConfig: "",
+				},
+				field{
+					FieldPath:   "UpdatedAt",
+					Order:       "DESCENDING",
+					ArrayConfig: "",
+				},
+				field{
+					FieldPath:   "__name__",
+					Order:       "DESCENDING",
+					ArrayConfig: "",
 				},
 			},
-			{
-				CollectionGroup: "Deployment",
-				Fields: []field{
-					{
-						FieldPath: "EnvId",
-						Order:     "ASCENDING",
-					},
-					{
-						FieldPath: "UpdatedAt",
-						Order:     "DESCENDING",
-					},
+		},
+		index{
+			CollectionGroup: "Deployment",
+			QueryScope:      "COLLECTION",
+			Fields: []field{
+				field{
+					FieldPath:   "ProjectId",
+					Order:       "ASCENDING",
+					ArrayConfig: "",
+				},
+				field{
+					FieldPath:   "UpdatedAt",
+					Order:       "DESCENDING",
+					ArrayConfig: "",
+				},
+				field{
+					FieldPath:   "__name__",
+					Order:       "DESCENDING",
+					ArrayConfig: "",
 				},
 			},
-			{
-				CollectionGroup: "Deployment",
-				Fields: []field{
-					{
-						FieldPath: "Kind",
-						Order:     "ASCENDING",
-					},
-					{
-						FieldPath: "UpdatedAt",
-						Order:     "DESCENDING",
-					},
+		},
+		index{
+			CollectionGroup: "Deployment",
+			QueryScope:      "COLLECTION",
+			Fields: []field{
+				field{
+					FieldPath:   "EnvId",
+					Order:       "ASCENDING",
+					ArrayConfig: "",
+				},
+				field{
+					FieldPath:   "UpdatedAt",
+					Order:       "DESCENDING",
+					ArrayConfig: "",
+				},
+				field{
+					FieldPath:   "__name__",
+					Order:       "DESCENDING",
+					ArrayConfig: "",
 				},
 			},
-			{
-				CollectionGroup: "Deployment",
-				Fields: []field{
-					{
-						FieldPath: "ProjectId",
-						Order:     "ASCENDING",
-					},
-					{
-						FieldPath: "UpdatedAt",
-						Order:     "DESCENDING",
-					},
+		},
+		index{
+			CollectionGroup: "Deployment",
+			QueryScope:      "COLLECTION",
+			Fields: []field{
+				field{
+					FieldPath:   "Kind",
+					Order:       "ASCENDING",
+					ArrayConfig: "",
+				},
+				field{
+					FieldPath:   "UpdatedAt",
+					Order:       "DESCENDING",
+					ArrayConfig: "",
+				},
+				field{
+					FieldPath:   "__name__",
+					Order:       "DESCENDING",
+					ArrayConfig: "",
 				},
 			},
-			{
-				CollectionGroup: "Deployment",
-				Fields: []field{
-					{
-						FieldPath: "Status",
-						Order:     "ASCENDING",
-					},
-					{
-						FieldPath: "UpdatedAt",
-						Order:     "DESCENDING",
-					},
+		},
+		index{
+			CollectionGroup: "Deployment",
+			QueryScope:      "COLLECTION",
+			Fields: []field{
+				field{
+					FieldPath:   "Status",
+					Order:       "ASCENDING",
+					ArrayConfig: "",
+				},
+				field{
+					FieldPath:   "UpdatedAt",
+					Order:       "DESCENDING",
+					ArrayConfig: "",
+				},
+				field{
+					FieldPath:   "__name__",
+					Order:       "DESCENDING",
+					ArrayConfig: "",
 				},
 			},
-			{
-				CollectionGroup: "Event",
-				Fields: []field{
-					{
-						FieldPath: "EventKey",
-						Order:     "ASCENDING",
-					},
-					{
-						FieldPath: "Name",
-						Order:     "ASCENDING",
-					},
-					{
-						FieldPath: "ProjectId",
-						Order:     "ASCENDING",
-					},
-					{
-						FieldPath: "CreatedAt",
-						Order:     "DESCENDING",
-					},
+		},
+		index{
+			CollectionGroup: "Event",
+			QueryScope:      "COLLECTION",
+			Fields: []field{
+				field{
+					FieldPath:   "ProjectId",
+					Order:       "ASCENDING",
+					ArrayConfig: "",
+				},
+				field{
+					FieldPath:   "CreatedAt",
+					Order:       "ASCENDING",
+					ArrayConfig: "",
+				},
+				field{
+					FieldPath:   "__name__",
+					Order:       "ASCENDING",
+					ArrayConfig: "",
 				},
 			},
-			{
-				CollectionGroup: "Event",
-				Fields: []field{
-					{
-						FieldPath: "ProjectId",
-						Order:     "ASCENDING",
-					},
-					{
-						FieldPath: "CreatedAt",
-						Order:     "ASCENDING",
-					},
+		},
+		index{
+			CollectionGroup: "Event",
+			QueryScope:      "COLLECTION",
+			Fields: []field{
+				field{
+					FieldPath:   "EventKey",
+					Order:       "ASCENDING",
+					ArrayConfig: "",
+				},
+				field{
+					FieldPath:   "Name",
+					Order:       "ASCENDING",
+					ArrayConfig: "",
+				},
+				field{
+					FieldPath:   "ProjectId",
+					Order:       "ASCENDING",
+					ArrayConfig: "",
+				},
+				field{
+					FieldPath:   "CreatedAt",
+					Order:       "DESCENDING",
+					ArrayConfig: "",
+				},
+				field{
+					FieldPath:   "__name__",
+					Order:       "DESCENDING",
+					ArrayConfig: "",
 				},
 			},
 		},
@@ -220,4 +332,123 @@ func TestParseIndexes(t *testing.T) {
 	got, err := parseIndexes()
 	assert.Equal(t, want, got)
 	require.NoError(t, err)
+}
+
+func TestFilterIndexes(t *testing.T) {
+	testcases := []struct {
+		name     string
+		indexes  []index
+		excludes []index
+		want     []index
+	}{
+		{
+			name: "no excludes given",
+			indexes: []index{
+				{
+					CollectionGroup: "collection-group",
+					QueryScope:      "COLLECTION",
+					Fields: []field{
+						{
+							FieldPath: "field-path",
+							Order:     "ASCENDING",
+						},
+					},
+				},
+			},
+			excludes: []index{},
+			want: []index{
+				{
+					CollectionGroup: "collection-group",
+					QueryScope:      "COLLECTION",
+					Fields: []field{
+						{
+							FieldPath: "field-path",
+							Order:     "ASCENDING",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "exclude an index",
+			indexes: []index{
+				{
+					CollectionGroup: "collection-group",
+					QueryScope:      "COLLECTION",
+					Fields: []field{
+						{
+							FieldPath: "field-path",
+							Order:     "ASCENDING",
+						},
+					},
+				},
+			},
+			excludes: []index{
+				{
+					CollectionGroup: "collection-group",
+					QueryScope:      "COLLECTION",
+					Fields: []field{
+						{
+							FieldPath: "field-path",
+							Order:     "ASCENDING",
+						},
+					},
+				},
+			},
+			want: []index{},
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := filterIndexes(tc.indexes, tc.excludes)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestIndexID(t *testing.T) {
+	testcases := []struct {
+		name string
+		idx  index
+		want string
+	}{
+		{
+			name: "single field",
+			idx: index{
+				CollectionGroup: "collection-group",
+				QueryScope:      "COLLECTION",
+				Fields: []field{
+					{
+						FieldPath: "field-path",
+						Order:     "ASCENDING",
+					},
+				},
+			},
+			want: "collection-group/COLLECTION/field-path:field-path/order:ASCENDING",
+		},
+		{
+			name: "two fields",
+			idx: index{
+				CollectionGroup: "collection-group",
+				QueryScope:      "COLLECTION",
+				Fields: []field{
+					{
+						FieldPath: "field-path1",
+						Order:     "ASCENDING",
+					},
+					{
+						FieldPath:   "field-path2",
+						ArrayConfig: "contains",
+					},
+				},
+			},
+			want: "collection-group/COLLECTION/field-path:field-path1/order:ASCENDING/field-path:field-path2/array-config:contains",
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.idx.id()
+			assert.Equal(t, tc.want, got)
+		})
+	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR also changes the indexes JSON file to our own format, which means dependency on the `firebase` command will be removed.
The reason why it did that is it became necessary to parse indexes inside Ops container in order to check indexes already exists. Besides, the indexes emitted by `gcloud firestore indexes composite list` includes project-specific value, that’s why we settled on using our own type.

Also unifying the parsing way makes it easier to solve https://github.com/pipe-cd/pipe/issues/1564. I'm looking into publishing the parsing APIs once got merged.

FYI: I've confirmed it works as well as we'd like this time as well.

**Which issue(s) this PR fixes**:

Fixes https://github.com/pipe-cd/pipe/issues/1559

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
