### PR TITLE
Update piped-base so that piped group can write to /piped/home

### DIFF
--- a/dockers/piped-base/DOCKER_BUILD
+++ b/dockers/piped-base/DOCKER_BUILD
@@ -1,2 +1,2 @@
-version: 0.2.1
+version: 0.2.2
 registry: gcr.io/pipecd/piped-base

--- a/dockers/piped-base/Dockerfile
+++ b/dockers/piped-base/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.12.1
 
-ENV PIPED_SHARED_HOME=/etc/pipecd
-ENV PIPED_TOOLS_DIR="${PIPED_SHARED_HOME}/tools"
+ENV PIPED_DIR=/etc/piped
+ENV PIPED_TOOLS_DIR="${PIPED_DIR}/tools"
 ENV PATH="${PIPED_TOOLS_DIR}:${PATH}"
 
 COPY install-helm.sh /installer/install-helm.sh
@@ -31,7 +31,7 @@ RUN \
     # Delete installer directory.
     rm -rf /installer && \
     rm -f /var/cache/apk/* && \
-    chown -hR pipecd:pipecd ${PIPED_SHARED_HOME} && \
-    chmod 770 -R ${PIPED_SHARED_HOME}
+    chown -hR pipecd:pipecd ${PIPED_DIR} && \
+    chmod 770 -R ${PIPED_DIR}
 
 USER pipecd

--- a/dockers/piped-base/Dockerfile
+++ b/dockers/piped-base/Dockerfile
@@ -1,6 +1,7 @@
 FROM alpine:3.12.1
 
-ENV PIPED_TOOLS_DIR=/tools
+ENV PIPED_SHARED_HOME=/etc/pipecd
+ENV PIPED_TOOLS_DIR="${PIPED_SHARED_HOME}/tools"
 ENV PATH="${PIPED_TOOLS_DIR}:${PATH}"
 
 COPY install-helm.sh /installer/install-helm.sh
@@ -18,8 +19,7 @@ RUN \
         curl \
         bash && \
     update-ca-certificates && \
-    mkdir ${PIPED_TOOLS_DIR} && \
-    chmod 776 /etc/ssh/ssh_config && \
+    mkdir -p ${PIPED_TOOLS_DIR} && \
     # Pre-install the default version of helm.
     /installer/install-helm.sh && \
     # Pre-install the default version of kubectl.
@@ -28,9 +28,10 @@ RUN \
     /installer/install-kustomize.sh && \
     # Pre-install the default version of terraform.
     /installer/install-terraform.sh && \
-    chmod 775 ${PIPED_TOOLS_DIR}/* && \
     # Delete installer directory.
     rm -rf /installer && \
-    rm -f /var/cache/apk/*
+    rm -f /var/cache/apk/* && \
+    chown -hR pipecd:pipecd ${PIPED_SHARED_HOME} && \
+    chmod 770 -R ${PIPED_SHARED_HOME}
 
 USER pipecd

--- a/dockers/piped-base/Dockerfile
+++ b/dockers/piped-base/Dockerfile
@@ -1,12 +1,13 @@
 FROM alpine:3.12.1
 
-ENV PIPED_DIR=/etc/piped
-ENV PIPED_TOOLS_DIR="${PIPED_DIR}/tools"
+ARG PIPED_USER=piped
+ARG PIPED_USER_GROUP=piped
+ARG PIPED_UID=1000
+ARG PIPED_GID=1000
+
+ENV HOME=/home/${PIPED_USER}
+ENV PIPED_TOOLS_DIR="${HOME}/.piped/tools"
 ENV PATH="${PIPED_TOOLS_DIR}:${PATH}"
-ENV HELM_CACHE_HOME="${PIPED_DIR}/.cache/helm"
-ENV HELM_CONFIG_HOME="${PIPED_DIR}/.config/helm"
-ENV HELM_DATA_HOME="${PIPED_DIR}/.local/share/helm"
-ENV KUBECONFIG="${PIPED_DIR}/.kube/config"
 
 COPY install-helm.sh /installer/install-helm.sh
 COPY install-kubectl.sh /installer/install-kubectl.sh
@@ -14,8 +15,8 @@ COPY install-kustomize.sh /installer/install-kustomize.sh
 COPY install-terraform.sh /installer/install-terraform.sh
 
 RUN \
-    addgroup -S -g 1000 pipecd && \
-    adduser -S -u 1000 -G pipecd pipecd && \
+    addgroup -S -g $PIPED_GID $PIPED_USER_GROUP && \
+    adduser -S -u $PIPED_UID -G $PIPED_USER_GROUP -h $HOME $PIPED_USER && \
     apk add --no-cache \
         ca-certificates \
         git \
@@ -35,7 +36,7 @@ RUN \
     # Delete installer directory.
     rm -rf /installer && \
     rm -f /var/cache/apk/* && \
-    chown -hR pipecd:pipecd ${PIPED_DIR} && \
-    chmod 770 -R ${PIPED_DIR}
+    chown -R $PIPED_USER:$PIPED_USER_GROUP $HOME && \
+    chmod 770 -R $HOME
 
-USER pipecd
+USER $PIPED_USER

--- a/dockers/piped-base/Dockerfile
+++ b/dockers/piped-base/Dockerfile
@@ -3,6 +3,10 @@ FROM alpine:3.12.1
 ENV PIPED_DIR=/etc/piped
 ENV PIPED_TOOLS_DIR="${PIPED_DIR}/tools"
 ENV PATH="${PIPED_TOOLS_DIR}:${PATH}"
+ENV HELM_CACHE_HOME="${PIPED_DIR}/.cache/helm"
+ENV HELM_CONFIG_HOME="${PIPED_DIR}/.config/helm"
+ENV HELM_DATA_HOME="${PIPED_DIR}/.local/share/helm"
+ENV KUBECONFIG="${PIPED_DIR}/.kube/config"
 
 COPY install-helm.sh /installer/install-helm.sh
 COPY install-kubectl.sh /installer/install-kubectl.sh

--- a/dockers/piped-base/dockertest/check-helm.sh
+++ b/dockers/piped-base/dockertest/check-helm.sh
@@ -15,8 +15,8 @@
 # limitations under the License.
 
 declare -A pathcases
-#pathcases["helm-2.16.7"]="/etc/piped/tools/helm-2.16.7"
-pathcases["helm"]="/etc/piped/tools/helm"
+#pathcases["helm-2.16.7"]="/home/piped/.piped/tools/helm-2.16.7"
+pathcases["helm"]="/home/piped/.piped/tools/helm"
 
 for h in "${!pathcases[@]}"
 do

--- a/dockers/piped-base/dockertest/check-helm.sh
+++ b/dockers/piped-base/dockertest/check-helm.sh
@@ -16,7 +16,7 @@
 
 declare -A pathcases
 #pathcases["helm-2.16.7"]="/tools/helm-2.16.7"
-pathcases["helm"]="/tools/helm"
+pathcases["helm"]="/etc/pipecd/tools/helm"
 
 for h in "${!pathcases[@]}"
 do

--- a/dockers/piped-base/dockertest/check-helm.sh
+++ b/dockers/piped-base/dockertest/check-helm.sh
@@ -15,8 +15,8 @@
 # limitations under the License.
 
 declare -A pathcases
-#pathcases["helm-2.16.7"]="/tools/helm-2.16.7"
-pathcases["helm"]="/etc/pipecd/tools/helm"
+#pathcases["helm-2.16.7"]="/etc/piped/tools/helm-2.16.7"
+pathcases["helm"]="/etc/piped/tools/helm"
 
 for h in "${!pathcases[@]}"
 do


### PR DESCRIPTION
**What this PR does / why we need it**:
We settled on using `/etc/pipecd` as a shared home directory for all users. All files will be included underneath this directory such as:
- the ssh configuration file
- tools to be used for deploying
- cache and configurations for the above tools

**Which issue(s) this PR fixes**:

Ref https://github.com/pipe-cd/pipe/issues/1885

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
