### PR TITLE
Add pipectl datastore command

### DIFF
--- a/cmd/pipectl/BUILD.bazel
+++ b/cmd/pipectl/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//pkg/app/pipectl/cmd/application:go_default_library",
+        "//pkg/app/pipectl/cmd/datastore:go_default_library",
         "//pkg/app/pipectl/cmd/deployment:go_default_library",
         "//pkg/app/pipectl/cmd/event:go_default_library",
         "//pkg/cli:go_default_library",

--- a/cmd/pipectl/main.go
+++ b/cmd/pipectl/main.go
@@ -19,6 +19,7 @@ import (
 	"os"
 
 	"github.com/pipe-cd/pipe/pkg/app/pipectl/cmd/application"
+	"github.com/pipe-cd/pipe/pkg/app/pipectl/cmd/datastore"
 	"github.com/pipe-cd/pipe/pkg/app/pipectl/cmd/deployment"
 	"github.com/pipe-cd/pipe/pkg/app/pipectl/cmd/event"
 	"github.com/pipe-cd/pipe/pkg/cli"
@@ -34,6 +35,7 @@ func main() {
 		application.NewCommand(),
 		deployment.NewCommand(),
 		event.NewCommand(),
+		datastore.NewCommand(),
 	)
 
 	if err := app.Run(); err != nil {

--- a/pkg/app/api/grpcapi/BUILD.bazel
+++ b/pkg/app/api/grpcapi/BUILD.bazel
@@ -25,6 +25,8 @@ go_library(
         "//pkg/config:go_default_library",
         "//pkg/crypto:go_default_library",
         "//pkg/datastore:go_default_library",
+        "//pkg/datastore/migration:go_default_library",
+        "//pkg/datastore/mysql:go_default_library",
         "//pkg/git:go_default_library",
         "//pkg/insight/insightstore:go_default_library",
         "//pkg/model:go_default_library",

--- a/pkg/app/api/grpcapi/api.go
+++ b/pkg/app/api/grpcapi/api.go
@@ -340,6 +340,10 @@ func (a *API) RegisterEvent(ctx context.Context, req *apiservice.RegisterEventRe
 	return &apiservice.RegisterEventResponse{}, nil
 }
 
+func (a *API) MigrateDatastore(ctx context.Context, req *apiservice.MigrateDatastoreRequest) (*apiservice.MigrateDatastoreResponse, error) {
+	return nil, nil
+}
+
 // requireAPIKey checks the existence of an API key inside the given context
 // and ensures that it has enough permissions for the give role.
 func requireAPIKey(ctx context.Context, role model.APIKey_Role, logger *zap.Logger) (*model.APIKey, error) {

--- a/pkg/app/api/service/apiservice/service.proto
+++ b/pkg/app/api/service/apiservice/service.proto
@@ -36,6 +36,8 @@ service APIService {
     rpc GetCommand(GetCommandRequest) returns (GetCommandResponse) {}
 
     rpc RegisterEvent(RegisterEventRequest) returns (RegisterEventResponse) {}
+
+    rpc MigrateDatastore(MigrateDatastoreRequest) returns (MigrateDatastoreResponse) {}
 }
 
 message AddApplicationRequest {
@@ -102,4 +104,12 @@ message RegisterEventRequest {
 }
 
 message RegisterEventResponse {
+}
+
+message MigrateDatastoreRequest {
+    string downstream_data_src = 1 [(validate.rules).string.min_len = 1];
+    repeated string models = 2;
+}
+
+message MigrateDatastoreResponse {
 }

--- a/pkg/app/api/service/apiservice/service.proto
+++ b/pkg/app/api/service/apiservice/service.proto
@@ -108,7 +108,8 @@ message RegisterEventResponse {
 
 message MigrateDatastoreRequest {
     string downstream_data_src = 1 [(validate.rules).string.min_len = 1];
-    repeated string models = 2;
+    string database = 2 [(validate.rules).string.min_len = 1];
+    repeated string models = 3;
 }
 
 message MigrateDatastoreResponse {

--- a/pkg/app/pipectl/cmd/datastore/BUILD.bazel
+++ b/pkg/app/pipectl/cmd/datastore/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//pkg/app/api/service/apiservice:go_default_library",
         "//pkg/app/pipectl/client:go_default_library",
         "//pkg/cli:go_default_library",
+        "//pkg/datastore:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",
     ],
 )

--- a/pkg/app/pipectl/cmd/datastore/BUILD.bazel
+++ b/pkg/app/pipectl/cmd/datastore/BUILD.bazel
@@ -1,0 +1,17 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "datastore.go",
+        "migrate.go",
+    ],
+    importpath = "github.com/pipe-cd/pipe/pkg/app/pipectl/cmd/datastore",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/app/api/service/apiservice:go_default_library",
+        "//pkg/app/pipectl/client:go_default_library",
+        "//pkg/cli:go_default_library",
+        "@com_github_spf13_cobra//:go_default_library",
+    ],
+)

--- a/pkg/app/pipectl/cmd/datastore/datastore.go
+++ b/pkg/app/pipectl/cmd/datastore/datastore.go
@@ -1,0 +1,43 @@
+// Copyright 2021 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datastore
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/pipe-cd/pipe/pkg/app/pipectl/client"
+)
+
+type command struct {
+	clientOptions *client.Options
+}
+
+func NewCommand() *cobra.Command {
+	c := &command{
+		clientOptions: &client.Options{},
+	}
+	cmd := &cobra.Command{
+		Use:   "datastore",
+		Short: "Manage control-plane datastore resource.",
+	}
+
+	cmd.AddCommand(
+		newMigrateCommand(c),
+	)
+
+	c.clientOptions.RegisterPersistentFlags(cmd)
+
+	return cmd
+}

--- a/pkg/app/pipectl/cmd/datastore/migrate.go
+++ b/pkg/app/pipectl/cmd/datastore/migrate.go
@@ -1,0 +1,105 @@
+// Copyright 2021 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datastore
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/pipe-cd/pipe/pkg/app/api/service/apiservice"
+	"github.com/pipe-cd/pipe/pkg/cli"
+)
+
+var availableModelsStringName = []string{
+	"Project",
+	"Application",
+	"Command",
+	"Deployment",
+	"Environment",
+	"Piped",
+	"APIKey",
+	"Event",
+}
+
+type migrate struct {
+	root *command
+
+	downstreamDataSrc string
+	models            []string
+}
+
+func newMigrateCommand(root *command) *cobra.Command {
+	m := &migrate{
+		root: root,
+	}
+	cmd := &cobra.Command{
+		Use:   "migrate",
+		Short: "Migrate data to MySQL datastore.",
+		Long:  "Migrate data to MySQL datastore.\nBoth upstream (MongoDB/Firestore) and downstream (MySQL) datastore have to available to connect from control-plane to use this command.",
+		RunE:  cli.WithContext(m.run),
+	}
+
+	cmd.Flags().StringVar(&m.downstreamDataSrc, "downstream-data-src", m.downstreamDataSrc, "The URL to connect to downstream datastore (MySQL).\n Format: username:password@tcp(hostname:3306)/database")
+	cmd.Flags().StringSliceVar(&m.models, "models", m.models, fmt.Sprintf("The list of migrating models. If nothing is passed, all models will be migrated.\n (%s)", strings.Join(availableModelsStringName, " | ")))
+
+	cmd.MarkFlagRequired("downstream-data-src")
+
+	return cmd
+}
+
+func (m *migrate) run(ctx context.Context, _ cli.Telemetry) error {
+	cli, err := m.root.clientOptions.NewClient(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to initialize client: %w", err)
+	}
+	defer cli.Close()
+
+	modelsNameList, err := makeMigrateModelsList(m.models)
+	if err != nil {
+		return fmt.Errorf("failed to migrate datastore: %w", err)
+	}
+
+	req := &apiservice.MigrateDatastoreRequest{
+		DownstreamDataSrc: m.downstreamDataSrc,
+		Models:            modelsNameList,
+	}
+
+	if _, err := cli.MigrateDatastore(ctx, req); err != nil {
+		return fmt.Errorf("failed to migrate datastore: %w", err)
+	}
+	return nil
+}
+
+func makeMigrateModelsList(modelsName []string) ([]string, error) {
+	if len(modelsName) == 0 {
+		return availableModelsStringName, nil
+	}
+
+	nameMap := make(map[string]interface{})
+	for _, name := range availableModelsStringName {
+		nameMap[name] = nil
+	}
+	// validate
+	for _, name := range modelsName {
+		if _, ok := nameMap[name]; !ok {
+			return nil, fmt.Errorf("invalid model name passed: %s", name)
+		}
+	}
+
+	return modelsName, nil
+}

