### PR TITLE
Use general invitation link to CNCF slack

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -150,7 +150,7 @@ no = 'Sorry to hear that. Please <a href="https://github.com/pipe-cd/pipe/issues
         desc = "Development takes place here!"
 [[params.links.developer]]
 	name = "Slack"
-	url = "https://join.slack.com/t/cloud-native/shared_invite/zt-fyy3b8up-qHeDNVqbz1j8HDY6g1cY4w"
+	url = "https://slack.cncf.io"
 	icon = "fab fa-slack"
         desc = "Chat with other project developers"
 [[params.links.developer]]

--- a/docs/content/en/_index.html
+++ b/docs/content/en/_index.html
@@ -63,10 +63,10 @@ linkTitle = "PipeCD"
 
 {{< blocks/section color="dark" >}}
 
-{{% blocks/feature icon="fab fa-slack" title="Join the conversation!" url="https://join.slack.com/t/cloud-native/shared_invite/zt-fyy3b8up-qHeDNVqbz1j8HDY6g1cY4w" %}}
+{{% blocks/feature icon="fab fa-slack" title="Join the conversation!" url="https://slack.cncf.io" %}}
 Have a question?
 
-Learn more by talking with other contributors in [Cloud Native Slack](https://join.slack.com/t/cloud-native/shared_invite/zt-fyy3b8up-qHeDNVqbz1j8HDY6g1cY4w) via [#pipecd](https://app.slack.com/client/T08PSQ7BQ/C01B27F9T0X) channel.
+Learn more by talking with other contributors in [Cloud Native Slack](https://slack.cncf.io) via [#pipecd](https://app.slack.com/client/T08PSQ7BQ/C01B27F9T0X) channel.
 {{% /blocks/feature %}}
 
 

--- a/docs/content/en/blog/news/announcing-pipecd/index.md
+++ b/docs/content/en/blog/news/announcing-pipecd/index.md
@@ -94,7 +94,7 @@ We value every contribution and invite you to join us on GitHub, Slack and Twitt
 
 - Visit our website and documentation at [https://pipecd.dev](https://pipecd.dev)
 - Check out the code at [https://github.com/pipe-cd/pipe](https://github.com/pipe-cd/pipe) or explore the [examples](https://pipecd.dev/docs/examples/)
-- Join us on Slack [@cloud-native/pipecd](https://join.slack.com/t/cloud-native/shared_invite/zt-fyy3b8up-qHeDNVqbz1j8HDY6g1cY4w) to chat with other developers
+- Join us on Slack [@cloud-native/pipecd](https://slack.cncf.io) to chat with other developers
 - Follow us on Twitter [@pipecd_dev](https://twitter.com/pipecd_dev) to get the latest news
 
 PipeCD team is hiring engineers/interns to work on PipeCD. Please contact us if you are interested.

--- a/docs/content/en/docs/faq/_index.md
+++ b/docs/content/en/docs/faq/_index.md
@@ -6,7 +6,7 @@ description: >
   List of frequently asked questions.
 ---
 
-If you have any other questions, please feel free to create the issue in the [pipe-cd/pipe](https://github.com/pipe-cd/pipe/issues/new/choose) repository or contact us on [Cloud Native Slack](https://join.slack.com/t/cloud-native/shared_invite/zt-fyy3b8up-qHeDNVqbz1j8HDY6g1cY4w) (channel [#pipecd](https://app.slack.com/client/T08PSQ7BQ/C01B27F9T0X)).
+If you have any other questions, please feel free to create the issue in the [pipe-cd/pipe](https://github.com/pipe-cd/pipe/issues/new/choose) repository or contact us on [Cloud Native Slack](https://slack.cncf.io) (channel [#pipecd](https://app.slack.com/client/T08PSQ7BQ/C01B27F9T0X)).
 
 ### 1. What kind of application (cloud provider) will be supported?
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently the link doesn't work. Head over to https://slack.cncf.io then it redirects to a proper link like `https://join.slack.com/t/cloud-native/shared_invite/xxx`

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
