### PR TITLE
Change color of loading indicator at the log viewer

### DIFF
--- a/pkg/app/web/src/components/log/index.tsx
+++ b/pkg/app/web/src/components/log/index.tsx
@@ -38,7 +38,7 @@ export const Log: FC<LogProps> = memo(function Log({ logs, loading }) {
       ))}
       {loading && (
         <Box display="flex" justifyContent="center" p={1}>
-          <CircularProgress />
+          <CircularProgress color="secondary" />
         </Box>
       )}
       <div className={classes.space} />


### PR DESCRIPTION
**What this PR does / why we need it**:

## Before

![image](https://user-images.githubusercontent.com/6136383/109109201-37bf5900-7778-11eb-9f04-5c4b1b7f2d6c.png)


## After

![image](https://user-images.githubusercontent.com/6136383/109109112-13637c80-7778-11eb-8d07-a8f7d0e75369.png)


**Which issue(s) this PR fixes**:

Fixes #1587 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Change color of loading indicator at the log viewer
```
