### PR TITLE
Run migration sequentially

### DIFF
--- a/pkg/datastore/migration/BUILD.bazel
+++ b/pkg/datastore/migration/BUILD.bazel
@@ -8,6 +8,5 @@ go_library(
     deps = [
         "//pkg/datastore:go_default_library",
         "//pkg/model:go_default_library",
-        "@org_golang_x_sync//errgroup:go_default_library",
     ],
 )

--- a/pkg/datastore/migration/data_transfer.go
+++ b/pkg/datastore/migration/data_transfer.go
@@ -18,8 +18,6 @@ import (
 	"context"
 	"fmt"
 
-	"golang.org/x/sync/errgroup"
-
 	"github.com/pipe-cd/pipe/pkg/datastore"
 	"github.com/pipe-cd/pipe/pkg/model"
 )
@@ -74,13 +72,12 @@ func transferOne(ctx context.Context, source, destination datastore.DataStore, k
 }
 
 func (d *dataTransfer) TransferMulti(ctx context.Context, kinds []string) error {
-	eg, ctx := errgroup.WithContext(ctx)
 	for _, kind := range kinds {
-		eg.Go(func() error {
-			return transferOne(ctx, d.source, d.destination, kind)
-		})
+		if err := transferOne(ctx, d.source, d.destination, kind); err != nil {
+			return err
+		}
 	}
-	return eg.Wait()
+	return nil
 }
 
 type modelData interface {


### PR DESCRIPTION
**What this PR does / why we need it**:

No need to run the migration process in parallel as current implementation since the data size is small and its cardinality is varied by kind (model).

**Which issue(s) this PR fixes**:

Rel #1806 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
