### PR TITLE
Increase timeout time for playground building

### DIFF
--- a/.kapetanios/postsubmit.yaml
+++ b/.kapetanios/postsubmit.yaml
@@ -111,6 +111,7 @@ spec:
         type: PROJECT
     steps:
       - name: web-build
+        timeout: 20m
         description: Build static files
         runner: gcr.io/pipecd/runner:1.0.0
         commands:

--- a/.kapetanios/postsubmit.yaml
+++ b/.kapetanios/postsubmit.yaml
@@ -102,6 +102,7 @@ spec:
         - docker push gcr.io/pipecd/site:$(git describe --tags --always --abbrev=7)
 
   - name: push-play-image
+    timeout: 20m
     branches:
       - master
     dockerAuth:
@@ -111,7 +112,6 @@ spec:
         type: PROJECT
     steps:
       - name: web-build
-        timeout: 20m
         description: Build static files
         runner: gcr.io/pipecd/runner:1.0.0
         commands:


### PR DESCRIPTION
**What this PR does / why we need it**:

The playground building job is failed by timed out(10m), so increase the timeout limit.


**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