--- a/pkg/app/pipectl/cmd/datastore/migrate.go
+++ b/pkg/app/pipectl/cmd/datastore/migrate.go
@@ -84,9 +84,9 @@ func makeMigrateModelsList(modelsName []string) ([]string, error) {
 		return datastore.MigratableModelsKind, nil
 	}
 
-	nameMap := make(map[string]interface{})
+	nameMap := make(map[string]struct{}, len(datastore.MigratableModelsKind))
 	for _, name := range datastore.MigratableModelsKind {
-		nameMap[name] = nil
+		nameMap[name] = struct{}{}
 	}
 	// validate
 	for _, name := range modelsName {

--- a/pkg/datastore/datastore.go
+++ b/pkg/datastore/datastore.go
@@ -38,7 +38,7 @@ var (
 	ErrUnimplemented   = errors.New("unimplemented")
 )
 
-// MigratableModelsKind is slide of models which available to migrate.
+// MigratableModelsKind is a slide of models' name which available to migrate.
 var MigratableModelsKind = []string{
 	apiKeyModelKind,
 	applicationModelKind,

--- a/pkg/datastore/datastore.go
+++ b/pkg/datastore/datastore.go
@@ -38,6 +38,18 @@ var (
 	ErrUnimplemented   = errors.New("unimplemented")
 )
 
+// MigratableModelsKind is slide of models which available to migrate.
+var MigratableModelsKind = []string{
+	apiKeyModelKind,
+	applicationModelKind,
+	commandModelKind,
+	deploymentModelKind,
+	environmentModelKind,
+	eventModelKind,
+	pipedModelKind,
+	projectModelKind,
+}
+
 type Factory func() interface{}
 type Updater func(interface{}) error
 

--- a/pkg/datastore/migration/BUILD.bazel
+++ b/pkg/datastore/migration/BUILD.bazel
@@ -8,5 +8,6 @@ go_library(
     deps = [
         "//pkg/datastore:go_default_library",
         "//pkg/model:go_default_library",
+        "@org_golang_x_sync//errgroup:go_default_library",
     ],
 )

--- a/pkg/datastore/migration/BUILD.bazel
+++ b/pkg/datastore/migration/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["data_transfer.go"],
+    importpath = "github.com/pipe-cd/pipe/pkg/datastore/migration",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/datastore:go_default_library",
+        "//pkg/model:go_default_library",
+    ],
+)

