### PR TITLE
Update schema validation

### DIFF
--- a/pkg/app/ops/mysqlensurer/indexes.sql
+++ b/pkg/app/ops/mysqlensurer/indexes.sql
@@ -19,7 +19,7 @@ ALTER TABLE Application ADD COLUMN Deleted BOOL GENERATED ALWAYS AS (IFNULL(data
 CREATE INDEX application_deleted_created_at_asc ON Application (Deleted, CreatedAt);
 
 -- index on `Kind` ASC and `UpdatedAt` DESC
-ALTER TABLE Application ADD COLUMN Kind INT GENERATED ALWAYS AS (data->>"$.kind") VIRTUAL NOT NULL;
+ALTER TABLE Application ADD COLUMN Kind INT GENERATED ALWAYS AS (IFNULL(data->>"$.kind", 0)) VIRTUAL NOT NULL;
 CREATE INDEX application_kind_updated_at_desc ON Application (Kind, UpdatedAt DESC);
 
 -- index on `SyncState.Status` ASC and `UpdatedAt` DESC
@@ -61,7 +61,7 @@ ALTER TABLE Deployment ADD COLUMN EnvId VARCHAR(36) GENERATED ALWAYS AS (data->>
 CREATE INDEX deployment_env_id_updated_at_desc ON Deployment (EnvId, UpdatedAt DESC);
 
 -- index on `Kind` ASC and `UpdatedAt` DESC
-ALTER TABLE Deployment ADD COLUMN Kind INT GENERATED ALWAYS AS (data->>"$.kind") VIRTUAL NOT NULL;
+ALTER TABLE Deployment ADD COLUMN Kind INT GENERATED ALWAYS AS (IFNULL(data->>"$.kind", 0)) VIRTUAL NOT NULL;
 CREATE INDEX deployment_kind_updated_at_desc ON Deployment (Kind, UpdatedAt DESC);
 
 -- index on `Status` ASC and `UpdatedAt` DESC

--- a/pkg/app/ops/mysqlensurer/indexes.sql
+++ b/pkg/app/ops/mysqlensurer/indexes.sql
@@ -6,31 +6,31 @@
 CREATE INDEX application_disabled_updated_at_desc ON Application (Disabled, UpdatedAt DESC);
 
 -- index on `EnvId` ASC and `UpdatedAt` DESC
-ALTER TABLE Application ADD COLUMN EnvId VARCHAR(36) GENERATED ALWAYS AS (data->>"$.env_id") VIRTUAL;
+ALTER TABLE Application ADD COLUMN EnvId VARCHAR(36) GENERATED ALWAYS AS (data->>"$.env_id") VIRTUAL NOT NULL;
 CREATE INDEX application_env_id_updated_at_desc ON Application (EnvId, UpdatedAt DESC);
 
 -- index on `Name` ASC and `UpdatedAt` DESC
-ALTER TABLE Application ADD COLUMN Name VARCHAR(50) GENERATED ALWAYS AS (data->>"$.name") VIRTUAL;
+ALTER TABLE Application ADD COLUMN Name VARCHAR(50) GENERATED ALWAYS AS (data->>"$.name") VIRTUAL NOT NULL;
 CREATE INDEX application_name_updated_at_desc ON Application (Name, UpdatedAt DESC);
 
 -- index on `Deleted` and `CreatedAt` ASC
 -- TODO: Reconsider make this Deleted column as STORED GENERATED COLUMN
-ALTER TABLE Application ADD COLUMN Deleted BOOL GENERATED ALWAYS AS (data->>"$.deleted") VIRTUAL;
+ALTER TABLE Application ADD COLUMN Deleted BOOL GENERATED ALWAYS AS (IFNULL(data->>"$.deleted", False)) VIRTUAL NOT NULL;
 CREATE INDEX application_deleted_created_at_asc ON Application (Deleted, CreatedAt);
 
 -- index on `Kind` ASC and `UpdatedAt` DESC
-ALTER TABLE Application ADD COLUMN Kind INT GENERATED ALWAYS AS (data->>"$.kind") VIRTUAL;
+ALTER TABLE Application ADD COLUMN Kind INT GENERATED ALWAYS AS (data->>"$.kind") VIRTUAL NOT NULL;
 CREATE INDEX application_kind_updated_at_desc ON Application (Kind, UpdatedAt DESC);
 
 -- index on `SyncState.Status` ASC and `UpdatedAt` DESC
-ALTER TABLE Application ADD COLUMN SyncState_Status INT GENERATED ALWAYS AS (data->>"$.sync_state.status") VIRTUAL;
+ALTER TABLE Application ADD COLUMN SyncState_Status INT GENERATED ALWAYS AS (IFNULL(data->>"$.sync_state.status", 0)) VIRTUAL NOT NULL;
 CREATE INDEX application_sync_state_updated_at_desc ON Application (SyncState_Status, UpdatedAt DESC);
 
 -- index on `ProjectId` ASC and `UpdatedAt` DESC
 CREATE INDEX application_project_id_updated_at_desc ON Application (ProjectId, UpdatedAt DESC);
 
 -- index on `PipedId` ASC
-ALTER TABLE Application ADD COLUMN PipedId VARCHAR(36) GENERATED ALWAYS AS (data->>"$.piped_id") VIRTUAL;
+ALTER TABLE Application ADD COLUMN PipedId VARCHAR(36) GENERATED ALWAYS AS (data->>"$.piped_id") VIRTUAL NOT NULL;
 CREATE INDEX application_piped_id ON Application (PipedId);
 
 --
@@ -38,11 +38,11 @@ CREATE INDEX application_piped_id ON Application (PipedId);
 --
 
 -- index on `Status` ASC and `CreatedAt` ASC
-ALTER TABLE Command ADD COLUMN Status INT GENERATED ALWAYS AS (data->>"$.status") VIRTUAL;
+ALTER TABLE Command ADD COLUMN Status INT GENERATED ALWAYS AS (IFNULL(data->>"$.status", 0)) VIRTUAL NOT NULL;
 CREATE INDEX command_status_created_at_asc ON Command (Status, CreatedAt);
 
 -- index on `PipedId` ASC
-ALTER TABLE Command ADD COLUMN PipedId VARCHAR(36) GENERATED ALWAYS AS (data->>"$.piped_id") VIRTUAL;
+ALTER TABLE Command ADD COLUMN PipedId VARCHAR(36) GENERATED ALWAYS AS (data->>"$.piped_id") VIRTUAL NOT NULL;
 CREATE INDEX command_piped_id ON Command (PipedId);
 
 --
@@ -50,26 +50,26 @@ CREATE INDEX command_piped_id ON Command (PipedId);
 --
 
 -- index on `ApplicationId` ASC and `UpdatedAt` DESC
-ALTER TABLE Deployment ADD COLUMN ApplicationId VARCHAR(36) GENERATED ALWAYS AS (data->>"$.application_id") VIRTUAL;
+ALTER TABLE Deployment ADD COLUMN ApplicationId VARCHAR(36) GENERATED ALWAYS AS (data->>"$.application_id") VIRTUAL NOT NULL;
 CREATE INDEX deployment_application_id_updated_at_desc ON Deployment (ApplicationId, UpdatedAt DESC);
 
 -- index on `ProjectId` ASC and `UpdatedAt` DESC
 CREATE INDEX deployment_project_id_updated_at_desc ON Deployment (ProjectId, UpdatedAt DESC);
 
 -- index on `EnvId` ASC and `UpdatedAt` DESC
-ALTER TABLE Deployment ADD COLUMN EnvId VARCHAR(36) GENERATED ALWAYS AS (data->>"$.env_id") VIRTUAL;
+ALTER TABLE Deployment ADD COLUMN EnvId VARCHAR(36) GENERATED ALWAYS AS (data->>"$.env_id") VIRTUAL NOT NULL;
 CREATE INDEX deployment_env_id_updated_at_desc ON Deployment (EnvId, UpdatedAt DESC);
 
 -- index on `Kind` ASC and `UpdatedAt` DESC
-ALTER TABLE Deployment ADD COLUMN Kind INT GENERATED ALWAYS AS (data->>"$.kind") VIRTUAL;
+ALTER TABLE Deployment ADD COLUMN Kind INT GENERATED ALWAYS AS (data->>"$.kind") VIRTUAL NOT NULL;
 CREATE INDEX deployment_kind_updated_at_desc ON Deployment (Kind, UpdatedAt DESC);
 
 -- index on `Status` ASC and `UpdatedAt` DESC
-ALTER TABLE Deployment ADD COLUMN Status INT GENERATED ALWAYS AS (data->>"$.status") VIRTUAL;
+ALTER TABLE Deployment ADD COLUMN Status INT GENERATED ALWAYS AS (IFNULL(data->>"$.status", 0)) VIRTUAL NOT NULL;
 CREATE INDEX deployment_status_updated_at_desc ON Deployment (Status, UpdatedAt DESC);
 
 -- index on `PipedId` ASC
-ALTER TABLE Deployment ADD COLUMN PipedId VARCHAR(36) GENERATED ALWAYS AS (data->>"$.piped_id") VIRTUAL;
+ALTER TABLE Deployment ADD COLUMN PipedId VARCHAR(36) GENERATED ALWAYS AS (data->>"$.piped_id") VIRTUAL NOT NULL;
 CREATE INDEX deployment_piped_id ON Deployment (PipedId);
 
 --
@@ -80,5 +80,5 @@ CREATE INDEX deployment_piped_id ON Deployment (PipedId);
 CREATE INDEX event_project_id_created_at_asc ON Event (ProjectId, CreatedAt);
 
 -- index on `EventKey` ASC, `Name` ASC, `ProjectId` ASC and `CreatedAt` DESC
-ALTER TABLE Event ADD COLUMN EventKey VARCHAR(64) GENERATED ALWAYS AS (data->>"$.event_key") VIRTUAL, ADD COLUMN Name VARCHAR(50) GENERATED ALWAYS AS (data->>"$.name") VIRTUAL;
+ALTER TABLE Event ADD COLUMN EventKey VARCHAR(64) GENERATED ALWAYS AS (data->>"$.event_key") VIRTUAL NOT NULL, ADD COLUMN Name VARCHAR(50) GENERATED ALWAYS AS (data->>"$.name") VIRTUAL NOT NULL;
 CREATE INDEX event_key_name_project_id_created_at_desc ON Event (EventKey, Name, ProjectId, CreatedAt DESC);

--- a/pkg/app/ops/mysqlensurer/schema.sql
+++ b/pkg/app/ops/mysqlensurer/schema.sql
@@ -5,9 +5,9 @@
 CREATE TABLE IF NOT EXISTS Project (
   Id BINARY(16) PRIMARY KEY,
   Data JSON NOT NULL,
+  Extra VARCHAR(100) GENERATED ALWAYS AS (data->>"$._extra") STORED UNIQUE,
   CreatedAt INT(11) GENERATED ALWAYS AS (data->>"$.created_at") STORED NOT NULL,
-  UpdatedAt INT(11) GENERATED ALWAYS AS (data->>"$.updated_at") STORED NOT NULL,
-  Extra VARCHAR(100) GENERATED ALWAYS AS (data->>"$._extra") STORED UNIQUE
+  UpdatedAt INT(11) GENERATED ALWAYS AS (data->>"$.updated_at") STORED NOT NULL
 ) ENGINE=InnoDB;
 
 --
@@ -18,10 +18,10 @@ CREATE TABLE IF NOT EXISTS Application (
   Id BINARY(16) PRIMARY KEY,
   Data JSON NOT NULL,
   ProjectId VARCHAR(50) GENERATED ALWAYS AS (data->>"$.project_id") STORED NOT NULL,
+  Disabled BOOL GENERATED ALWAYS AS (IFNULL(data->>"$.disabled", False)) STORED NOT NULL, 
+  Extra VARCHAR(100) GENERATED ALWAYS AS (data->>"$._extra") STORED,
   CreatedAt INT(11) GENERATED ALWAYS AS (data->>"$.created_at") STORED NOT NULL,
-  UpdatedAt INT(11) GENERATED ALWAYS AS (data->>"$.updated_at") STORED NOT NULL,
-  Disabled BOOL GENERATED ALWAYS AS (data->>"$.disabled") STORED,
-  Extra VARCHAR(100) GENERATED ALWAYS AS (data->>"$._extra") STORED
+  UpdatedAt INT(11) GENERATED ALWAYS AS (data->>"$.updated_at") STORED NOT NULL
 ) ENGINE=InnoDB;
 
 --
@@ -32,9 +32,9 @@ CREATE TABLE IF NOT EXISTS Command (
   Id BINARY(16) PRIMARY KEY,
   Data JSON NOT NULL,
   ProjectId VARCHAR(50) GENERATED ALWAYS AS (data->>"$.project_id") STORED NOT NULL,
+  Extra VARCHAR(100) GENERATED ALWAYS AS (data->>"$._extra") STORED,
   CreatedAt INT(11) GENERATED ALWAYS AS (data->>"$.created_at") STORED NOT NULL,
-  UpdatedAt INT(11) GENERATED ALWAYS AS (data->>"$.updated_at") STORED NOT NULL,
-  Extra VARCHAR(100) GENERATED ALWAYS AS (data->>"$._extra") STORED
+  UpdatedAt INT(11) GENERATED ALWAYS AS (data->>"$.updated_at") STORED NOT NULL
 ) ENGINE=InnoDB;
 
 --
@@ -45,9 +45,9 @@ CREATE TABLE IF NOT EXISTS Deployment (
   Id BINARY(16) PRIMARY KEY,
   Data JSON NOT NULL,
   ProjectId VARCHAR(50) GENERATED ALWAYS AS (data->>"$.project_id") STORED NOT NULL,
+  Extra VARCHAR(100) GENERATED ALWAYS AS (data->>"$._extra") STORED,
   CreatedAt INT(11) GENERATED ALWAYS AS (data->>"$.created_at") STORED NOT NULL,
-  UpdatedAt INT(11) GENERATED ALWAYS AS (data->>"$.updated_at") STORED NOT NULL,
-  Extra VARCHAR(100) GENERATED ALWAYS AS (data->>"$._extra") STORED
+  UpdatedAt INT(11) GENERATED ALWAYS AS (data->>"$.updated_at") STORED NOT NULL
 ) ENGINE=InnoDB;
 
 --
@@ -58,9 +58,9 @@ CREATE TABLE IF NOT EXISTS Environment (
   Id BINARY(16) PRIMARY KEY,
   Data JSON NOT NULL,
   ProjectId VARCHAR(50) GENERATED ALWAYS AS (data->>"$.project_id") STORED NOT NULL,
+  Extra VARCHAR(100) GENERATED ALWAYS AS (data->>"$._extra") STORED,
   CreatedAt INT(11) GENERATED ALWAYS AS (data->>"$.created_at") STORED NOT NULL,
-  UpdatedAt INT(11) GENERATED ALWAYS AS (data->>"$.updated_at") STORED NOT NULL,
-  Extra VARCHAR(100) GENERATED ALWAYS AS (data->>"$._extra") STORED
+  UpdatedAt INT(11) GENERATED ALWAYS AS (data->>"$.updated_at") STORED NOT NULL
 ) ENGINE=InnoDB;
 
 --
@@ -71,10 +71,10 @@ CREATE TABLE IF NOT EXISTS Piped (
   Id BINARY(16) PRIMARY KEY,
   Data JSON NOT NULL,
   ProjectId VARCHAR(50) GENERATED ALWAYS AS (data->>"$.project_id") STORED NOT NULL,
+  Disabled BOOL GENERATED ALWAYS AS (IFNULL(data->>"$.disabled", False)) STORED NOT NULL, 
+  Extra VARCHAR(100) GENERATED ALWAYS AS (data->>"$._extra") STORED,
   CreatedAt INT(11) GENERATED ALWAYS AS (data->>"$.created_at") STORED NOT NULL,
-  UpdatedAt INT(11) GENERATED ALWAYS AS (data->>"$.updated_at") STORED NOT NULL,
-  Disabled BOOL GENERATED ALWAYS AS (data->>"$.disabled") STORED,
-  Extra VARCHAR(100) GENERATED ALWAYS AS (data->>"$._extra") STORED
+  UpdatedAt INT(11) GENERATED ALWAYS AS (data->>"$.updated_at") STORED NOT NULL
 ) ENGINE=InnoDB;
 
 --
@@ -85,10 +85,10 @@ CREATE TABLE IF NOT EXISTS APIKey (
   Id BINARY(16) PRIMARY KEY,
   Data JSON NOT NULL,
   ProjectId VARCHAR(50) GENERATED ALWAYS AS (data->>"$.project_id") STORED NOT NULL,
+  Disabled BOOL GENERATED ALWAYS AS (IFNULL(data->>"$.disabled", False)) STORED NOT NULL, 
+  Extra VARCHAR(100) GENERATED ALWAYS AS (data->>"$._extra") STORED,
   CreatedAt INT(11) GENERATED ALWAYS AS (data->>"$.created_at") STORED NOT NULL,
-  UpdatedAt INT(11) GENERATED ALWAYS AS (data->>"$.updated_at") STORED NOT NULL,
-  Disabled BOOL GENERATED ALWAYS AS (data->>"$.disabled") STORED,
-  Extra VARCHAR(100) GENERATED ALWAYS AS (data->>"$._extra") STORED
+  UpdatedAt INT(11) GENERATED ALWAYS AS (data->>"$.updated_at") STORED NOT NULL
 ) ENGINE=InnoDB;
 
 --
@@ -99,7 +99,7 @@ CREATE TABLE IF NOT EXISTS Event (
   Id BINARY(16) PRIMARY KEY,
   Data JSON NOT NULL,
   ProjectId VARCHAR(50) GENERATED ALWAYS AS (data->>"$.project_id") STORED NOT NULL,
+  Extra VARCHAR(100) GENERATED ALWAYS AS (data->>"$._extra") STORED,
   CreatedAt INT(11) GENERATED ALWAYS AS (data->>"$.created_at") STORED NOT NULL,
-  UpdatedAt INT(11) GENERATED ALWAYS AS (data->>"$.updated_at") STORED NOT NULL,
-  Extra VARCHAR(100) GENERATED ALWAYS AS (data->>"$._extra") STORED
+  UpdatedAt INT(11) GENERATED ALWAYS AS (data->>"$.updated_at") STORED NOT NULL
 ) ENGINE=InnoDB;

--- a/pkg/app/ops/mysqlensurer/schema.sql
+++ b/pkg/app/ops/mysqlensurer/schema.sql
@@ -5,7 +5,7 @@
 CREATE TABLE IF NOT EXISTS Project (
   Id BINARY(16) PRIMARY KEY,
   Data JSON NOT NULL,
-  Extra VARCHAR(100) GENERATED ALWAYS AS (data->>"$._extra") STORED UNIQUE,
+  Extra VARCHAR(100) GENERATED ALWAYS AS (data->>"$._extra") STORED,
   CreatedAt INT(11) GENERATED ALWAYS AS (data->>"$.created_at") STORED NOT NULL,
   UpdatedAt INT(11) GENERATED ALWAYS AS (data->>"$.updated_at") STORED NOT NULL
 ) ENGINE=InnoDB;


### PR DESCRIPTION
**What this PR does / why we need it**:

- Add not null validation for all generated columns
- Add default value for INT, BOOL typed columns ~(except `kind` since ApplicationKind type must be specified on creating)~

Note: as for the implementation of `omitempty` is check value equal to zero value or not, to avoid NULL in case zero value passed, `kind` should have default value too.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
