### PR TITLE
Remove unnecessary NOT NULL check for omitempty fields

### DIFF
--- a/pkg/app/ops/mysqlensurer/schema.sql
+++ b/pkg/app/ops/mysqlensurer/schema.sql
@@ -18,9 +18,9 @@ CREATE TABLE IF NOT EXISTS Application (
   Id BINARY(16) PRIMARY KEY,
   Data JSON NOT NULL,
   ProjectId VARCHAR(50) GENERATED ALWAYS AS (data->>"$.project_id") STORED NOT NULL,
-  Disabled BOOL GENERATED ALWAYS AS (data->>"$.disabled") STORED,
   CreatedAt INT(11) GENERATED ALWAYS AS (data->>"$.created_at") STORED NOT NULL,
   UpdatedAt INT(11) GENERATED ALWAYS AS (data->>"$.updated_at") STORED NOT NULL,
+  Disabled BOOL GENERATED ALWAYS AS (data->>"$.disabled") STORED,
   Extra VARCHAR(100) GENERATED ALWAYS AS (data->>"$._extra") STORED
 ) ENGINE=InnoDB;
 
@@ -71,9 +71,9 @@ CREATE TABLE IF NOT EXISTS Piped (
   Id BINARY(16) PRIMARY KEY,
   Data JSON NOT NULL,
   ProjectId VARCHAR(50) GENERATED ALWAYS AS (data->>"$.project_id") STORED NOT NULL,
-  Disabled BOOL GENERATED ALWAYS AS (data->>"$.disabled") STORED,
   CreatedAt INT(11) GENERATED ALWAYS AS (data->>"$.created_at") STORED NOT NULL,
   UpdatedAt INT(11) GENERATED ALWAYS AS (data->>"$.updated_at") STORED NOT NULL,
+  Disabled BOOL GENERATED ALWAYS AS (data->>"$.disabled") STORED,
   Extra VARCHAR(100) GENERATED ALWAYS AS (data->>"$._extra") STORED
 ) ENGINE=InnoDB;
 
@@ -85,9 +85,9 @@ CREATE TABLE IF NOT EXISTS APIKey (
   Id BINARY(16) PRIMARY KEY,
   Data JSON NOT NULL,
   ProjectId VARCHAR(50) GENERATED ALWAYS AS (data->>"$.project_id") STORED NOT NULL,
-  Disabled BOOL GENERATED ALWAYS AS (data->>"$.disabled") STORED,
   CreatedAt INT(11) GENERATED ALWAYS AS (data->>"$.created_at") STORED NOT NULL,
   UpdatedAt INT(11) GENERATED ALWAYS AS (data->>"$.updated_at") STORED NOT NULL,
+  Disabled BOOL GENERATED ALWAYS AS (data->>"$.disabled") STORED,
   Extra VARCHAR(100) GENERATED ALWAYS AS (data->>"$._extra") STORED
 ) ENGINE=InnoDB;
 

--- a/pkg/app/ops/mysqlensurer/schema.sql
+++ b/pkg/app/ops/mysqlensurer/schema.sql
@@ -18,7 +18,7 @@ CREATE TABLE IF NOT EXISTS Application (
   Id BINARY(16) PRIMARY KEY,
   Data JSON NOT NULL,
   ProjectId VARCHAR(50) GENERATED ALWAYS AS (data->>"$.project_id") STORED NOT NULL,
-  Disabled BOOL GENERATED ALWAYS AS (data->>"$.disabled") STORED NOT NULL,
+  Disabled BOOL GENERATED ALWAYS AS (data->>"$.disabled") STORED,
   CreatedAt INT(11) GENERATED ALWAYS AS (data->>"$.created_at") STORED NOT NULL,
   UpdatedAt INT(11) GENERATED ALWAYS AS (data->>"$.updated_at") STORED NOT NULL,
   Extra VARCHAR(100) GENERATED ALWAYS AS (data->>"$._extra") STORED
@@ -71,7 +71,7 @@ CREATE TABLE IF NOT EXISTS Piped (
   Id BINARY(16) PRIMARY KEY,
   Data JSON NOT NULL,
   ProjectId VARCHAR(50) GENERATED ALWAYS AS (data->>"$.project_id") STORED NOT NULL,
-  Disabled BOOL GENERATED ALWAYS AS (data->>"$.disabled") STORED NOT NULL,
+  Disabled BOOL GENERATED ALWAYS AS (data->>"$.disabled") STORED,
   CreatedAt INT(11) GENERATED ALWAYS AS (data->>"$.created_at") STORED NOT NULL,
   UpdatedAt INT(11) GENERATED ALWAYS AS (data->>"$.updated_at") STORED NOT NULL,
   Extra VARCHAR(100) GENERATED ALWAYS AS (data->>"$._extra") STORED
@@ -85,7 +85,7 @@ CREATE TABLE IF NOT EXISTS APIKey (
   Id BINARY(16) PRIMARY KEY,
   Data JSON NOT NULL,
   ProjectId VARCHAR(50) GENERATED ALWAYS AS (data->>"$.project_id") STORED NOT NULL,
-  Disabled BOOL GENERATED ALWAYS AS (data->>"$.disabled") STORED NOT NULL,
+  Disabled BOOL GENERATED ALWAYS AS (data->>"$.disabled") STORED,
   CreatedAt INT(11) GENERATED ALWAYS AS (data->>"$.created_at") STORED NOT NULL,
   UpdatedAt INT(11) GENERATED ALWAYS AS (data->>"$.updated_at") STORED NOT NULL,
   Extra VARCHAR(100) GENERATED ALWAYS AS (data->>"$._extra") STORED


### PR DESCRIPTION
**What this PR does / why we need it**:

Fields such as `Disable` from current models are all omitted empty fields, which leads to error unable to create in case instances of those models passed without zero values on those fields.
After this PR, only `ProjectId`, `CreatedAt`, and `UpdatedAt` are required `NOT NULL` fields for data in MySQL datastore.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
