### PR TITLE
Enable differ to consider all maps/slides with a length of zero and nil to be equal

### DIFF
--- a/pkg/app/piped/diff/diff_test.go
+++ b/pkg/app/piped/diff/diff_test.go
@@ -37,7 +37,10 @@ func TestDiff(t *testing.T) {
 		{
 			name:     "no diff",
 			yamlFile: "testdata/no_diff.yaml",
-			diffNum:  0,
+			options: []Option{
+				WithEquateEmpty(),
+			},
+			diffNum: 0,
 		},
 		{
 			name:     "no diff by ignoring all adding map keys",

--- a/pkg/app/piped/diff/testdata/no_diff.yaml
+++ b/pkg/app/piped/diff/testdata/no_diff.yaml
@@ -27,6 +27,9 @@ spec:
         # Zero map and nil map should be equal.
         resources:
           null
+        emptyList:
+          []
+        emptyMap: {}
 ---
 apiVersion: apps/v1
 kind: Foo
@@ -56,3 +59,4 @@ spec:
         - containerPort: 9085
         # Zero map and nil map should be equal.
         resources: {}
+        emptyList2: []

--- a/pkg/app/piped/driftdetector/kubernetes/detector.go
+++ b/pkg/app/piped/driftdetector/kubernetes/detector.go
@@ -193,7 +193,10 @@ func (d *detector) checkApplication(ctx context.Context, app *model.Application,
 	// Now we will go to check the diff intersection group.
 	changes := make(map[provider.Manifest]*diff.Result)
 	for i := 0; i < len(headInters); i++ {
-		result, err := provider.Diff(headInters[i], liveInters[i], diff.WithIgnoreAddingMapKeys())
+		result, err := provider.Diff(headInters[i], liveInters[i],
+			diff.WithEquateEmpty(),
+			diff.WithIgnoreAddingMapKeys(),
+		)
 		if err != nil {
 			d.logger.Error("failed to calculate the diff of manifests", zap.Error(err))
 			return err


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Drift detector was configured to consider all maps/slides with a length of zero and nil to be equal
```
