### PR TITLE
Update piped-base to not depend on /home/pipecd

### DIFF
--- a/dockers/piped-base/DOCKER_BUILD
+++ b/dockers/piped-base/DOCKER_BUILD
@@ -1,2 +1,2 @@
-version: 0.1.5
+version: 0.2.0
 registry: gcr.io/pipecd/piped-base

--- a/dockers/piped-base/Dockerfile
+++ b/dockers/piped-base/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.12.1
 
-ENV PIPED_TOOLS_DIR=/home/pipecd/tools
+ENV PIPED_TOOLS_DIR=/tools
 ENV PATH="${PIPED_TOOLS_DIR}:${PATH}"
 
 COPY install-helm.sh /installer/install-helm.sh
@@ -10,7 +10,7 @@ COPY install-terraform.sh /installer/install-terraform.sh
 
 RUN \
     addgroup -S -g 1000 pipecd && \
-    adduser -S -u 1000 -G pipecd -h /home/pipecd pipecd && \
+    adduser -S -u 1000 -G pipecd pipecd && \
     apk add --no-cache \
         ca-certificates \
         git \
@@ -19,7 +19,7 @@ RUN \
         bash && \
     update-ca-certificates && \
     mkdir ${PIPED_TOOLS_DIR} && \
-    chown pipecd ${PIPED_TOOLS_DIR} && \
+    chmod 774 /etc/ssh/ssh_config && \
     # Pre-install the default version of helm.
     /installer/install-helm.sh && \
     # Pre-install the default version of kubectl.
@@ -28,6 +28,7 @@ RUN \
     /installer/install-kustomize.sh && \
     # Pre-install the default version of terraform.
     /installer/install-terraform.sh && \
+    chmod 775 ${PIPED_TOOLS_DIR}/* && \
     # Delete installer directory.
     rm -rf /installer && \
     rm -f /var/cache/apk/*

--- a/dockers/piped-base/dockertest/check-helm.sh
+++ b/dockers/piped-base/dockertest/check-helm.sh
@@ -15,8 +15,8 @@
 # limitations under the License.
 
 declare -A pathcases
-#pathcases["helm-2.16.7"]="/home/pipecd/tools/helm-2.16.7"
-pathcases["helm"]="/home/pipecd/tools/helm"
+#pathcases["helm-2.16.7"]="/tools/helm-2.16.7"
+pathcases["helm"]="/tools/helm"
 
 for h in "${!pathcases[@]}"
 do


### PR DESCRIPTION
**What this PR does / why we need it**:
Until now, we assumed the home directory of the user Piped runs as is `/home/pipecd`. But we can't specify the user name at the pod template. So I settled on going back to use `/etc/ssh/ssh_config` as an ssh config file and `/tools` as a binary directory. Let me check how it goes once got merged because I have no chance to build the container locally.

**Which issue(s) this PR fixes**:

Fixes 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
