### PR TITLE
Refine ListFilter value for MySQL datastore

### DIFF
--- a/pkg/datastore/mysql/mysql.go
+++ b/pkg/datastore/mysql/mysql.go
@@ -79,11 +79,6 @@ func NewMySQL(url, database string, opts ...Option) (*MySQL, error) {
 
 // Find implementation for MySQL
 func (m *MySQL) Find(ctx context.Context, kind string, opts datastore.ListOptions) (datastore.Iterator, error) {
-	filterVals := make([]interface{}, len(opts.Filters))
-	for i, filter := range opts.Filters {
-		filterVals[i] = filter.Value
-	}
-
 	query, err := buildFindQuery(kind, opts)
 	if err != nil {
 		m.logger.Error("failed to build find entities query",
@@ -93,7 +88,7 @@ func (m *MySQL) Find(ctx context.Context, kind string, opts datastore.ListOption
 		return nil, err
 	}
 
-	rows, err := m.client.QueryContext(ctx, query, filterVals...)
+	rows, err := m.client.QueryContext(ctx, query, refineFiltersValue(opts.Filters)...)
 	if err != nil {
 		m.logger.Error("failed to find entities",
 			zap.String("kind", kind),

--- a/pkg/datastore/mysql/query.go
+++ b/pkg/datastore/mysql/query.go
@@ -16,6 +16,7 @@ package mysql
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
 
 	"github.com/pipe-cd/pipe/pkg/datastore"
@@ -145,4 +146,22 @@ func refineFiltersOperator(filters []datastore.ListFilter) ([]datastore.ListFilt
 		out[i] = filter
 	}
 	return out, nil
+}
+
+func refineFiltersValue(filters []datastore.ListFilter) []interface{} {
+	filtersVals := make([]interface{}, len(filters))
+	for i, filter := range filters {
+		fv := reflect.ValueOf(filter.Value)
+		switch fv.Kind() {
+		case reflect.Slice, reflect.Array:
+			vals := make([]string, fv.Len())
+			for j := 0; j < fv.Len(); j++ {
+				vals[j] = fmt.Sprintf("%v", fv.Index(j))
+			}
+			filtersVals[i] = fmt.Sprintf("(%s)", strings.Join(vals, ","))
+		default:
+			filtersVals[i] = filter.Value
+		}
+	}
+	return filtersVals
 }

--- a/pkg/datastore/mysql/query_test.go
+++ b/pkg/datastore/mysql/query_test.go
@@ -272,3 +272,46 @@ func TestBuildFindQuery(t *testing.T) {
 		})
 	}
 }
+
+func TestRefineFiltersValue(t *testing.T) {
+	testcases := []struct {
+		name               string
+		filters            []datastore.ListFilter
+		expectedFiltersVal []interface{}
+	}{
+		{
+			name: "mixed types",
+			filters: []datastore.ListFilter{
+				{
+					Value: 1,
+				},
+				{
+					Value: "app-1",
+				},
+				{
+					Value: []string{"app-1", "app-2", "app-3"},
+				},
+				{
+					Value: []int32{1, 2, 3},
+				},
+				{
+					Value: [3]int32{1, 2, 3},
+				},
+			},
+			expectedFiltersVal: []interface{}{
+				1,
+				"app-1",
+				"(app-1,app-2,app-3)",
+				"(1,2,3)",
+				"(1,2,3)",
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			vals := refineFiltersValue(tc.filters)
+			assert.Equal(t, tc.expectedFiltersVal, vals)
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, `database/sql` package from Golang does not support values of type Slide, which leads to errors: `{"error": "sql: converting argument $2 type: unsupported type []model.DeploymentStatus, a slice of int32"}` on query `IN` operator in our current `Find` query implementation of MySQL client.

ref: https://golang.org/src/database/sql/driver/types.go#L280

**Which issue(s) this PR fixes**:

Avoid the above error by build query values of type `slide` or `array` as `(v1,v2,...)` pattern which satisfied the Golang SQL interface.

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
