### PR TITLE
Remove web target from coverage job on CI

### DIFF
--- a/.kapetanios/presubmit.yaml
+++ b/.kapetanios/presubmit.yaml
@@ -31,7 +31,7 @@ spec:
     - description: Run coverage for unit tests
       runner: gcr.io/pipecd/runner:1.0.0
       commands:
-        - bazelisk --output_base=/workspace/bazel_out coverage --config=ci --config=linux //pkg/...
+        - bazelisk --output_base=/workspace/bazel_out coverage --config=ci --config=linux -- //pkg/... -//pkg/app/web/...
       secrets:
       - name: bazel_cache_service_account
         type: PROJECT

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ test-integration:
 
 .PHONY: coverage
 coverage:
-	bazelisk ${BAZEL_FLAGS} coverage ${BAZEL_COMMAND_FLAGS} //pkg/...
+	bazelisk ${BAZEL_FLAGS} coverage ${BAZEL_COMMAND_FLAGS} -- //pkg/... -//pkg/app/web/...
 
 .PHONY: dep
 dep:


### PR DESCRIPTION
**What this PR does / why we need it**:

* This is because collecting web coverage is defined as another job.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
