### PR TITLE
Add make row id from model id

### DIFF
--- a/pkg/datastore/mysql/BUILD.bazel
+++ b/pkg/datastore/mysql/BUILD.bazel
@@ -27,5 +27,8 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     embed = [":go_default_library"],
-    deps = ["@com_github_stretchr_testify//assert:go_default_library"],
+    deps = [
+        "@com_github_google_uuid//:go_default_library",
+        "@com_github_stretchr_testify//assert:go_default_library",
+    ],
 )

--- a/pkg/datastore/mysql/mysql.go
+++ b/pkg/datastore/mysql/mysql.go
@@ -84,7 +84,7 @@ func (m *MySQL) Find(ctx context.Context, kind string, opts datastore.ListOption
 
 // Get implementation for MySQL
 func (m *MySQL) Get(ctx context.Context, kind, id string, v interface{}) error {
-	row := m.client.QueryRowContext(ctx, buildGetQuery(kind), id)
+	row := m.client.QueryRowContext(ctx, buildGetQuery(kind), makeRowID(id))
 	var val string
 	err := row.Scan(&val)
 	if err == sql.ErrNoRows {
@@ -125,12 +125,7 @@ func (m *MySQL) Create(ctx context.Context, kind, id string, entity interface{})
 		return err
 	}
 
-	// In case the given model is `project`, id is not in uuid type so just generate random uuid instead.
-	if kind == "Project" {
-		id = uuid.New().String()
-	}
-
-	_, err = stmt.ExecContext(ctx, id, data)
+	_, err = stmt.ExecContext(ctx, makeRowID(id), data)
 	if mysqlErr, ok := err.(*mysql.MySQLError); ok && mysqlErr.Number == mysqlErrorCodeDuplicate {
 		return datastore.ErrAlreadyExists
 	}
@@ -168,12 +163,7 @@ func (m *MySQL) Put(ctx context.Context, kind, id string, entity interface{}) er
 		return err
 	}
 
-	// In case the given model is `project`, id is not in uuid type so just generate random uuid instead.
-	if kind == "Project" {
-		id = uuid.New().String()
-	}
-
-	_, err = stmt.ExecContext(ctx, id, data, data)
+	_, err = stmt.ExecContext(ctx, makeRowID(id), data, data)
 	if err != nil {
 		m.logger.Error("failed to put entity",
 			zap.String("id", id),
@@ -198,7 +188,7 @@ func (m *MySQL) Update(ctx context.Context, kind, id string, factory datastore.F
 		return err
 	}
 
-	row := tx.QueryRowContext(ctx, buildGetQuery(kind), id)
+	row := tx.QueryRowContext(ctx, buildGetQuery(kind), makeRowID(id))
 	var val string
 	err = row.Scan(&val)
 	if err == sql.ErrNoRows {
@@ -246,7 +236,7 @@ func (m *MySQL) Update(ctx context.Context, kind, id string, factory datastore.F
 		tx.Rollback()
 		return err
 	}
-	_, err = tx.ExecContext(ctx, buildUpdateQuery(kind), data, id)
+	_, err = tx.ExecContext(ctx, buildUpdateQuery(kind), data, makeRowID(id))
 	if err != nil {
 		m.logger.Error("failed to update entity",
 			zap.String("id", id),
@@ -288,4 +278,9 @@ func buildDataSourceName(url, database, usernameFile, passwordFile string) (stri
 	}
 
 	return fmt.Sprintf("%s:%s@tcp(%s)/%s", username, password, url, database), nil
+}
+
+// makeRowID converts a given string (UUID or not) to UUID to be used as MySQL table primary key id.
+func makeRowID(id string) string {
+	return uuid.NewSHA1(uuid.NameSpaceOID, []byte(id)).String()
 }

--- a/pkg/datastore/mysql/mysql.go
+++ b/pkg/datastore/mysql/mysql.go
@@ -280,7 +280,12 @@ func buildDataSourceName(url, database, usernameFile, passwordFile string) (stri
 	return fmt.Sprintf("%s:%s@tcp(%s)/%s", username, password, url, database), nil
 }
 
-// makeRowID converts a given string (UUID or not) to UUID to be used as MySQL table primary key id.
+// makeRowID converts a given string which not in UUID format to UUID string.
+// Otherwise, return the id itself.
 func makeRowID(id string) string {
+	_, err := uuid.Parse(id)
+	if err == nil {
+		return id
+	}
 	return uuid.NewSHA1(uuid.NameSpaceOID, []byte(id)).String()
 }

--- a/pkg/datastore/mysql/mysql_test.go
+++ b/pkg/datastore/mysql/mysql_test.go
@@ -87,6 +87,11 @@ func TestMakeRowID(t *testing.T) {
 			rowID:   "1b247cf8-ee2c-56db-af91-be9e25ff3b6a",
 		},
 		{
+			name:    "modelID is as same as previuos, ensure test",
+			modelID: "pipecd",
+			rowID:   "1b247cf8-ee2c-56db-af91-be9e25ff3b6a",
+		},
+		{
 			name:    "modelID is UUID",
 			modelID: "dfc55495-7dbd-11eb-8636-42010a920020",
 			rowID:   "dfc55495-7dbd-11eb-8636-42010a920020",

--- a/pkg/datastore/mysql/mysql_test.go
+++ b/pkg/datastore/mysql/mysql_test.go
@@ -17,6 +17,8 @@ package mysql
 import (
 	"testing"
 
+	"github.com/google/uuid"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -71,6 +73,30 @@ func TestBuildDataSourceName(t *testing.T) {
 			dataSourceName, err := buildDataSourceName(tc.url, tc.database, tc.usernameFile, tc.passwordFile)
 			assert.Equal(t, tc.expectErr, err != nil)
 			assert.Equal(t, tc.dataSourceName, dataSourceName)
+		})
+	}
+}
+
+func TestMakeRowID(t *testing.T) {
+	testcases := []struct {
+		name    string
+		modelID string
+	}{
+		{
+			name:    "modelID is simple string, not UUID",
+			modelID: "pipecd",
+		},
+		{
+			name:    "modelID is UUID",
+			modelID: "dfc55495-7dbd-11eb-8636-42010a920020",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			rowID := makeRowID(tc.modelID)
+			_, err := uuid.Parse(rowID)
+			assert.Nil(t, err)
 		})
 	}
 }

--- a/pkg/datastore/mysql/mysql_test.go
+++ b/pkg/datastore/mysql/mysql_test.go
@@ -17,8 +17,6 @@ package mysql
 import (
 	"testing"
 
-	"github.com/google/uuid"
-
 	"github.com/stretchr/testify/assert"
 )
 
@@ -81,22 +79,24 @@ func TestMakeRowID(t *testing.T) {
 	testcases := []struct {
 		name    string
 		modelID string
+		rowID   string
 	}{
 		{
 			name:    "modelID is simple string, not UUID",
 			modelID: "pipecd",
+			rowID:   "1b247cf8-ee2c-56db-af91-be9e25ff3b6a",
 		},
 		{
 			name:    "modelID is UUID",
 			modelID: "dfc55495-7dbd-11eb-8636-42010a920020",
+			rowID:   "dfc55495-7dbd-11eb-8636-42010a920020",
 		},
 	}
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			rowID := makeRowID(tc.modelID)
-			_, err := uuid.Parse(rowID)
-			assert.Nil(t, err)
+			assert.Equal(t, tc.rowID, rowID)
 		})
 	}
 }

