### PR TITLE
Fix wrong error message and docs of the func

### DIFF
--- a/pkg/app/piped/eventwatcher/eventwatcher.go
+++ b/pkg/app/piped/eventwatcher/eventwatcher.go
@@ -265,7 +265,7 @@ func modifyYAML(path, field, newValue string) ([]byte, bool, error) {
 	}
 	value, err := convertStr(v)
 	if err != nil {
-		return nil, false, fmt.Errorf("a value of unknown type is defined at %s in %s: %w", err, field, path)
+		return nil, false, fmt.Errorf("a value of unknown type is defined at %s in %s: %w", field, path, err)
 	}
 	if newValue == value {
 		// Already up-to-date.

--- a/pkg/yamlprocessor/yamlprocessor.go
+++ b/pkg/yamlprocessor/yamlprocessor.go
@@ -25,7 +25,7 @@ import (
 )
 
 // GetValue gives back the value placed at a given path. The type of
-// returned value can be string, int64, uint64, float64, bool, and []interface{}.
+// returned value can be string, int64, uint64, float64 and bool.
 //
 // The path requires to start with "$" which represents the root element.
 // Available operators are:
@@ -33,7 +33,6 @@ import (
 // .     : child operator
 // ..    : recursive descent
 // [num] : object/element of array by number
-// [*]   : all objects/elements for array.
 //
 // e.g. "$.foo.bar[0].baz"
 func GetValue(yml []byte, path string) (interface{}, error) {

--- a/pkg/yamlprocessor/yamlprocessor_test.go
+++ b/pkg/yamlprocessor/yamlprocessor_test.go
@@ -112,16 +112,6 @@ foo:
 			want:    []interface{}{map[string]interface{}{"bar": uint64(1)}, map[string]interface{}{"baz": uint64(2)}},
 			wantErr: false,
 		},
-		{
-			name: "given an entire array path with wildcard",
-			yml: `
-foo:
-- bar: 1
-- baz: 2`,
-			path:    "$.foo[*]",
-			want:    []interface{}{map[string]interface{}{"bar": uint64(1)}, map[string]interface{}{"baz": uint64(2)}},
-			wantErr: false,
-		},
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:
~~Support multiple field on event watcher
Currently, the implementation does not expect yamlprocessor.GetValue to return []interface{}.
So, when the user register the event yamlField as `$.bar[*].hoge` and yamlprocessor.GetValue return slice, `convertStr` return error.~~

- Fix wrong error message
- remove the statement that yamlprocessor.GetValue supported []interface{}

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
