### PR TITLE
Ensure that chart-releaser reconstructs chart's dependencies

### DIFF
--- a/dockers/chart-releaser/DOCKER_BUILD
+++ b/dockers/chart-releaser/DOCKER_BUILD
@@ -1,2 +1,2 @@
-version: 1.1.0
+version: 1.2.0
 registry: gcr.io/pipecd/chart-releaser

--- a/dockers/chart-releaser/main.go
+++ b/dockers/chart-releaser/main.go
@@ -105,9 +105,6 @@ func main() {
 	// Package new charts.
 	for _, chart := range charts {
 		chartPath := filepath.Join(manifestsDir, chart)
-		if err := downloadDependencies(ctx, chartPath); err != nil {
-			log.Fatalf("Unable to download charts %s dependes on: %v", chart, err)
-		}
 		if err := packageHelmChart(ctx, chartPath, workingDir); err != nil {
 			log.Fatalf("Unable to package chart %s: %v", chart, err)
 		}
@@ -149,19 +146,8 @@ func main() {
 	log.Printf("Successfully stored all packages and index file")
 }
 
-func downloadDependencies(ctx context.Context, chartPath string) error {
-	args := []string{"dependency", "build", chartPath}
-	cmd := exec.CommandContext(ctx, "helm", args...)
-
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("failed to package: %s (%w)", string(out), err)
-	}
-	return nil
-}
-
 func packageHelmChart(ctx context.Context, chartPath, dest string) error {
-	args := []string{"package", chartPath, "--destination", dest}
+	args := []string{"package", chartPath, "--destination", dest, "--dependency-update"}
 	cmd := exec.CommandContext(ctx, "helm", args...)
 
 	out, err := cmd.CombinedOutput()

--- a/dockers/chart-releaser/main.go
+++ b/dockers/chart-releaser/main.go
@@ -105,6 +105,9 @@ func main() {
 	// Package new charts.
 	for _, chart := range charts {
 		chartPath := filepath.Join(manifestsDir, chart)
+		if err := downloadDependencies(ctx, chartPath); err != nil {
+			log.Fatalf("Unable to download charts %s dependes on: %v", chart, err)
+		}
 		if err := packageHelmChart(ctx, chartPath, workingDir); err != nil {
 			log.Fatalf("Unable to package chart %s: %v", chart, err)
 		}
@@ -144,6 +147,17 @@ func main() {
 	}
 
 	log.Printf("Successfully stored all packages and index file")
+}
+
+func downloadDependencies(ctx context.Context, chartPath string) error {
+	args := []string{"dependency", "build", chartPath}
+	cmd := exec.CommandContext(ctx, "helm", args...)
+
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to package: %s (%w)", string(out), err)
+	}
+	return nil
 }
 
 func packageHelmChart(ctx context.Context, chartPath, dest string) error {


### PR DESCRIPTION
**What this PR does / why we need it**:
In https://github.com/pipe-cd/pipe/pull/1850, we settled on not including dependency charts. But apparently it can fail to package chart without dependencies: https://kapetanios.io/builds/6e32b27b-d93b-4f0a-921b-7e7daaaee39f/step-0

To avoid them, added a step to run [helm dependency build](https://helm.sh/docs/helm/helm_dependency_build), which just downloads charts based on `Chart.lock`.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
