### PR TITLE
Make it changeable how to handle no data point

### DIFF
--- a/docs/content/en/docs/user-guide/configuration-reference.md
+++ b/docs/content/en/docs/user-guide/configuration-reference.md
@@ -286,7 +286,7 @@ spec:
 | expected | [AnalysisExpected](/docs/user-guide/configuration-reference/#analysisexpected) | The expected query result. | Yes |
 | interval | duration | Run a query at specified intervals. | Yes |
 | failureLimit | int | Acceptable number of failures. e.g. If 1 is set, the `ANALYSIS` stage will end with failure after two queries results failed. Defaults to 1. | No |
-| skipNoData | bool | If true, it considers as a success when no data returned from the analysis provider. Defaults to false. | No |
+| skipOnNoData | bool | If true, it considers as a success when no data returned from the analysis provider. Defaults to false. | No |
 | timeout | duration | How long after which the query times out. | No |
 | template | [AnalysisTemplateRef](/docs/user-guide/configuration-reference/#analysistemplateref) | Reference to the template to be used. | No |
 

--- a/docs/content/en/docs/user-guide/configuration-reference.md
+++ b/docs/content/en/docs/user-guide/configuration-reference.md
@@ -286,7 +286,7 @@ spec:
 | expected | [AnalysisExpected](/docs/user-guide/configuration-reference/#analysisexpected) | The expected query result. | Yes |
 | interval | duration | Run a query at specified intervals. | Yes |
 | failureLimit | int | Acceptable number of failures. e.g. If 1 is set, the `ANALYSIS` stage will end with failure after two queries results failed. Defaults to 1. | No |
-| nodataAsSuccess | bool | If true, it considers as a success when no data returned from the analysis provider. Defaults to false. | No |
+| skipNoData | bool | If true, it considers as a success when no data returned from the analysis provider. Defaults to false. | No |
 | timeout | duration | How long after which the query times out. | No |
 | template | [AnalysisTemplateRef](/docs/user-guide/configuration-reference/#analysistemplateref) | Reference to the template to be used. | No |
 

--- a/docs/content/en/docs/user-guide/configuration-reference.md
+++ b/docs/content/en/docs/user-guide/configuration-reference.md
@@ -286,6 +286,7 @@ spec:
 | expected | [AnalysisExpected](/docs/user-guide/configuration-reference/#analysisexpected) | The expected query result. | Yes |
 | interval | duration | Run a query at specified intervals. | Yes |
 | failureLimit | int | Acceptable number of failures. e.g. If 1 is set, the `ANALYSIS` stage will end with failure after two queries results failed. Defaults to 1. | No |
+| nodataAsSuccess | bool | If true, it considers as a success when no data returned from the analysis provider. Defaults to false. | No |
 | timeout | duration | How long after which the query times out. | No |
 | template | [AnalysisTemplateRef](/docs/user-guide/configuration-reference/#analysistemplateref) | Reference to the template to be used. | No |
 

--- a/pkg/app/piped/analysisprovider/metrics/datadog/datadog.go
+++ b/pkg/app/piped/analysisprovider/metrics/datadog/datadog.go
@@ -128,7 +128,7 @@ func (p *Provider) Evaluate(ctx context.Context, query string, queryRange metric
 		return false, "", fmt.Errorf("unexpected HTTP status code from %s: %d", httpResp.Request.URL, httpResp.StatusCode)
 	}
 	if resp.Series == nil || len(*resp.Series) == 0 {
-		return false, "", metrics.ErrNoValuesFound
+		return false, "", fmt.Errorf("no query metadata found: %w", metrics.ErrNoDataFound)
 	}
 	return evaluate(evaluator, *resp.Series)
 }
@@ -138,7 +138,7 @@ func evaluate(evaluator metrics.Evaluator, series []datadog.MetricsQueryMetadata
 	for _, s := range series {
 		points := s.Pointlist
 		if points == nil || len(*points) == 0 {
-			return false, "", fmt.Errorf("invalid response: no data points of the time series found")
+			return false, "", fmt.Errorf("invalid response: no data points found within the queried range: %w", metrics.ErrNoDataFound)
 		}
 		for _, point := range *points {
 			if len(point) < 2 {

--- a/pkg/app/piped/analysisprovider/metrics/prometheus/prometheus.go
+++ b/pkg/app/piped/analysisprovider/metrics/prometheus/prometheus.go
@@ -130,7 +130,7 @@ func (p *Provider) Evaluate(ctx context.Context, query string, queryRange metric
 func evaluate(evaluator metrics.Evaluator, response model.Value) (bool, string, error) {
 	evaluateValue := func(value float64) (bool, error) {
 		if math.IsNaN(value) {
-			return false, fmt.Errorf("the value is not a number")
+			return false, fmt.Errorf("the value is not a number: %w", metrics.ErrNoDataFound)
 		}
 		return evaluator.InRange(value), nil
 	}
@@ -148,7 +148,7 @@ func evaluate(evaluator metrics.Evaluator, response model.Value) (bool, string, 
 		}
 	case model.Vector:
 		if len(res) == 0 {
-			return false, "", fmt.Errorf("zero value in instant vector type returned")
+			return false, "", fmt.Errorf("zero value in instant vector type returned: %w", metrics.ErrNoDataFound)
 		}
 		// Check if all values are expected value.
 		for _, s := range res {
@@ -166,12 +166,12 @@ func evaluate(evaluator metrics.Evaluator, response model.Value) (bool, string, 
 		}
 	case model.Matrix:
 		if len(res) == 0 {
-			return false, "", fmt.Errorf("no time series data points in range vector type")
+			return false, "", fmt.Errorf("no time series data points in range vector type: %w", metrics.ErrNoDataFound)
 		}
 		// Check if all values are expected value.
 		for _, r := range res {
 			if len(r.Values) == 0 {
-				return false, "", fmt.Errorf("zero value in range vector type returned")
+				return false, "", fmt.Errorf("zero value in range vector type returned: %w", metrics.ErrNoDataFound)
 			}
 			for _, value := range r.Values {
 				expected, err := evaluateValue(float64(value.Value))

--- a/pkg/app/piped/analysisprovider/metrics/provider.go
+++ b/pkg/app/piped/analysisprovider/metrics/provider.go
@@ -22,7 +22,7 @@ import (
 )
 
 var (
-	ErrNoValuesFound = errors.New("no values found")
+	ErrNoDataFound = errors.New("no data found")
 )
 
 // Provider represents a client for metrics provider which provides metrics for analysis.
@@ -31,6 +31,7 @@ type Provider interface {
 	// Evaluate runs the given query against the metrics provider,
 	// and then checks if the results are expected or not.
 	// Returns the result reason if non-error occurred.
+	// The first value "expected" must be false if err isn't nil.
 	Evaluate(ctx context.Context, query string, queryRange QueryRange, evaluator Evaluator) (expected bool, reason string, err error)
 }
 

--- a/pkg/app/piped/executor/analysis/analysis.go
+++ b/pkg/app/piped/executor/analysis/analysis.go
@@ -213,7 +213,7 @@ func (e *Executor) newAnalyzerForMetrics(i int, templatable *config.TemplatableA
 		}
 		return provider.Evaluate(ctx, query, queryRange, &cfg.Expected)
 	}
-	return newAnalyzer(id, provider.Type(), cfg.Query, runner, time.Duration(cfg.Interval), cfg.FailureLimit, e.Logger, e.LogPersister), nil
+	return newAnalyzer(id, provider.Type(), cfg.Query, runner, time.Duration(cfg.Interval), cfg.FailureLimit, cfg.NodataAsSuccess, e.Logger, e.LogPersister), nil
 }
 
 func (e *Executor) newAnalyzerForLog(i int, templatable *config.TemplatableAnalysisLog, templateCfg *config.AnalysisTemplateSpec) (*analyzer, error) {
@@ -229,7 +229,7 @@ func (e *Executor) newAnalyzerForLog(i int, templatable *config.TemplatableAnaly
 	runner := func(ctx context.Context, query string) (bool, string, error) {
 		return provider.Evaluate(ctx, query)
 	}
-	return newAnalyzer(id, provider.Type(), cfg.Query, runner, time.Duration(cfg.Interval), cfg.FailureLimit, e.Logger, e.LogPersister), nil
+	return newAnalyzer(id, provider.Type(), cfg.Query, runner, time.Duration(cfg.Interval), cfg.FailureLimit, cfg.NodataAsSuccess, e.Logger, e.LogPersister), nil
 }
 
 func (e *Executor) newAnalyzerForHTTP(i int, templatable *config.TemplatableAnalysisHTTP, templateCfg *config.AnalysisTemplateSpec) (*analyzer, error) {
@@ -242,7 +242,7 @@ func (e *Executor) newAnalyzerForHTTP(i int, templatable *config.TemplatableAnal
 	runner := func(ctx context.Context, query string) (bool, string, error) {
 		return provider.Run(ctx, cfg)
 	}
-	return newAnalyzer(id, provider.Type(), "", runner, time.Duration(cfg.Interval), cfg.FailureLimit, e.Logger, e.LogPersister), nil
+	return newAnalyzer(id, provider.Type(), "", runner, time.Duration(cfg.Interval), cfg.FailureLimit, cfg.NodataAsSuccess, e.Logger, e.LogPersister), nil
 }
 
 func (e *Executor) newMetricsProvider(providerName string, templatable *config.TemplatableAnalysisMetrics) (metrics.Provider, error) {

--- a/pkg/app/piped/executor/analysis/analysis.go
+++ b/pkg/app/piped/executor/analysis/analysis.go
@@ -213,7 +213,7 @@ func (e *Executor) newAnalyzerForMetrics(i int, templatable *config.TemplatableA
 		}
 		return provider.Evaluate(ctx, query, queryRange, &cfg.Expected)
 	}
-	return newAnalyzer(id, provider.Type(), cfg.Query, runner, time.Duration(cfg.Interval), cfg.FailureLimit, cfg.NodataAsSuccess, e.Logger, e.LogPersister), nil
+	return newAnalyzer(id, provider.Type(), cfg.Query, runner, time.Duration(cfg.Interval), cfg.FailureLimit, cfg.SkipNoData, e.Logger, e.LogPersister), nil
 }
 
 func (e *Executor) newAnalyzerForLog(i int, templatable *config.TemplatableAnalysisLog, templateCfg *config.AnalysisTemplateSpec) (*analyzer, error) {
@@ -229,7 +229,7 @@ func (e *Executor) newAnalyzerForLog(i int, templatable *config.TemplatableAnaly
 	runner := func(ctx context.Context, query string) (bool, string, error) {
 		return provider.Evaluate(ctx, query)
 	}
-	return newAnalyzer(id, provider.Type(), cfg.Query, runner, time.Duration(cfg.Interval), cfg.FailureLimit, cfg.NodataAsSuccess, e.Logger, e.LogPersister), nil
+	return newAnalyzer(id, provider.Type(), cfg.Query, runner, time.Duration(cfg.Interval), cfg.FailureLimit, cfg.SkipNoData, e.Logger, e.LogPersister), nil
 }
 
 func (e *Executor) newAnalyzerForHTTP(i int, templatable *config.TemplatableAnalysisHTTP, templateCfg *config.AnalysisTemplateSpec) (*analyzer, error) {
@@ -242,7 +242,7 @@ func (e *Executor) newAnalyzerForHTTP(i int, templatable *config.TemplatableAnal
 	runner := func(ctx context.Context, query string) (bool, string, error) {
 		return provider.Run(ctx, cfg)
 	}
-	return newAnalyzer(id, provider.Type(), "", runner, time.Duration(cfg.Interval), cfg.FailureLimit, cfg.NodataAsSuccess, e.Logger, e.LogPersister), nil
+	return newAnalyzer(id, provider.Type(), "", runner, time.Duration(cfg.Interval), cfg.FailureLimit, cfg.SkipNoData, e.Logger, e.LogPersister), nil
 }
 
 func (e *Executor) newMetricsProvider(providerName string, templatable *config.TemplatableAnalysisMetrics) (metrics.Provider, error) {

--- a/pkg/app/piped/executor/analysis/analysis.go
+++ b/pkg/app/piped/executor/analysis/analysis.go
@@ -213,7 +213,7 @@ func (e *Executor) newAnalyzerForMetrics(i int, templatable *config.TemplatableA
 		}
 		return provider.Evaluate(ctx, query, queryRange, &cfg.Expected)
 	}
-	return newAnalyzer(id, provider.Type(), cfg.Query, runner, time.Duration(cfg.Interval), cfg.FailureLimit, cfg.SkipNoData, e.Logger, e.LogPersister), nil
+	return newAnalyzer(id, provider.Type(), cfg.Query, runner, time.Duration(cfg.Interval), cfg.FailureLimit, cfg.SkipOnNoData, e.Logger, e.LogPersister), nil
 }
 
 func (e *Executor) newAnalyzerForLog(i int, templatable *config.TemplatableAnalysisLog, templateCfg *config.AnalysisTemplateSpec) (*analyzer, error) {
@@ -229,7 +229,7 @@ func (e *Executor) newAnalyzerForLog(i int, templatable *config.TemplatableAnaly
 	runner := func(ctx context.Context, query string) (bool, string, error) {
 		return provider.Evaluate(ctx, query)
 	}
-	return newAnalyzer(id, provider.Type(), cfg.Query, runner, time.Duration(cfg.Interval), cfg.FailureLimit, cfg.SkipNoData, e.Logger, e.LogPersister), nil
+	return newAnalyzer(id, provider.Type(), cfg.Query, runner, time.Duration(cfg.Interval), cfg.FailureLimit, cfg.SkipOnNoData, e.Logger, e.LogPersister), nil
 }
 
 func (e *Executor) newAnalyzerForHTTP(i int, templatable *config.TemplatableAnalysisHTTP, templateCfg *config.AnalysisTemplateSpec) (*analyzer, error) {
@@ -242,7 +242,7 @@ func (e *Executor) newAnalyzerForHTTP(i int, templatable *config.TemplatableAnal
 	runner := func(ctx context.Context, query string) (bool, string, error) {
 		return provider.Run(ctx, cfg)
 	}
-	return newAnalyzer(id, provider.Type(), "", runner, time.Duration(cfg.Interval), cfg.FailureLimit, cfg.SkipNoData, e.Logger, e.LogPersister), nil
+	return newAnalyzer(id, provider.Type(), "", runner, time.Duration(cfg.Interval), cfg.FailureLimit, cfg.SkipOnNoData, e.Logger, e.LogPersister), nil
 }
 
 func (e *Executor) newMetricsProvider(providerName string, templatable *config.TemplatableAnalysisMetrics) (metrics.Provider, error) {

--- a/pkg/app/piped/executor/analysis/analyzer.go
+++ b/pkg/app/piped/executor/analysis/analyzer.go
@@ -21,7 +21,7 @@ type analyzer struct {
 	interval     time.Duration
 	// The analysis will fail, if this value is exceeded,
 	failureLimit int
-	skipNoData   bool
+	skipOnNoData bool
 
 	logger       *zap.Logger
 	logPersister executor.LogPersister
@@ -36,7 +36,7 @@ func newAnalyzer(
 	evaluate evaluator,
 	interval time.Duration,
 	failureLimit int,
-	skipNoData bool,
+	skipOnNodata bool,
 	logger *zap.Logger,
 	logPersister executor.LogPersister,
 ) *analyzer {
@@ -47,7 +47,7 @@ func newAnalyzer(
 		query:        query,
 		interval:     interval,
 		failureLimit: failureLimit,
-		skipNoData:   skipNoData,
+		skipOnNoData: skipOnNodata,
 		logPersister: logPersister,
 		logger: logger.With(
 			zap.String("analyzer-id", id),
@@ -71,8 +71,8 @@ func (a *analyzer) run(ctx context.Context) error {
 			if errors.Is(err, context.DeadlineExceeded) && ctx.Err() == context.DeadlineExceeded {
 				return nil
 			}
-			if errors.Is(err, metrics.ErrNoDataFound) && a.skipNoData {
-				a.logPersister.Infof("[%s] The query result evaluation was skipped because \"skipNoData\" is true even though no data returned. Reason: %v. Performed query: %q", a.id, err, a.query)
+			if errors.Is(err, metrics.ErrNoDataFound) && a.skipOnNoData {
+				a.logPersister.Infof("[%s] The query result evaluation was skipped because \"skipOnNoData\" is true even though no data returned. Reason: %v. Performed query: %q", a.id, err, a.query)
 				continue
 			}
 			if err != nil {

--- a/pkg/config/analysis.go
+++ b/pkg/config/analysis.go
@@ -40,7 +40,7 @@ type AnalysisMetrics struct {
 	FailureLimit int `json:"failureLimit"`
 	// If true, it considers as a success when no data returned from the analysis provider.
 	// Default is false.
-	SkipNoData bool `json:"skipNoData"`
+	SkipOnNoData bool `json:"skipOnNoData"`
 	// How long after which the query times out.
 	// Default is 30s.
 	Timeout Duration `json:"timeout"`
@@ -98,7 +98,7 @@ type AnalysisLog struct {
 	FailureLimit int `json:"failureLimit"`
 	// If true, it considers as success when no data returned from the analysis provider.
 	// Default is false.
-	SkipNoData bool `json:"skipNoData"`
+	SkipOnNoData bool `json:"skipOnNoData"`
 	// How long after which the query times out.
 	Timeout  Duration `json:"timeout"`
 	Provider string   `json:"provider"`
@@ -117,8 +117,8 @@ type AnalysisHTTP struct {
 	FailureLimit int `json:"failureLimit"`
 	// If true, it considers as success when no data returned from the analysis provider.
 	// Default is false.
-	SkipNoData bool     `json:"skipNoData"`
-	Timeout    Duration `json:"timeout"`
+	SkipOnNoData bool     `json:"skipOnNoData"`
+	Timeout      Duration `json:"timeout"`
 }
 
 type AnalysisHeader struct {

--- a/pkg/config/analysis.go
+++ b/pkg/config/analysis.go
@@ -40,7 +40,7 @@ type AnalysisMetrics struct {
 	FailureLimit int `json:"failureLimit"`
 	// If true, it considers as a success when no data returned from the analysis provider.
 	// Default is false.
-	NodataAsSuccess bool `json:"nodataAsSuccess"`
+	SkipNoData bool `json:"skipNoData"`
 	// How long after which the query times out.
 	// Default is 30s.
 	Timeout Duration `json:"timeout"`
@@ -98,7 +98,7 @@ type AnalysisLog struct {
 	FailureLimit int `json:"failureLimit"`
 	// If true, it considers as success when no data returned from the analysis provider.
 	// Default is false.
-	NodataAsSuccess bool `json:"nodataAsSuccess"`
+	SkipNoData bool `json:"skipNoData"`
 	// How long after which the query times out.
 	Timeout  Duration `json:"timeout"`
 	Provider string   `json:"provider"`
@@ -117,8 +117,8 @@ type AnalysisHTTP struct {
 	FailureLimit int `json:"failureLimit"`
 	// If true, it considers as success when no data returned from the analysis provider.
 	// Default is false.
-	NodataAsSuccess bool     `json:"nodataAsSuccess"`
-	Timeout         Duration `json:"timeout"`
+	SkipNoData bool     `json:"skipNoData"`
+	Timeout    Duration `json:"timeout"`
 }
 
 type AnalysisHeader struct {

--- a/pkg/config/analysis.go
+++ b/pkg/config/analysis.go
@@ -38,6 +38,9 @@ type AnalysisMetrics struct {
 	// the analysis will be considered a failure after 2 failures.
 	// Default is 0.
 	FailureLimit int `json:"failureLimit"`
+	// If true, it considers as a success when no data returned from the analysis provider.
+	// Default is false.
+	NodataAsSuccess bool `json:"nodataAsSuccess"`
 	// How long after which the query times out.
 	// Default is 30s.
 	Timeout Duration `json:"timeout"`
@@ -93,6 +96,9 @@ type AnalysisLog struct {
 	Interval Duration `json:"interval"`
 	// Maximum number of failed checks before the query result is considered as failure.
 	FailureLimit int `json:"failureLimit"`
+	// If true, it considers as success when no data returned from the analysis provider.
+	// Default is false.
+	NodataAsSuccess bool `json:"nodataAsSuccess"`
 	// How long after which the query times out.
 	Timeout  Duration `json:"timeout"`
 	Provider string   `json:"provider"`
@@ -108,8 +114,11 @@ type AnalysisHTTP struct {
 	ExpectedResponse string           `json:"expectedResponse"`
 	Interval         Duration         `json:"interval"`
 	// Maximum number of failed checks before the response is considered as failure.
-	FailureLimit int      `json:"failureLimit"`
-	Timeout      Duration `json:"timeout"`
+	FailureLimit int `json:"failureLimit"`
+	// If true, it considers as success when no data returned from the analysis provider.
+	// Default is false.
+	NodataAsSuccess bool     `json:"nodataAsSuccess"`
+	Timeout         Duration `json:"timeout"`
 }
 
 type AnalysisHeader struct {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a new configuration field called `skipOnNoData` which empowers us to control how to handle the no data points from analysis providers. That is, if true, it considers a success when no data returned from the analysis provider.

For Prometheus, I'm looking to NaN is also considered as no data for now.

**Which issue(s) this PR fixes**:

Fixes https://github.com/pipe-cd/pipe/issues/1683
Fixes https://github.com/pipe-cd/pipe/issues/1706
Fixes https://github.com/pipe-cd/pipe/issues/1707

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Add a new configuration field for the ANALYSIS stage named "skipOnNoData" which can control how to handle no data case.
```