--- a/pkg/datastore/migration/data_transfer.go
+++ b/pkg/datastore/migration/data_transfer.go
@@ -1,0 +1,128 @@
+// Copyright 2021 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migration
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/pipe-cd/pipe/pkg/datastore"
+	"github.com/pipe-cd/pipe/pkg/model"
+)
+
+type DataTransfer interface {
+	TransferMulti(ctx context.Context, kinds []string) error
+}
+
+type dataTransfer struct {
+	source      datastore.DataStore
+	destination datastore.DataStore
+}
+
+func NewDataTransfer(src, dest datastore.DataStore) DataTransfer {
+	return &dataTransfer{
+		source:      src,
+		destination: dest,
+	}
+}
+
+func transferOne(ctx context.Context, source, destination datastore.DataStore, kind string) error {
+	it, err := source.Find(ctx, kind, datastore.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to get data of kind %s from upstream datastore: %w", kind, err)
+	}
+
+	for {
+		data, err := makeModelObject(kind)
+		if err != nil {
+			return err
+		}
+
+		err = it.Next(data)
+		if err == datastore.ErrIteratorDone {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("failed to get data of kind %s from datastore: %w", kind, err)
+		}
+
+		if err = destination.Create(ctx, kind, data.GetId(), data); err != nil {
+			return fmt.Errorf("failed to insert data of kind %s (id: %s) to new datastore: %w", kind, data.GetId(), err)
+		}
+	}
+
+	return nil
+}
+
+func (d *dataTransfer) TransferMulti(ctx context.Context, kinds []string) error {
+	worker := func(kind string, errChan chan<- error, wg *sync.WaitGroup) {
+		defer wg.Done()
+		if err := transferOne(ctx, d.source, d.destination, kind); err != nil {
+			errChan <- err
+		}
+	}
+
+	var wg sync.WaitGroup
+	errChan := make(chan error)
+	doneChan := make(chan bool)
+
+	for _, kind := range kinds {
+		wg.Add(1)
+		go worker(kind, errChan, &wg)
+	}
+
+	go func() {
+		wg.Wait()
+		close(doneChan)
+	}()
+
+	select {
+	case <-doneChan:
+		break
+	case err := <-errChan:
+		close(errChan)
+		return err
+	}
+
+	return nil
+}
+
+type modelData interface {
+	GetId() string
+}
+
+func makeModelObject(kind string) (modelData, error) {
+	switch kind {
+	case "Project":
+		return &model.Project{}, nil
+	case "Application":
+		return &model.Application{}, nil
+	case "Command":
+		return &model.Command{}, nil
+	case "Deployment":
+		return &model.Deployment{}, nil
+	case "Environment":
+		return &model.Environment{}, nil
+	case "Piped":
+		return &model.Piped{}, nil
+	case "APIKey":
+		return &model.APIKey{}, nil
+	case "Event":
+		return &model.Event{}, nil
+	default:
+		return nil, fmt.Errorf("unsupported kind %s", kind)
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

To migrate data from other datastores (Firestore/MongoDB) to MySQL, use the following command:
```bash
$ pipectl datastore migrate \
	--address=*api-rpc-server* \
	--api-key-file=*path-to-api-key-file* \
	--downstream-data-src=*mysql-datastore-url* \
	--database=*database-name*
```

**Which issue(s) this PR fixes**:

Ref #1792 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Add pipectl datastore command.
```
