### PR TITLE
Update the feature status of Automated Rollback for CloudRun and Terraform to beta

### DIFF
--- a/docs/content/en/docs/feature-status/_index.md
+++ b/docs/content/en/docs/feature-status/_index.md
@@ -39,7 +39,7 @@ Please note that the phases (Incubating, Alpha, Beta, and Stable) are applied to
 |-|-|
 | Quick Sync Deployment | Beta |
 | Deployment with the Specified Pipeline | Beta |
-| Automated Rollback | Alpha |
+| Automated Rollback | Beta |
 | [Automated Configuration Drift Detection](/docs/user-guide/configuration-drift-detection/) | Incubating |
 | [Application Live State](/docs/user-guide/application-live-state/) | Incubating |
 
@@ -49,7 +49,7 @@ Please note that the phases (Incubating, Alpha, Beta, and Stable) are applied to
 |-|-|
 | Quick Sync Deployment | Beta |
 | Deployment with the Specified Pipeline | Beta |
-| Automated Rollback | Alpha |
+| Automated Rollback | Beta |
 | [Automated Configuration Drift Detection](/docs/user-guide/configuration-drift-detection/) | Incubating |
 | [Application Live State](/docs/user-guide/application-live-state/) | Incubating |
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The deployment features of CloudRun and Terraform have been at the Beta phase for a long time.
Since their Automated Rollback feature is now used and tested without any reported problem, so this PR changes their status to Beta too.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
