### PR TITLE
Add gRPC interceptor for Prometheus to the server

### DIFF
--- a/cmd/pipecd/server.go
+++ b/cmd/pipecd/server.go
@@ -206,6 +206,9 @@ func (s *server) run(ctx context.Context, t cli.Telemetry) error {
 		if s.enableGRPCReflection {
 			opts = append(opts, rpc.WithGRPCReflection())
 		}
+		if t.Flags.Metrics {
+			opts = append(opts, rpc.WithPrometheusUnaryInterceptor())
+		}
 
 		server := rpc.NewServer(service, opts...)
 		group.Go(func() error {
@@ -233,6 +236,9 @@ func (s *server) run(ctx context.Context, t cli.Telemetry) error {
 		)
 		if s.tls {
 			opts = append(opts, rpc.WithTLS(s.certFile, s.keyFile))
+		}
+		if t.Flags.Metrics {
+			opts = append(opts, rpc.WithPrometheusUnaryInterceptor())
 		}
 
 		server := rpc.NewServer(service, opts...)
@@ -268,6 +274,9 @@ func (s *server) run(ctx context.Context, t cli.Telemetry) error {
 		}
 		if s.enableGRPCReflection {
 			opts = append(opts, rpc.WithGRPCReflection())
+		}
+		if t.Flags.Metrics {
+			opts = append(opts, rpc.WithPrometheusUnaryInterceptor())
 		}
 
 		server := rpc.NewServer(service, opts...)

--- a/pkg/rpc/BUILD.bazel
+++ b/pkg/rpc/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
     deps = [
         "//pkg/jwt:go_default_library",
         "//pkg/rpc/rpcauth:go_default_library",
+        "@com_github_grpc_ecosystem_go_grpc_prometheus//:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//codes:go_default_library",
         "@org_golang_google_grpc//credentials:go_default_library",

--- a/pkg/rpc/server.go
+++ b/pkg/rpc/server.go
@@ -20,6 +20,7 @@ import (
 	"net"
 	"time"
 
+	"github.com/grpc-ecosystem/go-grpc-prometheus"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -52,6 +53,7 @@ type Server struct {
 	jwtAuthUnaryInterceptor           grpc.UnaryServerInterceptor
 	requestValidationUnaryInterceptor grpc.UnaryServerInterceptor
 	logUnaryInterceptor               grpc.UnaryServerInterceptor
+	prometheusUnaryInterceptor        grpc.UnaryServerInterceptor
 }
 
 // Option defines a function to set configurable field of Server.
@@ -103,6 +105,13 @@ func WithRequestValidationUnaryInterceptor() Option {
 func WithLogUnaryInterceptor(logger *zap.Logger) Option {
 	return func(s *Server) {
 		s.logUnaryInterceptor = LogUnaryServerInterceptor(logger.Named("rpc-server"))
+	}
+}
+
+// WithPrometheusUnaryInterceptor sets an interceptor for Prometheus monitoring.
+func WithPrometheusUnaryInterceptor() Option {
+	return func(s *Server) {
+		s.prometheusUnaryInterceptor = grpc_prometheus.UnaryServerInterceptor
 	}
 }
 
@@ -208,6 +217,9 @@ func (s *Server) init() error {
 	if s.requestValidationUnaryInterceptor != nil {
 		unaryInterceptors = append(unaryInterceptors, s.requestValidationUnaryInterceptor)
 	}
+	if s.prometheusUnaryInterceptor != nil {
+		unaryInterceptors = append(unaryInterceptors, s.prometheusUnaryInterceptor)
+	}
 	if len(unaryInterceptors) > 0 {
 		c := ChainUnaryServerInterceptors(unaryInterceptors...)
 		opts = append(opts, grpc.UnaryInterceptor(c))
@@ -223,6 +235,10 @@ func (s *Server) init() error {
 	}
 	if s.enabelGRPCReflection {
 		reflection.Register(s.grpcServer)
+	}
+	// NOTE: This should be registered after all services have been registered.
+	if s.prometheusUnaryInterceptor != nil {
+		grpc_prometheus.Register(s.grpcServer)
 	}
 
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**:
With this PR, we will be able to expose a couple of counter type metrics including:
- grpc_server_started_total
- grpc_server_handled_total
- grpc_server_msg_received_total
- grpc_server_msg_sent_total

via the `/metrics` endpoint. It will instrument when only enabling the `--metrics` flag.

Seems like [go-grpc-prometheus](https://github.com/grpc-ecosystem/go-grpc-prometheus) is in the middle of moving to [go-grpc-middleware](https://github.com/grpc-ecosystem/go-grpc-middleware/tree/v2/providers/openmetrics). We may have to replace with it after it becomes stable.

Once got merged, I'm looking to check its behavior in the dev cluster.

**Which issue(s) this PR fixes**:

Ref https://github.com/pipe-cd/pipe/issues/1808

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
