### PR TITLE
Make sure step is smaller than query range

### DIFF
--- a/pkg/app/piped/analysisprovider/log/provider.go
+++ b/pkg/app/piped/analysisprovider/log/provider.go
@@ -21,8 +21,8 @@ import (
 // Provider represents a client for log provider which provides logs for analysis.
 type Provider interface {
 	Type() string
-	// RunQuery runs the given query against the log provider,
+	// Evaluate runs the given query against the log provider,
 	// and then checks if there is at least one error log.
 	// Returns the result reason if non-error occurred.
-	RunQuery(ctx context.Context, query string) (result bool, reason string, err error)
+	Evaluate(ctx context.Context, query string) (result bool, reason string, err error)
 }

--- a/pkg/app/piped/analysisprovider/log/stackdriver/stackdriver.go
+++ b/pkg/app/piped/analysisprovider/log/stackdriver/stackdriver.go
@@ -38,6 +38,6 @@ func (p *Provider) Type() string {
 	return ProviderType
 }
 
-func (p *Provider) RunQuery(ctx context.Context, query string) (bool, string, error) {
+func (p *Provider) Evaluate(ctx context.Context, query string) (bool, string, error) {
 	return false, "", nil
 }

--- a/pkg/app/piped/analysisprovider/metrics/datadog/datadog.go
+++ b/pkg/app/piped/analysisprovider/metrics/datadog/datadog.go
@@ -89,9 +89,9 @@ func (p *Provider) Type() string {
 	return ProviderType
 }
 
-// RunQuery issues an HTTP request to the API named "MetricsApi.QueryMetrics", then evaluate its response.
+// Evaluate issues an HTTP request to the API named "MetricsApi.QueryMetrics", then evaluate its response.
 // See more: https://docs.datadoghq.com/api/latest/metrics/#query-timeseries-points
-func (p *Provider) RunQuery(ctx context.Context, query string, queryRange metrics.QueryRange, evaluator metrics.Evaluator) (bool, string, error) {
+func (p *Provider) Evaluate(ctx context.Context, query string, queryRange metrics.QueryRange, evaluator metrics.Evaluator) (bool, string, error) {
 	if err := queryRange.Validate(); err != nil {
 		return false, "", err
 	}

--- a/pkg/app/piped/analysisprovider/metrics/prometheus/prometheus.go
+++ b/pkg/app/piped/analysisprovider/metrics/prometheus/prometheus.go
@@ -93,7 +93,7 @@ func (p *Provider) Evaluate(ctx context.Context, query string, queryRange metric
 	ctx, cancel := context.WithTimeout(ctx, p.timeout)
 	defer cancel()
 
-	// NOTE: Use 1m as a step but make sure the "step" isn't smaller than the query range.
+	// NOTE: Use 1m as a step but make sure the "step" is smaller than the query range.
 	step := time.Minute
 	if diff := queryRange.To.Sub(queryRange.From); diff < step {
 		step = diff

--- a/pkg/app/piped/analysisprovider/metrics/prometheus/prometheus_test.go
+++ b/pkg/app/piped/analysisprovider/metrics/prometheus/prometheus_test.go
@@ -25,7 +25,7 @@ func TestType(t *testing.T) {
 	assert.Equal(t, ProviderType, p.Type())
 }
 
-func TestRunQuery(t *testing.T) {
+func TestProviderEvaluate(t *testing.T) {
 	cases := []struct {
 		name       string
 		value      model.Value
@@ -84,7 +84,7 @@ func TestRunQuery(t *testing.T) {
 				timeout: defaultTimeout,
 				logger:  zap.NewNop(),
 			}
-			res, _, err := p.RunQuery(context.Background(), "dummy", metrics.QueryRange{From: time.Now()}, tc.expected)
+			res, _, err := p.Evaluate(context.Background(), "dummy", metrics.QueryRange{From: time.Now()}, tc.expected)
 			assert.Equal(t, tc.wantErr, err != nil)
 			assert.Equal(t, res, tc.wantResult)
 		})

--- a/pkg/app/piped/analysisprovider/metrics/provider.go
+++ b/pkg/app/piped/analysisprovider/metrics/provider.go
@@ -28,10 +28,10 @@ var (
 // Provider represents a client for metrics provider which provides metrics for analysis.
 type Provider interface {
 	Type() string
-	// RunQuery runs the given query against the metrics provider,
+	// Evaluate runs the given query against the metrics provider,
 	// and then checks if the results are expected or not.
 	// Returns the result reason if non-error occurred.
-	RunQuery(ctx context.Context, query string, queryRange QueryRange, evaluator Evaluator) (expected bool, reason string, err error)
+	Evaluate(ctx context.Context, query string, queryRange QueryRange, evaluator Evaluator) (expected bool, reason string, err error)
 }
 
 // Evaluator evaluates the response from the metrics provider.
@@ -47,8 +47,6 @@ type QueryRange struct {
 	From time.Time
 	// End of the queried time period. Defaults to the current time.
 	To time.Time
-	// Query resolution step width. Defaults to 1m.
-	Step time.Duration
 }
 
 func (q *QueryRange) Validate() error {
@@ -58,9 +56,8 @@ func (q *QueryRange) Validate() error {
 	if q.To.IsZero() {
 		q.To = time.Now()
 	}
-	// TODO: Look into the appropriate default value of a Step
-	if q.Step == 0 {
-		q.Step = time.Minute
+	if q.From.After(q.To) {
+		return fmt.Errorf("\"to\" should be after \"from\"")
 	}
 	return nil
 }

--- a/pkg/app/piped/executor/analysis/analysis.go
+++ b/pkg/app/piped/executor/analysis/analysis.go
@@ -206,11 +206,12 @@ func (e *Executor) newAnalyzerForMetrics(i int, templatable *config.TemplatableA
 	}
 	id := fmt.Sprintf("metrics-%d", i)
 	runner := func(ctx context.Context, query string) (bool, string, error) {
+		now := time.Now()
 		queryRange := metrics.QueryRange{
-			From: time.Now().Add(-cfg.Interval.Duration()),
-			To:   time.Now(),
+			From: now.Add(-cfg.Interval.Duration()),
+			To:   now,
 		}
-		return provider.RunQuery(ctx, query, queryRange, &cfg.Expected)
+		return provider.Evaluate(ctx, query, queryRange, &cfg.Expected)
 	}
 	return newAnalyzer(id, provider.Type(), cfg.Query, runner, time.Duration(cfg.Interval), cfg.FailureLimit, e.Logger, e.LogPersister), nil
 }
@@ -226,7 +227,7 @@ func (e *Executor) newAnalyzerForLog(i int, templatable *config.TemplatableAnaly
 	}
 	id := fmt.Sprintf("log-%d", i)
 	runner := func(ctx context.Context, query string) (bool, string, error) {
-		return provider.RunQuery(ctx, query)
+		return provider.Evaluate(ctx, query)
 	}
 	return newAnalyzer(id, provider.Type(), cfg.Query, runner, time.Duration(cfg.Interval), cfg.FailureLimit, e.Logger, e.LogPersister), nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
The core part of this PR is in `pkg/app/piped/analysisprovider/metrics/prometheus/prometheus.go`. This PR guarantees the query step must be bigger than the query range (to - from).

**Which issue(s) this PR fixes**:

Fixes https://github.com/pipe-cd/pipe/issues/1708

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
