### PR TITLE
Stop dealing with "__name__" field

### DIFF
--- a/pkg/app/ops/firestoreindexensurer/README.md
+++ b/pkg/app/ops/firestoreindexensurer/README.md
@@ -1,0 +1,9 @@
+# Firestore index ensurer developers guide
+This package automatically creates the needed composite indexes for Google Firestore.
+It's based on well-defined JSON file named `indexes.json`, which is obtained by running the following, with the `__name__` field removed:
+
+```
+gcloud firestore indexes composite list --format=json --sort-by=name
+```
+
+For details for this command: https://cloud.google.com/sdk/gcloud/reference/firestore/indexes/composite/list

--- a/pkg/app/ops/firestoreindexensurer/gcloud.go
+++ b/pkg/app/ops/firestoreindexensurer/gcloud.go
@@ -130,10 +130,18 @@ func (c *gcloud) listIndexes(ctx context.Context) ([]index, error) {
 			c.logger.Warn("index has unexpected name", zap.String("name", idx.Name))
 			continue
 		}
+		// Ignore the "__name__" field which is automatically created by Firestore.
+		fields := make([]field, 0, len(idx.Fields)-1)
+		for _, f := range idx.Fields {
+			if f.FieldPath == "__name__" {
+				continue
+			}
+			fields = append(fields, f)
+		}
 		indexes = append(indexes, index{
 			CollectionGroup: name[5],
 			QueryScope:      idx.QueryScope,
-			Fields:          idx.Fields,
+			Fields:          fields,
 		})
 	}
 	return indexes, nil

--- a/pkg/app/ops/firestoreindexensurer/indexes.json
+++ b/pkg/app/ops/firestoreindexensurer/indexes.json
@@ -12,11 +12,6 @@
         "fieldPath": "UpdatedAt",
         "order": "DESCENDING",
         "arrayConfig": ""
-      },
-      {
-        "fieldPath": "__name__",
-        "order": "DESCENDING",
-        "arrayConfig": ""
       }
     ]
   },
@@ -31,11 +26,6 @@
       },
       {
         "fieldPath": "UpdatedAt",
-        "order": "DESCENDING",
-        "arrayConfig": ""
-      },
-      {
-        "fieldPath": "__name__",
         "order": "DESCENDING",
         "arrayConfig": ""
       }
@@ -54,11 +44,6 @@
         "fieldPath": "CreatedAt",
         "order": "ASCENDING",
         "arrayConfig": ""
-      },
-      {
-        "fieldPath": "__name__",
-        "order": "ASCENDING",
-        "arrayConfig": ""
       }
     ]
   },
@@ -73,11 +58,6 @@
       },
       {
         "fieldPath": "UpdatedAt",
-        "order": "DESCENDING",
-        "arrayConfig": ""
-      },
-      {
-        "fieldPath": "__name__",
         "order": "DESCENDING",
         "arrayConfig": ""
       }
@@ -96,11 +76,6 @@
         "fieldPath": "UpdatedAt",
         "order": "DESCENDING",
         "arrayConfig": ""
-      },
-      {
-        "fieldPath": "__name__",
-        "order": "DESCENDING",
-        "arrayConfig": ""
       }
     ]
   },
@@ -115,11 +90,6 @@
       },
       {
         "fieldPath": "UpdatedAt",
-        "order": "DESCENDING",
-        "arrayConfig": ""
-      },
-      {
-        "fieldPath": "__name__",
         "order": "DESCENDING",
         "arrayConfig": ""
       }
@@ -138,11 +108,6 @@
         "fieldPath": "CreatedAt",
         "order": "ASCENDING",
         "arrayConfig": ""
-      },
-      {
-        "fieldPath": "__name__",
-        "order": "ASCENDING",
-        "arrayConfig": ""
       }
     ]
   },
@@ -159,11 +124,6 @@
         "fieldPath": "UpdatedAt",
         "order": "DESCENDING",
         "arrayConfig": ""
-      },
-      {
-        "fieldPath": "__name__",
-        "order": "DESCENDING",
-        "arrayConfig": ""
       }
     ]
   },
@@ -178,11 +138,6 @@
       },
       {
         "fieldPath": "UpdatedAt",
-        "order": "DESCENDING",
-        "arrayConfig": ""
-      },
-      {
-        "fieldPath": "__name__",
         "order": "DESCENDING",
         "arrayConfig": ""
       }
@@ -201,11 +156,6 @@
         "fieldPath": "UpdatedAt",
         "order": "DESCENDING",
         "arrayConfig": ""
-      },
-      {
-        "fieldPath": "__name__",
-        "order": "DESCENDING",
-        "arrayConfig": ""
       }
     ]
   },
@@ -220,11 +170,6 @@
       },
       {
         "fieldPath": "UpdatedAt",
-        "order": "DESCENDING",
-        "arrayConfig": ""
-      },
-      {
-        "fieldPath": "__name__",
         "order": "DESCENDING",
         "arrayConfig": ""
       }
@@ -243,11 +188,6 @@
         "fieldPath": "UpdatedAt",
         "order": "DESCENDING",
         "arrayConfig": ""
-      },
-      {
-        "fieldPath": "__name__",
-        "order": "DESCENDING",
-        "arrayConfig": ""
       }
     ]
   },
@@ -262,11 +202,6 @@
       },
       {
         "fieldPath": "CreatedAt",
-        "order": "ASCENDING",
-        "arrayConfig": ""
-      },
-      {
-        "fieldPath": "__name__",
         "order": "ASCENDING",
         "arrayConfig": ""
       }
