### PR TITLE
Enable drift detector to compare number and numeric string

### DIFF
--- a/pkg/app/piped/diff/diff_test.go
+++ b/pkg/app/piped/diff/diff_test.go
@@ -39,6 +39,8 @@ func TestDiff(t *testing.T) {
 			yamlFile: "testdata/no_diff.yaml",
 			options: []Option{
 				WithEquateEmpty(),
+				WithIgnoreAddingMapKeys(),
+				WithCompareNumberAndNumericString(),
 			},
 			diffNum: 0,
 		},

--- a/pkg/app/piped/diff/testdata/no_diff.yaml
+++ b/pkg/app/piped/diff/testdata/no_diff.yaml
@@ -30,6 +30,13 @@ spec:
         emptyList:
           []
         emptyMap: {}
+        resources:
+          limits:
+            cpu: 1
+            memory: 1Gi
+          requests:
+            cpu: 1
+            memory: 1Gi
 ---
 apiVersion: apps/v1
 kind: Foo
@@ -60,3 +67,10 @@ spec:
         # Zero map and nil map should be equal.
         resources: {}
         emptyList2: []
+        resources:
+          limits:
+            cpu: "1"
+            memory: 1Gi
+          requests:
+            cpu: "1"
+            memory: 1Gi

--- a/pkg/app/piped/driftdetector/kubernetes/detector.go
+++ b/pkg/app/piped/driftdetector/kubernetes/detector.go
@@ -196,6 +196,7 @@ func (d *detector) checkApplication(ctx context.Context, app *model.Application,
 		result, err := provider.Diff(headInters[i], liveInters[i],
 			diff.WithEquateEmpty(),
 			diff.WithIgnoreAddingMapKeys(),
+			diff.WithCompareNumberAndNumericString(),
 		)
 		if err != nil {
 			d.logger.Error("failed to calculate the diff of manifests", zap.Error(err))


### PR DESCRIPTION
**What this PR does / why we need it**:

Some Kubernetes resource fields are using `resources.Quality` data type (a customized struct to allow specifying cpu/memory by either number or string), that causes inconsistent marshaling result with the defined one in Git.

Adding edge-handling for the case such as `resource.cpu`, `resource.memory` is not enough because so many CRDs are also using that data type too, not just standard resource like Deployment.

So I think we can enable our drift detector component to compare number values and numeric strings to avoid those diffs.
The downside of this way is that other fields (not `resource.cpu` or `resource.memory`) also will be the target of this comparation.
But I think once they are the wrong type, they will be failed while applying to the Kubernetes cluster. So the drift detector can rely on that assumption.)

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Enable drift detector to compare number and numeric string
```
