### PR TITLE
Support pagination with cursor for ListApplications api

### DIFF
--- a/pkg/app/api/grpcapi/api.go
+++ b/pkg/app/api/grpcapi/api.go
@@ -269,13 +269,14 @@ func (a *API) ListApplications(ctx context.Context, req *apiservice.ListApplicat
 		Limit:   limit,
 	}
 
-	apps, err := listApplications(ctx, a.applicationStore, opts, a.logger)
+	apps, cursor, err := listApplications(ctx, a.applicationStore, opts, a.logger)
 	if err != nil {
 		return nil, err
 	}
 
 	return &apiservice.ListApplicationsResponse{
 		Applications: apps,
+		Cursor:       cursor,
 	}, nil
 }
 

--- a/pkg/app/api/grpcapi/api.go
+++ b/pkg/app/api/grpcapi/api.go
@@ -182,6 +182,16 @@ func (a *API) ListApplications(ctx context.Context, req *apiservice.ListApplicat
 	}
 
 	const limit = 10
+	orders := []datastore.Order{
+		{
+			Field:     "UpdatedAt",
+			Direction: datastore.Desc,
+		},
+		{
+			Field:     "Id",
+			Direction: datastore.Asc,
+		},
+	}
 	filters := []datastore.ListFilter{
 		{
 			Field:    "ProjectId",
@@ -265,6 +275,7 @@ func (a *API) ListApplications(ctx context.Context, req *apiservice.ListApplicat
 		})
 	}
 	opts := datastore.ListOptions{
+		Orders:  orders,
 		Filters: filters,
 		Limit:   limit,
 	}

--- a/pkg/app/api/grpcapi/piped_api.go
+++ b/pkg/app/api/grpcapi/piped_api.go
@@ -715,6 +715,10 @@ func (a *PipedAPI) GetLatestEvent(ctx context.Context, req *pipedservice.GetLate
 				Field:     "CreatedAt",
 				Direction: datastore.Desc,
 			},
+			{
+				Field:     "Id",
+				Direction: datastore.Asc,
+			},
 		},
 	}
 	events, err := a.eventStore.ListEvents(ctx, opts)
@@ -769,12 +773,20 @@ func (a *PipedAPI) ListEvents(ctx context.Context, req *pipedservice.ListEventsR
 				Field:     "CreatedAt",
 				Direction: datastore.Asc,
 			},
+			{
+				Field:     "Id",
+				Direction: datastore.Asc,
+			},
 		}
 	case pipedservice.ListOrder_DESC:
 		opts.Orders = []datastore.Order{
 			{
 				Field:     "CreatedAt",
 				Direction: datastore.Desc,
+			},
+			{
+				Field:     "Id",
+				Direction: datastore.Asc,
 			},
 		}
 	}

--- a/pkg/app/api/grpcapi/piped_api.go
+++ b/pkg/app/api/grpcapi/piped_api.go
@@ -168,7 +168,7 @@ func (a *PipedAPI) ListApplications(ctx context.Context, req *pipedservice.ListA
 		},
 	}
 	// TODO: Support pagination in ListApplications
