### PR TITLE
[AWS Lambda] Fix bug unable to add multi newly defined tags

### DIFF
--- a/pkg/app/piped/cloudprovider/lambda/client.go
+++ b/pkg/app/piped/cloudprovider/lambda/client.go
@@ -356,7 +356,7 @@ func makeFlowControlTagsMaps(remoteTags, definedTags map[string]string) (newDefi
 		val, ok := remoteTags[k]
 		if !ok {
 			newDefinedTags[k] = v
-			break
+			continue
 		}
 		if val != v {
 			updatedTags[k] = v

--- a/pkg/app/piped/cloudprovider/lambda/client_test.go
+++ b/pkg/app/piped/cloudprovider/lambda/client_test.go
@@ -61,17 +61,34 @@ func TestMakeFlowControlTagsMap(t *testing.T) {
 			},
 		},
 		{
-			name: "has newly defined tags",
+			name: "has only newly defined tags",
+			remoteTags: map[string]string{
+				"app": "simple",
+			},
+			definedTags: map[string]string{
+				"app":      "simple",
+				"function": "code",
+			},
+			wantedNewDefinedTags: map[string]string{
+				"function": "code",
+			},
+			wantedUpdatedTags: map[string]string{},
+			wantedRemovedTags: map[string]string{},
+		},
+		{
+			name: "complex defined tags",
 			remoteTags: map[string]string{
 				"app":      "simple",
 				"function": "code",
 			},
 			definedTags: map[string]string{
-				"app": "simple-app",
 				"foo": "bar",
+				"app": "simple-app",
+				"bar": "foo",
 			},
 			wantedNewDefinedTags: map[string]string{
 				"foo": "bar",
+				"bar": "foo",
 			},
 			wantedUpdatedTags: map[string]string{
 				"app": "simple-app",


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, only the first newly defined tags will be reflected in the remote cluster. The expected behavior is all newly defined and updated tags should be reflected.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
