### PR TITLE
Ensure to show the query results reason

### DIFF
--- a/pkg/app/piped/analysisprovider/http/http.go
+++ b/pkg/app/piped/analysisprovider/http/http.go
@@ -48,23 +48,23 @@ func NewProvider(timeout time.Duration) *Provider {
 }
 
 // Run sends an HTTP request and then evaluate whether the response is expected one.
-func (p *Provider) Run(ctx context.Context, cfg *config.AnalysisHTTP) (bool, error) {
+func (p *Provider) Run(ctx context.Context, cfg *config.AnalysisHTTP) (bool, string, error) {
 	req, err := p.makeRequest(ctx, cfg)
 	if err != nil {
-		return false, err
+		return false, "", err
 	}
 
 	res, err := p.client.Do(req)
 	if err != nil {
-		return false, err
+		return false, "", err
 	}
 	defer res.Body.Close()
 
 	if res.StatusCode != cfg.ExpectedCode {
-		return false, fmt.Errorf("unexpected status code %d", res.StatusCode)
+		return false, "", fmt.Errorf("unexpected status code %d", res.StatusCode)
 	}
 	// TODO: Decide how to check if the body is expected one.
-	return true, nil
+	return true, "", nil
 }
 
 func (p *Provider) makeRequest(ctx context.Context, cfg *config.AnalysisHTTP) (*http.Request, error) {

--- a/pkg/app/piped/analysisprovider/log/provider.go
+++ b/pkg/app/piped/analysisprovider/log/provider.go
@@ -22,6 +22,7 @@ import (
 type Provider interface {
 	Type() string
 	// RunQuery runs the given query against the log provider,
-	// and then checks if there is at least one error log..
-	RunQuery(ctx context.Context, query string) (result bool, err error)
+	// and then checks if there is at least one error log.
+	// Returns the result reason if non-error occurred.
+	RunQuery(ctx context.Context, query string) (result bool, reason string, err error)
 }

--- a/pkg/app/piped/analysisprovider/log/stackdriver/stackdriver.go
+++ b/pkg/app/piped/analysisprovider/log/stackdriver/stackdriver.go
@@ -38,6 +38,6 @@ func (p *Provider) Type() string {
 	return ProviderType
 }
 
-func (p *Provider) RunQuery(ctx context.Context, query string) (bool, error) {
-	return false, nil
+func (p *Provider) RunQuery(ctx context.Context, query string) (bool, string, error) {
+	return false, "", nil
 }

--- a/pkg/app/piped/analysisprovider/metrics/datadog/datadog_test.go
+++ b/pkg/app/piped/analysisprovider/metrics/datadog/datadog_test.go
@@ -35,7 +35,7 @@ func TestEvaluate(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := evaluate(tc.evaluator, tc.series)
+			got, _, err := evaluate(tc.evaluator, tc.series)
 			assert.Equal(t, tc.wantErr, err != nil)
 			assert.Equal(t, tc.want, got)
 		})

--- a/pkg/app/piped/analysisprovider/metrics/prometheus/prometheus_test.go
+++ b/pkg/app/piped/analysisprovider/metrics/prometheus/prometheus_test.go
@@ -84,7 +84,7 @@ func TestRunQuery(t *testing.T) {
 				timeout: defaultTimeout,
 				logger:  zap.NewNop(),
 			}
-			res, err := p.RunQuery(context.Background(), "dummy", metrics.QueryRange{From: time.Now()}, tc.expected)
+			res, _, err := p.RunQuery(context.Background(), "dummy", metrics.QueryRange{From: time.Now()}, tc.expected)
 			assert.Equal(t, tc.wantErr, err != nil)
 			assert.Equal(t, res, tc.wantResult)
 		})
@@ -121,7 +121,7 @@ func TestEvaluate(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := evaluate(tc.evaluator, tc.response)
+			got, _, err := evaluate(tc.evaluator, tc.response)
 			assert.Equal(t, tc.wantErr, err != nil)
 			assert.Equal(t, tc.want, got)
 		})

--- a/pkg/app/piped/analysisprovider/metrics/provider.go
+++ b/pkg/app/piped/analysisprovider/metrics/provider.go
@@ -30,16 +30,15 @@ type Provider interface {
 	Type() string
 	// RunQuery runs the given query against the metrics provider,
 	// and then checks if the results are expected or not.
-	// TODO: Give back the reason of the result
-	RunQuery(ctx context.Context, query string, queryRange QueryRange, evaluator Evaluator) (result bool, err error)
+	// Returns the result reason if non-error occurred.
+	RunQuery(ctx context.Context, query string, queryRange QueryRange, evaluator Evaluator) (expected bool, reason string, err error)
 }
 
 // Evaluator evaluates the response from the metrics provider.
 type Evaluator interface {
 	// InRange checks if the value is expected one.
 	InRange(value float64) bool
-	// Validates ensures its own configuration has no problem.
-	Validate() error
+	String() string
 }
 
 // QueryRange represents a sliced time range.

