### PR TITLE
Add required index for MySQL datastore

### DIFF
--- a/pkg/app/ops/mysqlensurer/client.go
+++ b/pkg/app/ops/mysqlensurer/client.go
@@ -31,7 +31,10 @@ var (
 	mysqlDatabaseIndexes = mysqlProperties_0
 )
 
-const mysqlErrorCodeDuplicateKeyName = 1061
+const (
+	mysqlErrorCodeDuplicateColumnName = 1060
+	mysqlErrorCodeDuplicateKeyName    = 1061
+)
 
 type mysqlEnsurer struct {
 	client       *sql.DB
@@ -68,8 +71,8 @@ func NewMySQLEnsurer(url, database, usernameFile, passwordFile string, logger *z
 func (m *mysqlEnsurer) EnsureIndexes(ctx context.Context) error {
 	for _, stmt := range makeCreateIndexStatements(mysqlDatabaseIndexes) {
 		_, err := m.client.ExecContext(ctx, stmt)
-		// Ignore in case error duplicate key name occurred.
-		if mysqlErr, ok := err.(*mysql.MySQLError); ok && mysqlErr.Number == mysqlErrorCodeDuplicateKeyName {
+		// Ignore in case error duplicate key name or column name occurred.
+		if mysqlErr, ok := err.(*mysql.MySQLError); ok && (mysqlErr.Number == mysqlErrorCodeDuplicateKeyName || mysqlErr.Number == mysqlErrorCodeDuplicateColumnName) {
 			continue
 		}
 		if err != nil {

--- a/pkg/app/ops/mysqlensurer/indexes.sql
+++ b/pkg/app/ops/mysqlensurer/indexes.sql
@@ -6,24 +6,24 @@
 CREATE INDEX application_disabled_updated_at_desc ON Application (Disabled, UpdatedAt DESC);
 
 -- index on `EnvId` ASC and `UpdatedAt` DESC
-ALTER TABLE Application ADD COLUMN EnvId VARCHAR(32) GENERATED ALWAYS AS (data->>"$.env_id");
+ALTER TABLE Application ADD COLUMN EnvId VARCHAR(32) GENERATED ALWAYS AS (data->>"$.env_id") VIRTUAL;
 CREATE INDEX application_env_id_updated_at_desc ON Application (EnvId, UpdatedAt DESC);
 
 -- index on `Name` ASC and `UpdatedAt` DESC
-ALTER TABLE Application ADD COLUMN Name VARCHAR(50) GENERATED ALWAYS AS (data->>"$.name");
+ALTER TABLE Application ADD COLUMN Name VARCHAR(50) GENERATED ALWAYS AS (data->>"$.name") VIRTUAL;
 CREATE INDEX application_name_updated_at_desc ON Application (Name, UpdatedAt DESC);
 
 -- index on `Deleted` and `CreatedAt` ASC
 -- TODO: Reconsider make this Deleted column as STORED GENERATED COLUMN
-ALTER TABLE Application ADD COLUMN Deleted BOOL GENERATED ALWAYS AS (data->>"$.deleted");
+ALTER TABLE Application ADD COLUMN Deleted BOOL GENERATED ALWAYS AS (data->>"$.deleted") VIRTUAL;
 CREATE INDEX application_deleted_created_at_asc ON Application (Deleted, CreatedAt);
 
 -- index on `Kind` ASC and `UpdatedAt` DESC
-ALTER TABLE Application ADD COLUMN Kind INT GENERATED ALWAYS AS (data->>"$.kind");
+ALTER TABLE Application ADD COLUMN Kind INT GENERATED ALWAYS AS (data->>"$.kind") VIRTUAL;
 CREATE INDEX application_kind_updated_at_desc ON Application (Kind, UpdatedAt DESC);
 
 -- index on `SyncState.Status` ASC and `UpdatedAt` DESC
-ALTER TABLE Application ADD COLUMN SyncState INT GENERATED ALWAYS AS (data->>"$.sync_state.status");
+ALTER TABLE Application ADD COLUMN SyncState INT GENERATED ALWAYS AS (data->>"$.sync_state.status") VIRTUAL;
 CREATE INDEX application_sync_state_updated_at_desc ON Application (SyncState, UpdatedAt DESC);
 
 -- index on `ProjectId` ASC and `UpdatedAt` DESC
@@ -34,7 +34,7 @@ CREATE INDEX application_project_id_updated_at_desc ON Application (ProjectId, U
 --
 
 -- index on `Status` ASC and `CreatedAt` ASC
-ALTER TABLE Command ADD COLUMN Status INT GENERATED ALWAYS AS (data->>"$.status");
+ALTER TABLE Command ADD COLUMN Status INT GENERATED ALWAYS AS (data->>"$.status") VIRTUAL;
 CREATE INDEX command_status_created_at_asc ON Command (Status, CreatedAt);
 
 --
@@ -42,22 +42,22 @@ CREATE INDEX command_status_created_at_asc ON Command (Status, CreatedAt);
 --
 
 -- index on `ApplicationId` ASC and `UpdatedAt` DESC
-ALTER TABLE Deployment ADD COLUMN ApplicationId VARCHAR(32) GENERATED ALWAYS AS (data->>"$.application_id");
+ALTER TABLE Deployment ADD COLUMN ApplicationId VARCHAR(32) GENERATED ALWAYS AS (data->>"$.application_id") VIRTUAL;
 CREATE INDEX deployment_application_id_updated_at_desc ON Deployment (ApplicationId, UpdatedAt DESC);
 
 -- index on `ProjectId` ASC and `UpdatedAt` DESC
 CREATE INDEX deployment_project_id_updated_at_desc ON Deployment (ProjectId, UpdatedAt DESC);
 
 -- index on `EnvId` ASC and `UpdatedAt` DESC
-ALTER TABLE Deployment ADD COLUMN EnvId VARCHAR(32) GENERATED ALWAYS AS (data->>"$.env_id");
+ALTER TABLE Deployment ADD COLUMN EnvId VARCHAR(32) GENERATED ALWAYS AS (data->>"$.env_id") VIRTUAL;
 CREATE INDEX deployment_env_id_updated_at_desc ON Deployment (EnvId, UpdatedAt DESC);
 
 -- index on `Kind` ASC and `UpdatedAt` DESC
-ALTER TABLE Deployment ADD COLUMN Kind INT GENERATED ALWAYS AS (data->>"$.kind");
+ALTER TABLE Deployment ADD COLUMN Kind INT GENERATED ALWAYS AS (data->>"$.kind") VIRTUAL;
 CREATE INDEX deployment_kind_updated_at_desc ON Deployment (Kind, UpdatedAt DESC);
 
 -- index on `Status` ASC and `UpdatedAt` DESC
-ALTER TABLE Deployment ADD COLUMN Status INT GENERATED ALWAYS AS (data->>"$.status");
+ALTER TABLE Deployment ADD COLUMN Status INT GENERATED ALWAYS AS (data->>"$.status") VIRTUAL;
 CREATE INDEX deployment_status_updated_at_desc ON Deployment (Status, UpdatedAt DESC);
 
 --
@@ -68,5 +68,5 @@ CREATE INDEX deployment_status_updated_at_desc ON Deployment (Status, UpdatedAt 
 CREATE INDEX event_project_id_created_at_asc ON Event (ProjectId, CreatedAt);
 
 -- index on `EventKey` ASC, `Name` ASC, `ProjectId` ASC and `CreatedAt` DESC
-ALTER TABLE Event ADD COLUMN EventKey VARCHAR(64) GENERATED ALWAYS AS (data->>"$.event_key"), ADD COLUMN Name VARCHAR(50) GENERATED ALWAYS AS (data->>"$.name");
+ALTER TABLE Event ADD COLUMN EventKey VARCHAR(64) GENERATED ALWAYS AS (data->>"$.event_key") VIRTUAL, ADD COLUMN Name VARCHAR(50) GENERATED ALWAYS AS (data->>"$.name") VIRTUAL;
 CREATE INDEX event_key_name_project_id_created_at_desc ON Event (EventKey, Name, ProjectId, CreatedAt DESC);

--- a/pkg/app/ops/mysqlensurer/indexes.sql
+++ b/pkg/app/ops/mysqlensurer/indexes.sql
@@ -1,6 +1,72 @@
--- TODO: Add all required indexes for PipeCD.
--- index on `updated_at` field on `Application` table in ASC direction
-CREATE INDEX application_updated_at_asc ON Application (updated_at ASC);
+--
+-- Application table indexes
+--
 
--- index on `created_at` field on `Application` table in DESC direction
-CREATE INDEX application_created_at_desc ON Application (created_at DESC);
+-- index on `Disabled` and `UpdatedAt` DESC
+CREATE INDEX application_disabled_updated_at_desc ON Application (Disabled, UpdatedAt DESC);
+
+-- index on `EnvId` ASC and `UpdatedAt` DESC
+ALTER TABLE Application ADD COLUMN EnvId VARCHAR(32) GENERATED ALWAYS AS (data->>"$.env_id");
+CREATE INDEX application_env_id_updated_at_desc ON Application (EnvId, UpdatedAt DESC);
+
+-- index on `Name` ASC and `UpdatedAt` DESC
+ALTER TABLE Application ADD COLUMN Name VARCHAR(50) GENERATED ALWAYS AS (data->>"$.name");
+CREATE INDEX application_name_updated_at_desc ON Application (Name, UpdatedAt DESC);
+
+-- index on `Deleted` and `CreatedAt` ASC
+-- TODO: Reconsider make this Deleted column as STORED GENERATED COLUMN
+ALTER TABLE Application ADD COLUMN Deleted BOOL GENERATED ALWAYS AS (data->>"$.deleted");
+CREATE INDEX application_deleted_created_at_asc ON Application (Deleted, CreatedAt);
+
+-- index on `Kind` ASC and `UpdatedAt` DESC
+ALTER TABLE Application ADD COLUMN Kind INT GENERATED ALWAYS AS (data->>"$.kind");
+CREATE INDEX application_kind_updated_at_desc ON Application (Kind, UpdatedAt DESC);
+
+-- index on `SyncState.Status` ASC and `UpdatedAt` DESC
+ALTER TABLE Application ADD COLUMN SyncState INT GENERATED ALWAYS AS (data->>"$.sync_state.status");
+CREATE INDEX application_sync_state_updated_at_desc ON Application (SyncState, UpdatedAt DESC);
+
+-- index on `ProjectId` ASC and `UpdatedAt` DESC
+CREATE INDEX application_project_id_updated_at_desc ON Application (ProjectId, UpdatedAt DESC);
+
+--
+-- Command table indexes
+--
+
+-- index on `Status` ASC and `CreatedAt` ASC
+ALTER TABLE Command ADD COLUMN Status INT GENERATED ALWAYS AS (data->>"$.status");
+CREATE INDEX command_status_created_at_asc ON Command (Status, CreatedAt);
+
+--
+-- Deployment table indexes
+--
+
+-- index on `ApplicationId` ASC and `UpdatedAt` DESC
+ALTER TABLE Deployment ADD COLUMN ApplicationId VARCHAR(32) GENERATED ALWAYS AS (data->>"$.application_id");
+CREATE INDEX deployment_application_id_updated_at_desc ON Deployment (ApplicationId, UpdatedAt DESC);
+
+-- index on `ProjectId` ASC and `UpdatedAt` DESC
+CREATE INDEX deployment_project_id_updated_at_desc ON Deployment (ProjectId, UpdatedAt DESC);
+
+-- index on `EnvId` ASC and `UpdatedAt` DESC
+ALTER TABLE Deployment ADD COLUMN EnvId VARCHAR(32) GENERATED ALWAYS AS (data->>"$.env_id");
+CREATE INDEX deployment_env_id_updated_at_desc ON Deployment (EnvId, UpdatedAt DESC);
+
+-- index on `Kind` ASC and `UpdatedAt` DESC
+ALTER TABLE Deployment ADD COLUMN Kind INT GENERATED ALWAYS AS (data->>"$.kind");
+CREATE INDEX deployment_kind_updated_at_desc ON Deployment (Kind, UpdatedAt DESC);
+
+-- index on `Status` ASC and `UpdatedAt` DESC
+ALTER TABLE Deployment ADD COLUMN Status INT GENERATED ALWAYS AS (data->>"$.status");
+CREATE INDEX deployment_status_updated_at_desc ON Deployment (Status, UpdatedAt DESC);
+
+--
+-- Event table indexes
+--
+
+-- index on `ProjectId` ASC and `CreatedAt` ASC
+CREATE INDEX event_project_id_created_at_asc ON Event (ProjectId, CreatedAt);
+
+-- index on `EventKey` ASC, `Name` ASC, `ProjectId` ASC and `CreatedAt` DESC
+ALTER TABLE Event ADD COLUMN EventKey VARCHAR(64) GENERATED ALWAYS AS (data->>"$.event_key"), ADD COLUMN Name VARCHAR(50) GENERATED ALWAYS AS (data->>"$.name");
+CREATE INDEX event_key_name_project_id_created_at_desc ON Event (EventKey, Name, ProjectId, CreatedAt DESC);


### PR DESCRIPTION
**What this PR does / why we need it**:

Add required indexes for MySQL.

Note: In order to create indexes on JSON data attribute (which not mapped as `STORED GENERATED COLUMNS` in Schema), I created a `VIRTUAL GENERATED COLUMN` for each required JSON attribute. The column adding action requires an `ALTER TABLE` statement, but as far as I investigated, the `ADD VIRTUAL GENERATED COLUMN` run "online" (ref: [online DDL generated column operations](https://dev.mysql.com/doc/refman/8.0/en/innodb-online-ddl-operations.html#online-ddl-generated-column-operations)) so it would not affect PipeCD control plane readiness.

**Which issue(s) this PR fixes**:

Fixes #1710 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
