### PR TITLE
Disable mongodb as control-plane datastore

### DIFF
--- a/cmd/pipecd/BUILD.bazel
+++ b/cmd/pipecd/BUILD.bazel
@@ -32,7 +32,6 @@ go_library(
         "//pkg/crypto:go_default_library",
         "//pkg/datastore:go_default_library",
         "//pkg/datastore/firestore:go_default_library",
-        "//pkg/datastore/mongodb:go_default_library",
         "//pkg/datastore/mysql:go_default_library",
         "//pkg/filestore:go_default_library",
         "//pkg/filestore/gcs:go_default_library",

--- a/cmd/pipecd/server.go
+++ b/cmd/pipecd/server.go
@@ -43,7 +43,6 @@ import (
 	"github.com/pipe-cd/pipe/pkg/crypto"
 	"github.com/pipe-cd/pipe/pkg/datastore"
 	"github.com/pipe-cd/pipe/pkg/datastore/firestore"
-	"github.com/pipe-cd/pipe/pkg/datastore/mongodb"
 	"github.com/pipe-cd/pipe/pkg/datastore/mysql"
 	"github.com/pipe-cd/pipe/pkg/filestore"
 	"github.com/pipe-cd/pipe/pkg/filestore/gcs"
@@ -413,18 +412,8 @@ func createDatastore(ctx context.Context, cfg *config.ControlPlaneSpec, logger *
 		return nil, errors.New("dynamodb is unimplemented yet")
 
 	case model.DataStoreMongoDB:
-		mdConfig := cfg.Datastore.MongoDBConfig
-		options := []mongodb.Option{
-			mongodb.WithLogger(logger),
-		}
-		if mdConfig.UsernameFile != "" || mdConfig.PasswordFile != "" {
-			options = append(options, mongodb.WithAuthenticationFile(mdConfig.UsernameFile, mdConfig.PasswordFile))
-		}
-		return mongodb.NewMongoDB(
-			ctx,
-			mdConfig.URL,
-			mdConfig.Database,
-			options...)
+		return nil, errors.New("mongodb is deprecated")
+
 	case model.DataStoreMySQL:
 		mqConfig := cfg.Datastore.MySQLConfig
 		options := []mysql.Option{


### PR DESCRIPTION
**What this PR does / why we need it**:

Note: `datastore/mongodb` package still exist since we use it for `pipectl datastore migrate` command. Will remove it once the migrate command be disabled.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Disable MongoDB as ControlPlane's datastore
```