--- a/pkg/app/piped/executor/analysis/analysis.go
+++ b/pkg/app/piped/executor/analysis/analysis.go
@@ -117,7 +117,7 @@ func (e *Executor) Execute(sig executor.StopSignal) model.StageStatus {
 	for i := range options.Metrics {
 		analyzer, err := e.newAnalyzerForMetrics(i, &options.Metrics[i], templateCfg)
 		if err != nil {
-			e.LogPersister.Errorf("failed to spawn analyzer for %s: %v", options.Metrics[i].Provider, err)
+			e.LogPersister.Errorf("Failed to spawn analyzer for %s: %v", options.Metrics[i].Provider, err)
 			return model.StageStatus_STAGE_FAILURE
 		}
 		eg.Go(func() error {
@@ -129,7 +129,7 @@ func (e *Executor) Execute(sig executor.StopSignal) model.StageStatus {
 	for i := range options.Logs {
 		analyzer, err := e.newAnalyzerForLog(i, &options.Logs[i], templateCfg)
 		if err != nil {
-			e.LogPersister.Errorf("failed to spawn analyzer for %s: %v", options.Logs[i].Provider, err)
+			e.LogPersister.Errorf("Failed to spawn analyzer for %s: %v", options.Logs[i].Provider, err)
 			return model.StageStatus_STAGE_FAILURE
 		}
 		eg.Go(func() error {
@@ -141,7 +141,7 @@ func (e *Executor) Execute(sig executor.StopSignal) model.StageStatus {
 	for i := range options.Https {
 		analyzer, err := e.newAnalyzerForHTTP(i, &options.Https[i], templateCfg)
 		if err != nil {
-			e.LogPersister.Errorf("failed to spawn analyzer for HTTP: %v", err)
+			e.LogPersister.Errorf("Failed to spawn analyzer for HTTP: %v", err)
 			return model.StageStatus_STAGE_FAILURE
 		}
 		eg.Go(func() error {
@@ -205,15 +205,14 @@ func (e *Executor) newAnalyzerForMetrics(i int, templatable *config.TemplatableA
 		return nil, err
 	}
 	id := fmt.Sprintf("metrics-%d", i)
-	runner := func(ctx context.Context) (bool, error) {
-		e.LogPersister.Infof("[%s] Run query against %s: %q", id, provider.Type(), cfg.Query)
+	runner := func(ctx context.Context, query string) (bool, string, error) {
 		queryRange := metrics.QueryRange{
 			From: time.Now().Add(-cfg.Interval.Duration()),
 			To:   time.Now(),
 		}
-		return provider.RunQuery(ctx, cfg.Query, queryRange, &cfg.Expected)
+		return provider.RunQuery(ctx, query, queryRange, &cfg.Expected)
 	}
-	return newAnalyzer(id, provider.Type(), runner, time.Duration(cfg.Interval), cfg.FailureLimit, e.Logger, e.LogPersister), nil
+	return newAnalyzer(id, provider.Type(), cfg.Query, runner, time.Duration(cfg.Interval), cfg.FailureLimit, e.Logger, e.LogPersister), nil
 }
 
 func (e *Executor) newAnalyzerForLog(i int, templatable *config.TemplatableAnalysisLog, templateCfg *config.AnalysisTemplateSpec) (*analyzer, error) {
@@ -226,11 +225,10 @@ func (e *Executor) newAnalyzerForLog(i int, templatable *config.TemplatableAnaly
 		return nil, err
 	}
 	id := fmt.Sprintf("log-%d", i)
-	runner := func(ctx context.Context) (bool, error) {
-		e.LogPersister.Infof("[%s] Run query against %s: %q", id, provider.Type(), cfg.Query)
-		return provider.RunQuery(ctx, cfg.Query)
+	runner := func(ctx context.Context, query string) (bool, string, error) {
+		return provider.RunQuery(ctx, query)
 	}
-	return newAnalyzer(id, provider.Type(), runner, time.Duration(cfg.Interval), cfg.FailureLimit, e.Logger, e.LogPersister), nil
+	return newAnalyzer(id, provider.Type(), cfg.Query, runner, time.Duration(cfg.Interval), cfg.FailureLimit, e.Logger, e.LogPersister), nil
 }
 
 func (e *Executor) newAnalyzerForHTTP(i int, templatable *config.TemplatableAnalysisHTTP, templateCfg *config.AnalysisTemplateSpec) (*analyzer, error) {
@@ -240,11 +238,10 @@ func (e *Executor) newAnalyzerForHTTP(i int, templatable *config.TemplatableAnal
 	}
 	provider := httpprovider.NewProvider(time.Duration(cfg.Timeout))
 	id := fmt.Sprintf("http-%d", i)
-	runner := func(ctx context.Context) (bool, error) {
-		e.LogPersister.Infof("[%s] Start running query against %s: %s %s", id, provider.Type(), cfg.Method, cfg.URL)
+	runner := func(ctx context.Context, query string) (bool, string, error) {
 		return provider.Run(ctx, cfg)
 	}
-	return newAnalyzer(id, provider.Type(), runner, time.Duration(cfg.Interval), cfg.FailureLimit, e.Logger, e.LogPersister), nil
+	return newAnalyzer(id, provider.Type(), "", runner, time.Duration(cfg.Interval), cfg.FailureLimit, e.Logger, e.LogPersister), nil
 }
 
 func (e *Executor) newMetricsProvider(providerName string, templatable *config.TemplatableAnalysisMetrics) (metrics.Provider, error) {

--- a/pkg/config/analysis.go
+++ b/pkg/config/analysis.go
@@ -14,7 +14,11 @@
 
 package config
 
-import "fmt"
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
 
 // AnalysisMetrics contains common configurable values for deployment analysis with metrics.
 type AnalysisMetrics struct {
@@ -54,13 +58,33 @@ func (e *AnalysisExpected) Validate() error {
 
 // InRange returns true if the given value is within the range.
 func (e *AnalysisExpected) InRange(value float64) bool {
-	if min := e.Min; min != nil && *min > value {
+	if e.Min != nil && *e.Min > value {
 		return false
 	}
-	if max := e.Max; max != nil && *max < value {
+	if e.Max != nil && *e.Max < value {
 		return false
 	}
 	return true
+}
+
+func (e *AnalysisExpected) String() string {
+	if e.Min == nil && e.Max == nil {
+		return ""
+	}
+
+	var b strings.Builder
+	if e.Min != nil {
+		min := strconv.FormatFloat(*e.Min, 'f', -1, 64)
+		b.WriteString(min + " ")
+	}
+
+	b.WriteString("<=")
+
+	if e.Max != nil {
+		max := strconv.FormatFloat(*e.Max, 'f', -1, 64)
+		b.WriteString(" " + max)
+	}
+	return b.String()
 }
 
 // AnalysisLog contains common configurable values for deployment analysis with log.

--- a/pkg/config/analysis_test.go
+++ b/pkg/config/analysis_test.go
@@ -13,3 +13,53 @@
 // limitations under the License.
 
 package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func floatPointer(v float64) *float64 {
+	return &v
+}
+
+func TestAnalysisExpectedString(t *testing.T) {
+	testcases := []struct {
+		name string
+		Min  *float64
+		Max  *float64
+		want string
+	}{
+		{
+			name: "only min given",
+			Min:  floatPointer(1.5),
+			want: "1.5 <=",
+		},
+		{
+			name: "only max given",
+			Max:  floatPointer(1.5),
+			want: "<= 1.5",
+		},
+		{
+			name: "both min and max given",
+			Min:  floatPointer(1.5),
+			Max:  floatPointer(2.5),
+			want: "1.5 <= 2.5",
+		},
+		{
+			name: "invalid range",
+			want: "",
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			e := &AnalysisExpected{
+				Min: tc.Min,
+				Max: tc.Max,
+			}
+			got := e.String()
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes the ANALYSIS stage log more readable a kind of like:

```
The query result is unexpected. Reason: found a value (9.846569061279297) that is out of the expected range (<= 5). Performed query: avg:system.cpu.user{host:gke-pipecd-dev-nakabonne-default-pool-d3361c90-17l1.c.pipecd.internal}
```

Until now, we were running into an issue that it has been a black box as to why query evaluation results are the way they are. But this makes it a little bit better.

**Which issue(s) this PR fixes**:

Fixes https://github.com/pipe-cd/pipe/issues/1682
Fixes https://github.com/pipe-cd/pipe/issues/790

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
