### PR TITLE
Refactor API mock data

### DIFF
--- a/pkg/app/web/src/__fixtures__/dummy-api-key.ts
+++ b/pkg/app/web/src/__fixtures__/dummy-api-key.ts
@@ -1,13 +1,32 @@
 import { APIKey } from "../modules/api-keys";
+import { createRandTime, randomKeyHash, randomUUID } from "./utils";
 
-export const dummyAPIKey = {
-  id: "api-key-1",
+const createdAt = createRandTime();
+
+export const dummyAPIKey: APIKey.AsObject = {
+  id: randomUUID(),
   name: "API_KEY_1",
-  keyHash: "KEY_HASH",
+  keyHash: randomKeyHash(),
   projectId: "pipecd",
   role: APIKey.Role.READ_WRITE,
   creator: "user",
   disabled: false,
-  createdAt: 0,
-  updatedAt: 0,
+  createdAt: createdAt.unix(),
+  updatedAt: createdAt.unix(),
 };
+
+export function createAPIKeyFromObject(o: APIKey.AsObject): APIKey {
+  const key = new APIKey();
+
+  key.setId(o.id);
+  key.setName(o.name);
+  key.setKeyHash(o.keyHash);
+  key.setProjectId(o.projectId);
+  key.setRole(o.role);
+  key.setCreator(o.creator);
+  key.setDisabled(o.disabled);
+  key.setCreatedAt(o.createdAt);
+  key.setUpdatedAt(o.updatedAt);
+
+  return key;
+}

--- a/pkg/app/web/src/__fixtures__/dummy-application-live-state.ts
+++ b/pkg/app/web/src/__fixtures__/dummy-application-live-state.ts
@@ -10,14 +10,11 @@ import {
 } from "../modules/applications-live-state";
 import { dummyApplication } from "./dummy-application";
 import { dummyEnv } from "./dummy-environment";
-import faker from "faker";
 import { dummyPiped } from "./dummy-piped";
+import { createRandTimes, randomUUID } from "./utils";
 
-const resourceIds = [
-  faker.random.uuid(),
-  faker.random.uuid(),
-  faker.random.uuid(),
-];
+const resourceIds = [randomUUID(), randomUUID(), randomUUID()];
+const resourceTimes = createRandTimes(3);
 
 export const resourcesList: KubernetesResourceState.AsObject[] = [
   {
@@ -30,8 +27,8 @@ export const resourcesList: KubernetesResourceState.AsObject[] = [
     namespace: "default",
     healthStatus: KubernetesResourceState.HealthStatus.HEALTHY,
     healthDescription: "",
-    createdAt: 1592472088,
-    updatedAt: 1592472088,
+    createdAt: resourceTimes[0].unix(),
+    updatedAt: resourceTimes[0].unix(),
   },
   {
     id: resourceIds[1],
@@ -43,8 +40,8 @@ export const resourcesList: KubernetesResourceState.AsObject[] = [
     namespace: "default",
     healthStatus: KubernetesResourceState.HealthStatus.HEALTHY,
     healthDescription: "",
-    createdAt: 1592472088,
-    updatedAt: 1592472088,
+    createdAt: resourceTimes[1].unix(),
+    updatedAt: resourceTimes[1].unix(),
   },
   {
     id: "f55c7891-ba25-44bb-bca4-ffbc16b0089f",
@@ -56,8 +53,8 @@ export const resourcesList: KubernetesResourceState.AsObject[] = [
     namespace: "default",
     healthStatus: KubernetesResourceState.HealthStatus.OTHER,
     healthDescription: "",
-    createdAt: 1592472088,
-    updatedAt: 1592472088,
+    createdAt: resourceTimes[2].unix(),
+    updatedAt: resourceTimes[2].unix(),
   },
 ];
 

--- a/pkg/app/web/src/__fixtures__/dummy-application.ts
+++ b/pkg/app/web/src/__fixtures__/dummy-application.ts
@@ -1,4 +1,3 @@
-import faker from "faker";
 import { ApplicationKind } from "pipe/pkg/app/web/model/common_pb";
 import {
   Application,
@@ -11,7 +10,7 @@ import { dummyEnv } from "./dummy-environment";
 import { dummyPiped } from "./dummy-piped";
 import { dummyRepo } from "./dummy-repo";
 import { createTriggerFromObject, dummyTrigger } from "./dummy-trigger";
-import { createdRandTime, subtractRandTimeFrom } from "./utils";
+import { createRandTimes, randomUUID } from "./utils";
 
 export const dummyApplicationSyncState: ApplicationSyncState.AsObject = {
   headDeploymentId: "deployment-1",
@@ -21,12 +20,10 @@ export const dummyApplicationSyncState: ApplicationSyncState.AsObject = {
   timestamp: 0,
 };
 
-const updatedAt = createdRandTime();
-const startedAt = subtractRandTimeFrom(updatedAt);
-const createdAt = subtractRandTimeFrom(updatedAt);
+const [createdAt, startedAt, updatedAt] = createRandTimes(3);
 
 export const dummyApplication: Application.AsObject = {
-  id: faker.random.uuid(),
+  id: randomUUID(),
   cloudProvider: "kubernetes-default",
   disabled: false,
   envId: dummyEnv.id,

--- a/pkg/app/web/src/__fixtures__/dummy-command.ts
+++ b/pkg/app/web/src/__fixtures__/dummy-command.ts
@@ -1,6 +1,9 @@
 import { SyncStrategy } from "pipe/pkg/app/web/model/deployment_pb";
 import { Command, CommandStatus } from "../modules/commands";
 import { dummyDeployment } from "./dummy-deployment";
+import { createRandTimes } from "./utils";
+
+const [createdAt, handledAt] = createRandTimes(3);
 
 export const dummyCommand: Command.AsObject = {
   id: "command-1",
@@ -11,14 +14,14 @@ export const dummyCommand: Command.AsObject = {
   commander: "user",
   status: CommandStatus.COMMAND_NOT_HANDLED_YET,
   metadataMap: [],
-  handledAt: 0,
   type: Command.Type.SYNC_APPLICATION,
   syncApplication: {
     applicationId: "app-1",
     syncStrategy: SyncStrategy.AUTO,
   },
-  createdAt: 0,
-  updatedAt: 0,
+  createdAt: createdAt.unix(),
+  updatedAt: handledAt.unix(),
+  handledAt: handledAt.unix(),
 };
 
 export const dummySyncSucceededCommand: Command.AsObject = {

--- a/pkg/app/web/src/__fixtures__/dummy-deployment.ts
+++ b/pkg/app/web/src/__fixtures__/dummy-deployment.ts
@@ -4,25 +4,19 @@ import { createGitPathFromObject } from "./common";
 import { dummyApplication } from "./dummy-application";
 import { dummyEnv } from "./dummy-environment";
 import { dummyPiped } from "./dummy-piped";
-import { dummyPipeline } from "./dummy-pipeline";
-import { dummyTrigger, createTriggerFromObject } from "./dummy-trigger";
-import { createdRandTime, subtractRandTimeFrom } from "./utils";
-import faker from "faker";
-import { createPipelineFromObject } from "./dummy-pipeline";
+import { createPipelineFromObject, dummyPipeline } from "./dummy-pipeline";
+import { createTriggerFromObject, dummyTrigger } from "./dummy-trigger";
+import { createRandTimes, randomUUID } from "./utils";
 
-faker.seed(1);
-
-const completedAt = createdRandTime();
-const updatedAt = subtractRandTimeFrom(completedAt);
-const createdAt = subtractRandTimeFrom(updatedAt);
+const [createdAt, completedAt] = createRandTimes(3);
 
 export const dummyDeployment: Deployment.AsObject = {
-  id: faker.random.uuid(),
+  id: randomUUID(),
   pipedId: dummyPiped.id,
   projectId: "project-1",
   applicationName: dummyApplication.name,
   applicationId: dummyApplication.id,
-  runningCommitHash: faker.random.uuid().slice(0, 8),
+  runningCommitHash: randomUUID().slice(0, 8),
   stagesList: dummyPipeline,
   status: DeploymentStatus.DEPLOYMENT_SUCCESS,
   statusReason: "good",
@@ -30,7 +24,7 @@ export const dummyDeployment: Deployment.AsObject = {
   version: "0.0.0",
   cloudProvider: "kube-1",
   createdAt: createdAt.unix(),
-  updatedAt: updatedAt.unix(),
+  updatedAt: completedAt.unix(),
   completedAt: completedAt.unix(),
   summary:
     "Quick sync by deploying the new version and configuring all traffic to it because no pipeline was configured",

--- a/pkg/app/web/src/__fixtures__/dummy-environment.ts
+++ b/pkg/app/web/src/__fixtures__/dummy-environment.ts
@@ -1,8 +1,5 @@
-import faker from "faker";
 import { Environment } from "../modules/environments";
-import { createdRandTime, subtractRandTimeFrom } from "./utils";
-
-faker.seed(1);
+import { createRandTimes, randomUUID, randomWords } from "./utils";
 
 export const createEnvFromObject = (o: Environment.AsObject): Environment => {
   const env = new Environment();
@@ -15,12 +12,11 @@ export const createEnvFromObject = (o: Environment.AsObject): Environment => {
   return env;
 };
 
-const updatedAt = createdRandTime();
-const createdAt = subtractRandTimeFrom(updatedAt);
+const [createdAt, updatedAt] = createRandTimes(2);
 
 export const dummyEnv: Environment.AsObject = {
-  id: faker.random.uuid(),
-  desc: faker.lorem.words(8),
+  id: randomUUID(),
+  desc: randomWords(8),
   name: "staging",
   projectId: "project-1",
   updatedAt: updatedAt.unix(),

--- a/pkg/app/web/src/__fixtures__/dummy-piped.ts
+++ b/pkg/app/web/src/__fixtures__/dummy-piped.ts
@@ -1,14 +1,9 @@
 import { Piped } from "../modules/pipeds";
 import { dummyEnv } from "./dummy-environment";
 import { createApplicationGitRepository, dummyRepo } from "./dummy-repo";
-import faker from "faker";
-import { createdRandTime, subtractRandTimeFrom } from "./utils";
+import { createRandTimes, randomText, randomUUID } from "./utils";
 
-faker.seed(1);
-
-const updatedAt = createdRandTime();
-const startedAt = subtractRandTimeFrom(updatedAt);
-const createdAt = subtractRandTimeFrom(startedAt);
+const [createdAt, startedAt, updatedAt] = createRandTimes(3);
 
 export const dummyPiped: Piped.AsObject = {
   cloudProvidersList: [
@@ -22,9 +17,9 @@ export const dummyPiped: Piped.AsObject = {
       type: "TERRAFORM",
     },
   ],
-  desc: faker.lorem.text(1),
+  desc: randomText(1),
   disabled: false,
-  id: faker.random.uuid(),
+  id: randomUUID(),
   name: "dummy-piped",
   projectId: "project-1",
   repositoriesList: [dummyRepo],

--- a/pkg/app/web/src/__fixtures__/dummy-pipeline.ts
+++ b/pkg/app/web/src/__fixtures__/dummy-pipeline.ts
@@ -1,18 +1,13 @@
 import { PipelineStage, StageStatus } from "../modules/deployments";
 import * as jspb from "google-protobuf";
-import { createdRandTime, subtractRandTimeFrom } from "./utils";
-import faker from "faker";
+import { createRandTimes, randomUUID, randomWords } from "./utils";
 
-faker.seed(1);
-
-const completedAt = createdRandTime();
-const updatedAt = subtractRandTimeFrom(completedAt);
-const createdAt = subtractRandTimeFrom(updatedAt);
+const [createdAt, updatedAt, completedAt] = createRandTimes(3);
 
 export const dummyPipelineStage: PipelineStage.AsObject = {
-  id: faker.random.uuid(),
+  id: randomUUID(),
   name: "K8S_CANARY_ROLLOUT",
-  desc: "",
+  desc: randomWords(8),
   index: 0,
   predefined: true,
   requiresList: [],
@@ -30,7 +25,7 @@ export function createPipelineStage(
   pipeline: Partial<PipelineStage.AsObject>
 ): PipelineStage.AsObject {
   return Object.assign({}, dummyPipelineStage, pipeline, {
-    id: faker.random.uuid(),
+    id: randomUUID(),
   });
 }
 

--- a/pkg/app/web/src/__fixtures__/dummy-project.ts
+++ b/pkg/app/web/src/__fixtures__/dummy-project.ts
@@ -1,15 +1,55 @@
-import { Project } from "pipe/pkg/app/web/model/project_pb";
-import faker from "faker";
-import { createdRandTime, subtractRandTimeFrom } from "./utils";
+import {
+  Project,
+  ProjectRBACConfig,
+  ProjectStaticUser,
+} from "pipe/pkg/app/web/model/project_pb";
+import {
+  createRandTimes,
+  randomKeyHash,
+  randomUUID,
+  randomWords,
+} from "./utils";
 
-const updatedAt = createdRandTime();
-const createdAt = subtractRandTimeFrom(updatedAt);
+const [createdAt, updatedAt] = createRandTimes(2);
 
 export const dummyProject: Project.AsObject = {
-  id: faker.random.uuid(),
-  desc: "",
-  sharedSsoName: "",
+  id: randomUUID(),
+  desc: randomWords(8),
+  sharedSsoName: "shared-sso",
   createdAt: createdAt.unix(),
   updatedAt: updatedAt.unix(),
   staticAdminDisabled: false,
+  rbac: {
+    admin: "admin-team",
+    editor: "editor-team",
+    viewer: "viewer-team",
+  },
+  staticAdmin: {
+    username: "static-admin-user",
+    passwordHash: randomKeyHash(),
+  },
 };
+
+export function createProjectFromObject(o: Project.AsObject): Project {
+  const project = new Project();
+  project.setId(o.id);
+  project.setDesc(o.desc);
+  project.setSharedSsoName(o.sharedSsoName);
+  project.setCreatedAt(o.createdAt);
+  project.setUpdatedAt(o.updatedAt);
+  project.setStaticAdminDisabled(o.staticAdminDisabled);
+  if (o.rbac) {
+    const rbac = new ProjectRBACConfig();
+    rbac.setAdmin(o.rbac.admin);
+    rbac.setEditor(o.rbac.editor);
+    rbac.setViewer(o.rbac.viewer);
+    project.setRbac(rbac);
+  }
+  if (o.staticAdmin) {
+    const user = new ProjectStaticUser();
+    user.setUsername(o.staticAdmin.username);
+    user.setPasswordHash(o.staticAdmin.passwordHash);
+    project.setStaticAdmin(user);
+  }
+  return project;
+}

--- a/pkg/app/web/src/__fixtures__/dummy-stage-log.ts
+++ b/pkg/app/web/src/__fixtures__/dummy-stage-log.ts
@@ -1,14 +1,30 @@
 import { LogBlock, LogSeverity } from "../modules/stage-logs";
-import { createdRandTime } from "./utils";
+import { createRandTimes, randomWords } from "./utils";
 
-const createdAt = createdRandTime();
+const logTimes = createRandTimes(3);
 
 export const dummyLogBlock: LogBlock.AsObject = {
   index: 0,
-  log: "This is stage log",
+  log: randomWords(8),
   severity: LogSeverity.SUCCESS,
-  createdAt: createdAt.unix(),
+  createdAt: logTimes[0].unix(),
 };
+
+export const dummyLogBlocks: LogBlock.AsObject[] = [
+  dummyLogBlock,
+  {
+    index: 1,
+    log: randomWords(8),
+    severity: LogSeverity.INFO,
+    createdAt: logTimes[1].unix(),
+  },
+  {
+    index: 2,
+    log: randomWords(8),
+    severity: LogSeverity.ERROR,
+    createdAt: logTimes[2].unix(),
+  },
+];
 
 export function createLogBlockFromObject(o: LogBlock.AsObject): LogBlock {
   const block = new LogBlock();

--- a/pkg/app/web/src/__fixtures__/dummy-trigger.ts
+++ b/pkg/app/web/src/__fixtures__/dummy-trigger.ts
@@ -3,10 +3,9 @@ import {
   SyncStrategy,
   Commit,
 } from "pipe/pkg/app/web/model/deployment_pb";
-import { createdRandTime } from "./utils";
-import faker from "faker";
+import { createRandTime, randomUUID } from "./utils";
 
-const commitTimestamp = createdRandTime();
+const commitTimestamp = createRandTime();
 
 export const dummyTrigger: DeploymentTrigger.AsObject = {
   commander: "user",
@@ -15,7 +14,7 @@ export const dummyTrigger: DeploymentTrigger.AsObject = {
     author: "pipecd-user",
     branch: "feat/awesome-feature",
     createdAt: 1,
-    hash: faker.random.uuid().slice(0, 8),
+    hash: randomUUID().slice(0, 8),
     message: "fix",
     pullRequest: 123,
     url: "",

--- a/pkg/app/web/src/__fixtures__/utils.ts
+++ b/pkg/app/web/src/__fixtures__/utils.ts
@@ -1,12 +1,45 @@
-import faker from "faker";
 import dayjs, { Dayjs } from "dayjs";
+import faker from "faker";
 
 faker.seed(1);
 
-export function createdRandTime(): Dayjs {
+export function randomUUID(): string {
+  return faker.random.uuid();
+}
+
+export function randomKeyHash(): string {
+  return faker.random.alphaNumeric(128);
+}
+
+export function randomWords(num: number): string {
+  return faker.lorem.words(num);
+}
+
+export function randomText(times: number): string {
+  return faker.lorem.text(times);
+}
+
+export function createRandTime(): Dayjs {
   return dayjs().subtract(faker.random.number({ min: 1, max: 10 }), "minute");
 }
 
-export function subtractRandTimeFrom(t: Dayjs): Dayjs {
+function subtractRandTimeFrom(t: Dayjs): Dayjs {
   return t.subtract(faker.random.number({ min: 5, max: 30 }), "minute");
+}
+
+/**
+ * Generate times that are ascending ordered.
+ */
+export function createRandTimes(count: number): Dayjs[] {
+  const times: Dayjs[] = [createRandTime()];
+
+  if (count === 1) {
+    return times;
+  }
+
+  for (let i = 1; i < count; i++) {
+    times.push(subtractRandTimeFrom(times[i - 1]));
+  }
+
+  return times.reverse();
 }

--- a/pkg/app/web/src/mocks/handlers.ts
+++ b/pkg/app/web/src/mocks/handlers.ts
@@ -7,6 +7,7 @@ import { pipedHandlers } from "./services/piped";
 import { environmentHandlers } from "./services/environment";
 import { liveStateHandlers } from "./services/live-state";
 import { stageLogHandlers } from "./services/stage-log";
+import { apiKeyHandlers } from "./services/api-keys";
 
 export const handlers = [
   ...meHandlers,
@@ -18,4 +19,5 @@ export const handlers = [
   ...environmentHandlers,
   ...liveStateHandlers,
   ...stageLogHandlers,
+  ...apiKeyHandlers,
 ];

--- a/pkg/app/web/src/mocks/services/api-keys.ts
+++ b/pkg/app/web/src/mocks/services/api-keys.ts
@@ -1,0 +1,22 @@
+import {
+  ListAPIKeysResponse,
+  GenerateAPIKeyResponse,
+} from "pipe/pkg/app/web/api_client/service_pb";
+import {
+  createAPIKeyFromObject,
+  dummyAPIKey,
+} from "../../__fixtures__/dummy-api-key";
+import { createHandler } from "../create-handler";
+
+export const apiKeyHandlers = [
+  createHandler<ListAPIKeysResponse>("/ListAPIKeys", () => {
+    const response = new ListAPIKeysResponse();
+    response.setKeysList([createAPIKeyFromObject(dummyAPIKey)]);
+    return response;
+  }),
+  createHandler<GenerateAPIKeyResponse>("/GenerateAPIKey", () => {
+    const response = new GenerateAPIKeyResponse();
+    response.setKey(dummyAPIKey.keyHash);
+    return response;
+  }),
+];

--- a/pkg/app/web/src/mocks/services/piped.ts
+++ b/pkg/app/web/src/mocks/services/piped.ts
@@ -1,19 +1,26 @@
 import {
   GenerateApplicationSealedSecretResponse,
   ListPipedsResponse,
+  RecreatePipedKeyResponse,
 } from "pipe/pkg/app/web/api_client/service_pb";
 import {
   createPipedFromObject,
   dummyPiped,
 } from "../../__fixtures__/dummy-piped";
+import { randomKeyHash } from "../../__fixtures__/utils";
 import { createHandler } from "../create-handler";
 
 export const pipedHandlers = [
+  createHandler<RecreatePipedKeyResponse>("/RecreatePipedKey", () => {
+    const response = new RecreatePipedKeyResponse();
+    response.setKey(randomKeyHash());
+    return response;
+  }),
   createHandler<GenerateApplicationSealedSecretResponse>(
     "/GenerateApplicationSealedSecret",
     () => {
       const response = new GenerateApplicationSealedSecretResponse();
-      response.setData("xxxxx");
+      response.setData(randomKeyHash());
       return response;
     }
   ),

--- a/pkg/app/web/src/mocks/services/project.ts
+++ b/pkg/app/web/src/mocks/services/project.ts
@@ -1,18 +1,12 @@
 import {
-  UpdateProjectStaticAdminResponse,
   GetProjectResponse,
+  UpdateProjectStaticAdminResponse,
 } from "pipe/pkg/app/web/api_client/service_pb";
-import { Project } from "pipe/pkg/app/web/model/project_pb";
-import { dummyProject } from "../../__fixtures__/dummy-project";
+import {
+  createProjectFromObject,
+  dummyProject,
+} from "../../__fixtures__/dummy-project";
 import { createHandler } from "../create-handler";
-
-function createProjectFromObject(o: Project.AsObject): Project {
-  const project = new Project();
-  project.setId(o.id);
-  project.setCreatedAt(o.createdAt);
-  project.setUpdatedAt(o.updatedAt);
-  return project;
-}
 
 export const projectHandlers = [
   createHandler<UpdateProjectStaticAdminResponse>(

--- a/pkg/app/web/src/mocks/services/stage-log.ts
+++ b/pkg/app/web/src/mocks/services/stage-log.ts
@@ -1,14 +1,14 @@
 import { GetStageLogResponse } from "pipe/pkg/app/web/api_client/service_pb";
 import {
   createLogBlockFromObject,
-  dummyLogBlock,
+  dummyLogBlocks,
 } from "../../__fixtures__/dummy-stage-log";
 import { createHandler } from "../create-handler";
 
 export const stageLogHandlers = [
   createHandler<GetStageLogResponse>("/GetStageLog", () => {
     const response = new GetStageLogResponse();
-    response.setBlocksList([createLogBlockFromObject(dummyLogBlock)]);
+    response.setBlocksList(dummyLogBlocks.map(createLogBlockFromObject));
     response.setCompleted(true);
 
     return response;


### PR DESCRIPTION
**What this PR does / why we need it**:

- Define functions to generate random data and use those instead of faker directly.
  - This will avoid call `faker.seed` many times.
- Use `createRandTimes` for generating multiple dates.
 
**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