-	apps, err := a.applicationStore.ListApplications(ctx, opts)
+	apps, _, err := a.applicationStore.ListApplications(ctx, opts)
 	if err != nil {
 		a.logger.Error("failed to fetch applications", zap.Error(err))
 		return nil, status.Error(codes.Internal, "failed to fetch applications")

--- a/pkg/app/api/grpcapi/utils.go
+++ b/pkg/app/api/grpcapi/utils.go
@@ -54,14 +54,14 @@ func getApplication(ctx context.Context, store datastore.ApplicationStore, id st
 	return app, nil
 }
 
-func listApplications(ctx context.Context, store datastore.ApplicationStore, opts datastore.ListOptions, logger *zap.Logger) ([]*model.Application, error) {
-	apps, _, err := store.ListApplications(ctx, opts)
+func listApplications(ctx context.Context, store datastore.ApplicationStore, opts datastore.ListOptions, logger *zap.Logger) ([]*model.Application, string, error) {
+	apps, cursor, err := store.ListApplications(ctx, opts)
 	if err != nil {
 		logger.Error("failed to list applications", zap.Error(err))
-		return nil, status.Error(codes.Internal, "Failed to list applications")
+		return nil, "", status.Error(codes.Internal, "Failed to list applications")
 	}
 
-	return apps, nil
+	return apps, cursor, nil
 }
 
 func getDeployment(ctx context.Context, store datastore.DeploymentStore, id string, logger *zap.Logger) (*model.Deployment, error) {

--- a/pkg/app/api/grpcapi/utils.go
+++ b/pkg/app/api/grpcapi/utils.go
@@ -55,7 +55,7 @@ func getApplication(ctx context.Context, store datastore.ApplicationStore, id st
 }
 
 func listApplications(ctx context.Context, store datastore.ApplicationStore, opts datastore.ListOptions, logger *zap.Logger) ([]*model.Application, error) {
-	apps, err := store.ListApplications(ctx, opts)
+	apps, _, err := store.ListApplications(ctx, opts)
 	if err != nil {
 		logger.Error("failed to list applications", zap.Error(err))
 		return nil, status.Error(codes.Internal, "Failed to list applications")

--- a/pkg/app/api/grpcapi/web_api.go
+++ b/pkg/app/api/grpcapi/web_api.go
@@ -575,6 +575,10 @@ func (a *WebAPI) ListApplications(ctx context.Context, req *webservice.ListAppli
 			Field:     "UpdatedAt",
 			Direction: datastore.Desc,
 		},
+		{
+			Field:     "Id",
+			Direction: datastore.Asc,
+		},
 	}
 	filters := []datastore.ListFilter{
 		{
@@ -781,6 +785,10 @@ func (a *WebAPI) ListDeployments(ctx context.Context, req *webservice.ListDeploy
 		{
 			Field:     "UpdatedAt",
 			Direction: datastore.Desc,
+		},
+		{
+			Field:     "Id",
+			Direction: datastore.Asc,
 		},
 	}
 	filters := []datastore.ListFilter{

--- a/pkg/app/api/grpcapi/web_api.go
+++ b/pkg/app/api/grpcapi/web_api.go
@@ -623,7 +623,7 @@ func (a *WebAPI) ListApplications(ctx context.Context, req *webservice.ListAppli
 		}
 	}
 
-	apps, err := a.applicationStore.ListApplications(ctx, datastore.ListOptions{
+	apps, _, err := a.applicationStore.ListApplications(ctx, datastore.ListOptions{
 		Filters: filters,
 		Orders:  orders,
 	})

--- a/pkg/app/api/service/apiservice/service.proto
+++ b/pkg/app/api/service/apiservice/service.proto
@@ -77,6 +77,7 @@ message ListApplicationsRequest {
 
 message ListApplicationsResponse {
     repeated pipe.model.Application applications = 1;
+    string cursor = 2;
 }
 
 message GetDeploymentRequest {

--- a/pkg/app/ops/insightcollector/applications.go
+++ b/pkg/app/ops/insightcollector/applications.go
@@ -69,7 +69,7 @@ func (i *InsightCollector) getApplications(ctx context.Context, to time.Time) ([
 	var applications []*model.Application
 	maxCreatedAt := to.Unix()
 	for {
-		apps, err := i.applicationStore.ListApplications(ctx, datastore.ListOptions{
+		apps, _, err := i.applicationStore.ListApplications(ctx, datastore.ListOptions{
 			Limit: limit,
 			Filters: []datastore.ListFilter{
 				{

--- a/pkg/app/ops/insightcollector/applications_test.go
+++ b/pkg/app/ops/insightcollector/applications_test.go
@@ -65,7 +65,7 @@ func TestInsightCollector_getApplications(t *testing.T) {
 					{
 						Id: "2",
 					},
-				}, nil)
+				}, "", nil)
 			},
 			want: []*model.Application{
 				{
@@ -101,7 +101,7 @@ func TestInsightCollector_getApplications(t *testing.T) {
 					{
 						CreatedAt: time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC).Unix(),
 					},
-				}, nil)
+				}, "", nil)
 				m.EXPECT().ListApplications(gomock.Any(), datastore.ListOptions{
 					Limit: limit,
 					Filters: []datastore.ListFilter{
@@ -118,7 +118,7 @@ func TestInsightCollector_getApplications(t *testing.T) {
 						},
 					}}).Return([]*model.Application{
 					{}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {},
-				}, nil)
+				}, "", nil)
 			},
 			want: []*model.Application{
 				{}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {},
@@ -148,7 +148,7 @@ func TestInsightCollector_getApplications(t *testing.T) {
 							Field:     "CreatedAt",
 							Direction: datastore.Desc,
 						},
-					}}).Return(nil, errors.New("error"))
+					}}).Return(nil, "", errors.New("error"))
 			},
 			wantErr: true,
 		},

--- a/pkg/app/pipectl/cmd/application/list.go
+++ b/pkg/app/pipectl/cmd/application/list.go
@@ -86,7 +86,7 @@ func (c *list) run(ctx context.Context, _ cli.Telemetry) error {
 		return fmt.Errorf("failed to list application: %w", err)
 	}
 
-	bytes, err := json.Marshal(resp.Applications)
+	bytes, err := json.Marshal(resp)
 	if err != nil {
 		return fmt.Errorf("failed to marshal applications: %w", err)
 	}

--- a/pkg/datastore/applicationstore_test.go
+++ b/pkg/datastore/applicationstore_test.go
@@ -171,7 +171,7 @@ func TestListApplications(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			s := NewApplicationStore(tc.ds)
-			_, err := s.ListApplications(context.Background(), tc.opts)
+			_, _, err := s.ListApplications(context.Background(), tc.opts)
 			assert.Equal(t, tc.wantErr, err != nil)
 		})
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Check command on local
```console
$ bazel-bin/pipectl application list \
     --address=127.0.0.1:8080 \
     --api-key-file=.dev/local_cluster_piped.key \
     --insecure | jq
{
  "applications": [
    {
      "id": "b9097cba-8cff-4b8d-99a0-5ba4695c2b08",
      "name": "simple",
      "env_id": "7636ef4d-8649-4068-be79-417798de3562",
      "piped_id": "a8d25b84-29e4-456a-8a11-5fee5ea4efe3",
      "project_id": "quickstart",
      "git_path": {
        "repo": {
          "id": "examples-1",
          "remote": "https://github.com/khanhtc1202/examples-1.git",
          "branch": "master"
        },
        "path": "kubernetes/simple",
        "url": "https://github.com/khanhtc1202/examples-1/tree/master/kubernetes/simple"
      },
      "cloud_provider": "kubernetes-default",
      "created_at": 1618931497,
      "updated_at": 1618931497
    }
  ],
  "cursor": "eyJJZCI6ImI5MDk3Y2JhLThjZmYtNGI4ZC05OWEwLTViYTQ2OTVjMmIwOCIsIlVwZGF0ZWRBdCI6MTYxODkzMTQ5N30="
}
```
The cursor value is
```console
$ echo "eyJJZCI6ImI5MDk3Y2JhLThjZmYtNGI4ZC05OWEwLTViYTQ2OTVjMmIwOCIsIlVwZGF0ZWRBdCI6MTYxODkzMTQ5N30=" | base64 --decode - | jq
{
  "Id": "b9097cba-8cff-4b8d-99a0-5ba4695c2b08",
  "UpdatedAt": 1618931497
}
```

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Add cursor to the result from pipectl list applications command
```
