### PR TITLE
Change application description position

### DIFF
--- a/pkg/app/web/src/components/application-detail/index.tsx
+++ b/pkg/app/web/src/components/application-detail/index.tsx
@@ -231,11 +231,6 @@ export const ApplicationDetail: FC<ApplicationDetailProps> = memo(
                 <AppLiveState applicationId={applicationId} />
               </Box>
 
-              <ApplicationDescription
-                description={app.description}
-                onUpdate={handleDescriptionEdit}
-              />
-
               {app.syncState && (
                 <SyncStateReason
                   summary={app.syncState.shortReason}
@@ -291,6 +286,13 @@ export const ApplicationDetail: FC<ApplicationDetailProps> = memo(
             />
           </div>
         </Box>
+
+        {app && (
+          <ApplicationDescription
+            description={app.description}
+            onUpdate={handleDescriptionEdit}
+          />
+        )}
 
         <Box top={0} right={0} pr={2} pt={2} position="absolute">
           <SplitButton


### PR DESCRIPTION
**What this PR does / why we need it**:

![image](https://user-images.githubusercontent.com/6136383/114998214-b4022d00-9edb-11eb-99ac-3ad7ede7d6de.png)

Changed the description position because it was in a place that could be mistaken for an out of sync reason.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Change application description position
```
