### PR TITLE
Enable to specify UID that Piped runs as

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -129,8 +129,7 @@ load(
 
 container_pull(
     name = "piped-base",
-    # FIXME: Populate the hash
-    digest = "",
+    digest = "sha256:792ac87ea71cc12d3213f669717d045cd4a0db2a2d8b512ab1450c8301eae475",
     registry = "gcr.io",
     repository = "pipecd/piped-base",
     tag = "0.2.0",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -129,10 +129,11 @@ load(
 
 container_pull(
     name = "piped-base",
-    digest = "sha256:24ff16ed2b89b6a370523566ec8c1f57c5892f0d3dfc9cdefb7b3471427be0c3",
+    # FIXME: Populate the hash
+    digest = "",
     registry = "gcr.io",
     repository = "pipecd/piped-base",
-    tag = "0.1.5",
+    tag = "0.2.0",
 )
 
 container_pull(

--- a/docs/content/en/docs/operator-manual/piped/configuration-reference.md
+++ b/docs/content/en/docs/operator-manual/piped/configuration-reference.md
@@ -39,7 +39,7 @@ spec:
 |-|-|-|-|
 | username | string | The username that will be configured for `git` user. Default is `piped`. | No |
 | email | string | The email that will be configured for `git` user. Default is `pipecd.dev@gmail.com`. | No |
-| sshConfigFilePath | string | Where to write ssh config file. Default is `/home/pipecd/.ssh/config`. | No |
+| sshConfigFilePath | string | Where to write ssh config file. Default is `/etc/ssh/ssh_config`. | No |
 | host | string | The host name. Default is `github.com`. | No |
 | hostName | string | The hostname or IP address of the remote git server. Default is the same value with Host. | No |
 | sshKeyFile | string | The path to the private ssh key file. This will be used to clone the source code of the specified git repositories. | No |

--- a/manifests/piped/templates/deployment.yaml
+++ b/manifests/piped/templates/deployment.yaml
@@ -61,10 +61,10 @@ spec:
         - name: piped-config
           configMap:
             name: {{ include "piped.configMapName" . }}
+      {{- with .Values.securityContext }}
       securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
-        fsGroup: 1000
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/manifests/piped/values.yaml
+++ b/manifests/piped/values.yaml
@@ -75,6 +75,11 @@ secret:
     fileName: datadog-application-key
     data: ""
 
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  fsGroup: 1000
+
 nodeSelector: {}
 
 tolerations: []

--- a/pkg/app/piped/cmd/piped/piped.go
+++ b/pkg/app/piped/cmd/piped/piped.go
@@ -75,7 +75,7 @@ type piped struct {
 func NewCommand() *cobra.Command {
 	p := &piped{
 		adminPort:   9085,
-		toolsDir:    "/home/pipecd/tools",
+		toolsDir:    "/tools",
 		gracePeriod: 30 * time.Second,
 	}
 	cmd := &cobra.Command{

--- a/pkg/config/piped.go
+++ b/pkg/config/piped.go
@@ -172,7 +172,7 @@ type PipedGit struct {
 	// Default is "pipecd.dev@gmail.com".
 	Email string `json:"email"`
 	// Where to write ssh config file.
-	// Default is "/home/pipecd/.ssh/config".
+	// Default is "/etc/ssh/ssh_config".
 	SSHConfigFilePath string `json:"sshConfigFilePath"`
 	// The host name.
 	// e.g. github.com, gitlab.com

--- a/pkg/git/ssh_config.go
+++ b/pkg/git/ssh_config.go
@@ -25,7 +25,7 @@ import (
 )
 
 const (
-	defaultSSHConfigFilePath = "/home/pipecd/.ssh/config"
+	defaultSSHConfigFilePath = "/etc/ssh/ssh_config"
 	defaultHost              = "github.com"
 
 	sshConfigTemplate = `


### PR DESCRIPTION
**What this PR does / why we need it**:
Once https://github.com/pipe-cd/pipe/pull/1871 got merged, I will open up this one after populating the image digest.

**Which issue(s) this PR fixes**:

Fixes https://github.com/pipe-cd/pipe/issues/1870

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Enable to specify UID that Piped runs as
```
