### PR TITLE
Add serviceAccountAnnotations to piped chart

### DIFF
--- a/manifests/piped/templates/rbac.yaml
+++ b/manifests/piped/templates/rbac.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "piped.fullname" . }}
   labels:
     {{- include "piped.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccountAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/manifests/piped/templates/rbac.yaml
+++ b/manifests/piped/templates/rbac.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ include "piped.fullname" . }}
   labels:
     {{- include "piped.labels" . | nindent 4 }}
-  {{- with .Values.serviceAccountAnnotations }}
+  {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/manifests/piped/values.yaml
+++ b/manifests/piped/values.yaml
@@ -77,3 +77,5 @@ affinity: {}
 
 # Specifies how much of each resource the Piped container needs.
 resources: {}
+
+serviceAccountAnnotations: {}

--- a/manifests/piped/values.yaml
+++ b/manifests/piped/values.yaml
@@ -78,4 +78,5 @@ affinity: {}
 # Specifies how much of each resource the Piped container needs.
 resources: {}
 
-serviceAccountAnnotations: {}
+serviceAccount:
+  annotations: {}


### PR DESCRIPTION
**What this PR does / why we need it**:
Want to add annotations to associate [AWS IRSA](https://docs.aws.amazon.com/eks/latest/userguide/specify-service-account-role.html) etc. with ServiceAccount.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
