### PR TITLE
Fix nil error by shadowing outer error variable

### DIFF
--- a/pkg/app/piped/cloudprovider/lambda/client.go
+++ b/pkg/app/piped/cloudprovider/lambda/client.go
@@ -193,7 +193,7 @@ func (c *client) UpdateFunction(ctx context.Context, fm FunctionManifest) error 
 				Variables: aws.StringMap(fm.Spec.Environments),
 			},
 		}
-		_, err := c.client.UpdateFunctionConfigurationWithContext(ctx, configInput)
+		_, err = c.client.UpdateFunctionConfigurationWithContext(ctx, configInput)
 		if err != nil {
 			c.logger.Error("Failed to update function configuration")
 		} else {


### PR DESCRIPTION
**What this PR does / why we need it**:

In case error occurred on `UpdateFunction`, the inner declared `err` can't be used outside of `retry.WaitNext` for loop scope.
ref: https://github.com/pipe-cd/pipe/blob/master/pkg/app/piped/cloudprovider/lambda/client.go#L196-L202

Shadowing the outer `err` variable will avoid the following error
```
Failed to update lambda function SimpleFunction: failed to update configuration for Lambda function SimpleFunction: %!w(<nil>)
```

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
