### PR TITLE
Add workflow to automatically add issue to the ROADMAP project

### DIFF
--- a/.github/workflows/opened-issues-triage.yml
+++ b/.github/workflows/opened-issues-triage.yml
@@ -1,0 +1,13 @@
+name: Move new issues into Triage
+on:
+  issues:
+    types: [opened]
+jobs:
+  automate-project-columns:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: alex-page/github-project-automation-plus@v0.3.0
+        with:
+          project: ROADMAP
+          column: Future
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/opened-issues-triage.yml
+++ b/.github/workflows/opened-issues-triage.yml
@@ -1,4 +1,4 @@
-name: Move new issues into Triage
+name: Move new issues into Future column
 on:
   issues:
     types: [opened]


### PR DESCRIPTION
**What this PR does / why we need it**:
I little poked around the Github actions to triage Github projects. And looks like [alex-page/github-project-automation-plus](https://github.com/marketplace/actions/github-project-automation) is the simplest one.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