--- a/pkg/datastore/mysql/query.go
+++ b/pkg/datastore/mysql/query.go
@@ -17,17 +17,10 @@ package mysql
 import "fmt"
 
 func buildGetQuery(table string) string {
-	// TODO: Make kinds from datastore package public
-	if table == "Project" {
-		return fmt.Sprintf("SELECT data FROM %s WHERE data->>\"$.id\" = ?", table)
-	}
 	return fmt.Sprintf("SELECT data FROM %s WHERE id = UUID_TO_BIN(?,true)", table)
 }
 
 func buildUpdateQuery(table string) string {
-	if table == "Project" {
-		return fmt.Sprintf("UPDATE %s SET data = ? WHERE data->>\"$.id\" = ?", table)
-	}
 	return fmt.Sprintf("UPDATE %s SET data = ? WHERE id = UUID_TO_BIN(?,true)", table)
 }
 

--- a/pkg/datastore/mysql/query_test.go
+++ b/pkg/datastore/mysql/query_test.go
@@ -29,12 +29,7 @@ func TestBuildGetQuery(t *testing.T) {
 		{
 			name:          "query for Project kind",
 			kind:          "Project",
-			expectedQuery: "SELECT data FROM Project WHERE data->>\"$.id\" = ?",
-		},
-		{
-			name:          "query for other kinds than Project",
-			kind:          "Application",
-			expectedQuery: "SELECT data FROM Application WHERE id = UUID_TO_BIN(?,true)",
+			expectedQuery: "SELECT data FROM Project WHERE id = UUID_TO_BIN(?,true)",
 		},
 	}
 
@@ -55,12 +50,7 @@ func TestBuildUpdateQuery(t *testing.T) {
 		{
 			name:          "query for Project kind",
 			kind:          "Project",
-			expectedQuery: "UPDATE Project SET data = ? WHERE data->>\"$.id\" = ?",
-		},
-		{
-			name:          "query for other kinds than Project",
-			kind:          "Application",
-			expectedQuery: "UPDATE Application SET data = ? WHERE id = UUID_TO_BIN(?,true)",
+			expectedQuery: "UPDATE Project SET data = ? WHERE id = UUID_TO_BIN(?,true)",
 		},
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Regard https://github.com/pipe-cd/pipe/pull/1653#discussion_r588101686, but instead of making change on `data.id`, just wrap the logic to create `rowID` (ID used as database's tables primary keys) every time we interact with the database. 
Resolve https://github.com/pipe-cd/pipe/pull/1653#discussion_r588269910 issue.

**Which issue(s) this PR fixes**:

Ref #1638 Related to PR #1653 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
