### PR TITLE
Update firestore index ensurer to use configured CollectionNamePrefix

### DIFF
--- a/cmd/pipecd/ops.go
+++ b/cmd/pipecd/ops.go
@@ -150,7 +150,13 @@ func (s *ops) run(ctx context.Context, t cli.Telemetry) error {
 
 	if cfg.Datastore.Type == model.DataStoreFirestore {
 		// Create needed composite indexes for Firestore.
-		ensurer := firestoreindexensurer.NewIndexEnsurer(s.gcloudPath, cfg.Datastore.FirestoreConfig.Project, cfg.Datastore.FirestoreConfig.CredentialsFile, t.Logger)
+		ensurer := firestoreindexensurer.NewIndexEnsurer(
+			s.gcloudPath,
+			cfg.Datastore.FirestoreConfig.Project,
+			cfg.Datastore.FirestoreConfig.CredentialsFile,
+			cfg.Datastore.FirestoreConfig.CollectionNamePrefix,
+			t.Logger,
+		)
 		group.Go(func() error {
 			return ensurer.CreateIndexes(ctx)
 		})

--- a/pkg/app/ops/firestoreindexensurer/indexes.go
+++ b/pkg/app/ops/firestoreindexensurer/indexes.go
@@ -113,3 +113,11 @@ func filterIndexes(indexes []index, excludes []index) []index {
 	}
 	return filtered
 }
+
+// prefixIndexes adds the given prefix to all indexes.
+// Currently, it just prefixes the CollectionGroup.
+func prefixIndexes(indexes []index, prefix string) {
+	for i := range indexes {
+		indexes[i].CollectionGroup = prefix + indexes[i].CollectionGroup
+	}
+}

--- a/pkg/app/ops/firestoreindexensurer/indexes_test.go
+++ b/pkg/app/ops/firestoreindexensurer/indexes_test.go
@@ -474,3 +474,45 @@ func TestIndexID(t *testing.T) {
 		})
 	}
 }
+
+func TestPrefixIndexes(t *testing.T) {
+	testcases := []struct {
+		name     string
+		indexes  []index
+		prefix   string
+		expected []index
+	}{
+		{
+			name:   "nil list",
+			prefix: "TestPrefix",
+		},
+		{
+			name:   "normal list",
+			prefix: "TestPrefix",
+			indexes: []index{
+				{
+					CollectionGroup: "CollectionA",
+				},
+				{
+					CollectionGroup: "CollectionB",
+				},
+			},
+			expected: []index{
+				{
+					CollectionGroup: "TestPrefixCollectionA",
+				},
+				{
+					CollectionGroup: "TestPrefixCollectionB",
+				},
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			indexes := tc.indexes
+			prefixIndexes(indexes, tc.prefix)
+			assert.Equal(t, tc.expected, indexes)
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #1580

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