@@ -293,11 +228,6 @@
       },
       {
         "fieldPath": "CreatedAt",
-        "order": "DESCENDING",
-        "arrayConfig": ""
-      },
-      {
-        "fieldPath": "__name__",
         "order": "DESCENDING",
         "arrayConfig": ""
       }

--- a/pkg/app/ops/firestoreindexensurer/indexes_test.go
+++ b/pkg/app/ops/firestoreindexensurer/indexes_test.go
@@ -37,11 +37,6 @@ func TestParseIndexes(t *testing.T) {
 					Order:       "DESCENDING",
 					ArrayConfig: "",
 				},
-				{
-					FieldPath:   "__name__",
-					Order:       "DESCENDING",
-					ArrayConfig: "",
-				},
 			},
 		},
 		{
@@ -55,11 +50,6 @@ func TestParseIndexes(t *testing.T) {
 				},
 				{
 					FieldPath:   "UpdatedAt",
-					Order:       "DESCENDING",
-					ArrayConfig: "",
-				},
-				{
-					FieldPath:   "__name__",
 					Order:       "DESCENDING",
 					ArrayConfig: "",
 				},
@@ -79,11 +69,6 @@ func TestParseIndexes(t *testing.T) {
 					Order:       "ASCENDING",
 					ArrayConfig: "",
 				},
-				{
-					FieldPath:   "__name__",
-					Order:       "ASCENDING",
-					ArrayConfig: "",
-				},
 			},
 		},
 		{
@@ -97,11 +82,6 @@ func TestParseIndexes(t *testing.T) {
 				},
 				{
 					FieldPath:   "UpdatedAt",
-					Order:       "DESCENDING",
-					ArrayConfig: "",
-				},
-				{
-					FieldPath:   "__name__",
 					Order:       "DESCENDING",
 					ArrayConfig: "",
 				},
@@ -121,11 +101,6 @@ func TestParseIndexes(t *testing.T) {
 					Order:       "DESCENDING",
 					ArrayConfig: "",
 				},
-				{
-					FieldPath:   "__name__",
-					Order:       "DESCENDING",
-					ArrayConfig: "",
-				},
 			},
 		},
 		{
@@ -139,11 +114,6 @@ func TestParseIndexes(t *testing.T) {
 				},
 				{
 					FieldPath:   "UpdatedAt",
-					Order:       "DESCENDING",
-					ArrayConfig: "",
-				},
-				{
-					FieldPath:   "__name__",
 					Order:       "DESCENDING",
 					ArrayConfig: "",
 				},
@@ -163,11 +133,6 @@ func TestParseIndexes(t *testing.T) {
 					Order:       "ASCENDING",
 					ArrayConfig: "",
 				},
-				{
-					FieldPath:   "__name__",
-					Order:       "ASCENDING",
-					ArrayConfig: "",
-				},
 			},
 		},
 		{
@@ -184,11 +149,6 @@ func TestParseIndexes(t *testing.T) {
 					Order:       "DESCENDING",
 					ArrayConfig: "",
 				},
-				{
-					FieldPath:   "__name__",
-					Order:       "DESCENDING",
-					ArrayConfig: "",
-				},
 			},
 		},
 		{
@@ -202,11 +162,6 @@ func TestParseIndexes(t *testing.T) {
 				},
 				{
 					FieldPath:   "UpdatedAt",
-					Order:       "DESCENDING",
-					ArrayConfig: "",
-				},
-				{
-					FieldPath:   "__name__",
 					Order:       "DESCENDING",
 					ArrayConfig: "",
 				},
@@ -226,11 +181,6 @@ func TestParseIndexes(t *testing.T) {
 					Order:       "DESCENDING",
 					ArrayConfig: "",
 				},
-				{
-					FieldPath:   "__name__",
-					Order:       "DESCENDING",
-					ArrayConfig: "",
-				},
 			},
 		},
 		{
@@ -244,11 +194,6 @@ func TestParseIndexes(t *testing.T) {
 				},
 				{
 					FieldPath:   "UpdatedAt",
-					Order:       "DESCENDING",
-					ArrayConfig: "",
-				},
-				{
-					FieldPath:   "__name__",
 					Order:       "DESCENDING",
 					ArrayConfig: "",
 				},
@@ -268,11 +213,6 @@ func TestParseIndexes(t *testing.T) {
 					Order:       "DESCENDING",
 					ArrayConfig: "",
 				},
-				{
-					FieldPath:   "__name__",
-					Order:       "DESCENDING",
-					ArrayConfig: "",
-				},
 			},
 		},
 		{
@@ -286,11 +226,6 @@ func TestParseIndexes(t *testing.T) {
 				},
 				{
 					FieldPath:   "CreatedAt",
-					Order:       "ASCENDING",
-					ArrayConfig: "",
-				},
-				{
-					FieldPath:   "__name__",
 					Order:       "ASCENDING",
 					ArrayConfig: "",
 				},
@@ -317,11 +252,6 @@ func TestParseIndexes(t *testing.T) {
 				},
 				{
 					FieldPath:   "CreatedAt",
-					Order:       "DESCENDING",
-					ArrayConfig: "",
-				},
-				{
-					FieldPath:   "__name__",
 					Order:       "DESCENDING",
 					ArrayConfig: "",
 				},


### PR DESCRIPTION
**What this PR does / why we need it**:
An appropriate `__name` field is created by Firestore, so we don't have to care about it.

**Which issue(s) this PR fixes**:

Fixes https://github.com/pipe-cd/pipe/issues/1578

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
