### PR TITLE
Rename MySQL error code const

### DIFF
--- a/pkg/datastore/mysql/mysql.go
+++ b/pkg/datastore/mysql/mysql.go
@@ -27,7 +27,7 @@ import (
 	"github.com/pipe-cd/pipe/pkg/datastore"
 )
 
-const mysqlErrorCodeDuplicate = 1062
+const mysqlErrorCodeDuplicateEntry = 1062
 
 // MySQL client wrapper
 type MySQL struct {
@@ -140,7 +140,7 @@ func (m *MySQL) Create(ctx context.Context, kind, id string, entity interface{})
 	}
 
 	_, err = stmt.ExecContext(ctx, makeRowID(id), data)
-	if mysqlErr, ok := err.(*mysql.MySQLError); ok && mysqlErr.Number == mysqlErrorCodeDuplicate {
+	if mysqlErr, ok := err.(*mysql.MySQLError); ok && mysqlErr.Number == mysqlErrorCodeDuplicateEntry {
 		return datastore.ErrAlreadyExists
 	}
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

Rename `mysqlErrorCodeDuplicate` to `mysqlErrorCodeDuplicateEntry` to clarify it from other duplicate errors.
ref: https://fromdual.com/mysql-error-codes-and-messages-1050-1099#error_er_dup_entry

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
