### PR TITLE
Define default values of prometheus chart

### DIFF
--- a/manifests/pipecd/values.yaml
+++ b/manifests/pipecd/values.yaml
@@ -109,14 +109,24 @@ cors:
 quickstart: false
 
 monitoring:
+  # If true, prometheus and grafana sub-charts will be installed
   enabled: false
 
 # All directives inside this section will be directly sent to the prometheus chart.
 # Head to the below link to see all available values.
 # https://github.com/prometheus-community/helm-charts/blob/main/charts/prometheus/values.yaml
 prometheus:
+  server:
+    fullnameOverride: pipecd-prometheus-server
   pushgateway:
     enabled: false
+  nodeExporter:
+    enabled: false
+  kubeStateMetrics:
+    enabled: false
+  configmapReload:
+    prometheus:
+      enabled: true
   serverFiles:
     prometheus.yml:
       rule_files:
@@ -133,7 +143,7 @@ prometheus:
           scrape_interval: 2m
           metrics_path: /stats/prometheus
           kubernetes_sd_configs:
-            - role: service
+            - role: endpoints
           relabel_configs:
             - source_labels: [__meta_kubernetes_service_label_app_kubernetes_io_name]
               action: keep
@@ -141,3 +151,6 @@ prometheus:
             - source_labels: [__meta_kubernetes_service_label_app_kubernetes_io_component]
               action: keep
               regex: gateway
+            - source_labels: [__meta_kubernetes_pod_container_port_number]
+              action: keep
+              regex: "9095"

--- a/manifests/pipecd/values.yaml
+++ b/manifests/pipecd/values.yaml
@@ -138,9 +138,8 @@ prometheus:
           static_configs:
             - targets:
                 - localhost:9090
-
         - job_name: pipecd-gateway
-          scrape_interval: 2m
+          scrape_interval: 1m
           metrics_path: /stats/prometheus
           kubernetes_sd_configs:
             - role: endpoints
@@ -151,6 +150,34 @@ prometheus:
             - source_labels: [__meta_kubernetes_service_label_app_kubernetes_io_component]
               action: keep
               regex: gateway
-            - source_labels: [__meta_kubernetes_pod_container_port_number]
+            - source_labels: [__meta_kubernetes_pod_container_port_name]
               action: keep
-              regex: "9095"
+              regex: "envoy-admin"
+        - job_name: pipecd-server
+          scrape_interval: 1m
+          kubernetes_sd_configs:
+            - role: endpoints
+          relabel_configs:
+            - source_labels: [__meta_kubernetes_service_label_app_kubernetes_io_name]
+              action: keep
+              regex: pipecd
+            - source_labels: [__meta_kubernetes_service_label_app_kubernetes_io_component]
+              action: keep
+              regex: server
+            - source_labels: [__meta_kubernetes_pod_container_port_name]
+              action: keep
+              regex: "admin"
+        - job_name: pipecd-ops
+          scrape_interval: 1m
+          kubernetes_sd_configs:
+            - role: endpoints
+          relabel_configs:
+            - source_labels: [__meta_kubernetes_service_label_app_kubernetes_io_name]
+              action: keep
+              regex: pipecd
+            - source_labels: [__meta_kubernetes_service_label_app_kubernetes_io_component]
+              action: keep
+              regex: ops
+            - source_labels: [__meta_kubernetes_pod_container_port_name]
+              action: keep
+              regex: "admin"

--- a/manifests/pipecd/values.yaml
+++ b/manifests/pipecd/values.yaml
@@ -152,7 +152,7 @@ prometheus:
               regex: gateway
             - source_labels: [__meta_kubernetes_pod_container_port_name]
               action: keep
-              regex: "envoy-admin"
+              regex: envoy-admin
         - job_name: pipecd-server
           scrape_interval: 1m
           kubernetes_sd_configs:
@@ -166,7 +166,7 @@ prometheus:
               regex: server
             - source_labels: [__meta_kubernetes_pod_container_port_name]
               action: keep
-              regex: "admin"
+              regex: admin
         - job_name: pipecd-ops
           scrape_interval: 1m
           kubernetes_sd_configs:
@@ -180,4 +180,4 @@ prometheus:
               regex: ops
             - source_labels: [__meta_kubernetes_pod_container_port_name]
               action: keep
-              regex: "admin"
+              regex: admin

--- a/manifests/pipecd/values.yaml
+++ b/manifests/pipecd/values.yaml
@@ -114,5 +114,30 @@ monitoring:
 # All directives inside this section will be directly sent to the prometheus chart.
 # Head to the below link to see all available values.
 # https://github.com/prometheus-community/helm-charts/blob/main/charts/prometheus/values.yaml
-# TODO: Prepare the default prometheus.yml
-prometheus: {}
+prometheus:
+  pushgateway:
+    enabled: false
+  serverFiles:
+    prometheus.yml:
+      rule_files:
+        - /etc/config/recording_rules.yml
+        - /etc/config/alerting_rules.yml
+
+      scrape_configs:
+        - job_name: prometheus
+          static_configs:
+            - targets:
+                - localhost:9090
+
+        - job_name: pipecd-gateway
+          scrape_interval: 2m
+          metrics_path: /stats/prometheus
+          kubernetes_sd_configs:
+            - role: service
+          relabel_configs:
+            - source_labels: [__meta_kubernetes_service_label_app_kubernetes_io_name]
+              action: keep
+              regex: pipecd
+            - source_labels: [__meta_kubernetes_service_label_app_kubernetes_io_component]
+              action: keep
+              regex: gateway


### PR DESCRIPTION
**What this PR does / why we need it**:
I just settled on disabling Pushgateway and k8s resource watch until needed. And I put `persistentVolume` stuff off for now.

**Which issue(s) this PR fixes**:

Fixes https://github.com/pipe-cd/pipe/issues/1852
Fixes https://github.com/pipe-cd/pipe/issues/1859

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
