### PR TITLE
Reimplement pagination query for MySQL datastore

### DIFF
--- a/pkg/datastore/mysql/query.go
+++ b/pkg/datastore/mysql/query.go
@@ -106,7 +106,7 @@ func buildPaginationCondition(opts datastore.ListOptions) string {
 	subSetConds := make([]string, len(opts.Orders))
 	for i, o := range opts.Orders {
 		if o.Field == "Id" {
-			subSetConds[i] = fmt.Sprintf("%s %s UUID_TO_BIN(?, true)", o.Field, makeCompareOperatorForSubSet(o.Direction))
+			subSetConds[i] = fmt.Sprintf("%s %s UUID_TO_BIN(?,true)", o.Field, makeCompareOperatorForSubSet(o.Direction))
 		} else {
 			subSetConds[i] = fmt.Sprintf("%s = ?", o.Field)
 		}

--- a/pkg/datastore/mysql/query.go
+++ b/pkg/datastore/mysql/query.go
@@ -87,35 +87,50 @@ func buildPaginationCondition(opts datastore.ListOptions) string {
 		return ""
 	}
 
-	conds := make([]string, len(opts.Orders))
+	// Build outer set condition. The outer set condition should be
+	// in format:
+	//   X < Vx AND Y < Vy AND ...
+	// with x, y, etc is not Id field.
+	outerSetConds := make([]string, len(opts.Orders)-1)
 	for i, o := range opts.Orders {
 		if o.Field == "Id" {
-			conds[i] = fmt.Sprintf("%s %s UUID_TO_BIN(?,true)", o.Field, makePaginationConditionOperator(o))
+			continue
+		}
+		outerSetConds[i] = fmt.Sprintf("%s %s ?", o.Field, makeCompareOperatorForOuterSet(o.Direction))
+	}
+
+	// Build sub set condition. The sub set condition should be
+	// in format:
+	//   X = Vx AND Y = Vy AND ... AND Id <= last_iterated_id
+	// with last_iterated_id from the given cursor.
+	subSetConds := make([]string, len(opts.Orders))
+	for i, o := range opts.Orders {
+		if o.Field == "Id" {
+			subSetConds[i] = fmt.Sprintf("%s %s UUID_TO_BIN(?, true)", o.Field, makeCompareOperatorForSubSet(o.Direction))
 		} else {
-			conds[i] = fmt.Sprintf("%s %s ?", o.Field, makePaginationConditionOperator(o))
+			subSetConds[i] = fmt.Sprintf("%s = ?", o.Field)
 		}
 	}
 
 	// If there is no filter, mean pagination condition should be treated as the only where condition.
 	if len(opts.Filters) == 0 {
-		return fmt.Sprintf("WHERE %s", strings.Join(conds[:], " AND "))
+		return fmt.Sprintf("WHERE %s AND NOT (%s)", strings.Join(outerSetConds[:], " AND "), strings.Join(subSetConds[:], " AND "))
 	}
-	return fmt.Sprintf("AND %s", strings.Join(conds[:], " AND "))
+	return fmt.Sprintf("AND %s AND NOT (%s)", strings.Join(outerSetConds[:], " AND "), strings.Join(subSetConds[:], " AND "))
 }
 
-func makePaginationConditionOperator(order datastore.Order) string {
-	// Only the Id field should be used strict with greater/lower than operators.
-	if order.Field == "Id" {
-		if order.Direction == datastore.Asc {
-			return ">"
-		}
-		return "<"
-	}
-
-	if order.Direction == datastore.Asc {
+func makeCompareOperatorForOuterSet(direction datastore.OrderDirection) string {
+	if direction == datastore.Asc {
 		return ">="
 	}
 	return "<="
+}
+
+func makeCompareOperatorForSubSet(direction datastore.OrderDirection) string {
+	if direction == datastore.Asc {
+		return "<="
+	}
+	return ">="
 }
 
 func buildOrderByClause(orders []datastore.Order) (string, error) {

--- a/pkg/datastore/mysql/query.go
+++ b/pkg/datastore/mysql/query.go
@@ -114,9 +114,9 @@ func buildPaginationCondition(opts datastore.ListOptions) string {
 
 	// If there is no filter, mean pagination condition should be treated as the only where condition.
 	if len(opts.Filters) == 0 {
-		return fmt.Sprintf("WHERE %s AND NOT (%s)", strings.Join(outerSetConds[:], " AND "), strings.Join(subSetConds[:], " AND "))
+		return fmt.Sprintf("WHERE %s AND NOT (%s)", strings.Join(outerSetConds, " AND "), strings.Join(subSetConds, " AND "))
 	}
-	return fmt.Sprintf("AND %s AND NOT (%s)", strings.Join(outerSetConds[:], " AND "), strings.Join(subSetConds[:], " AND "))
+	return fmt.Sprintf("AND %s AND NOT (%s)", strings.Join(outerSetConds, " AND "), strings.Join(subSetConds, " AND "))
 }
 
 func makeCompareOperatorForOuterSet(direction datastore.OrderDirection) string {

--- a/pkg/datastore/mysql/query_test.go
+++ b/pkg/datastore/mysql/query_test.go
@@ -319,7 +319,7 @@ func TestBuildFindQuery(t *testing.T) {
 					return base64.StdEncoding.EncodeToString([]byte(`{"Id":"object-id","UpdatedAt":100}`))
 				}(),
 			},
-			expectedQuery: "SELECT Data FROM Application WHERE ProjectId = ? AND UpdatedAt <= ? AND NOT (UpdatedAt = ? AND Id <= UUID_TO_BIN(?, true)) ORDER BY UpdatedAt DESC, Id ASC LIMIT 20",
+			expectedQuery: "SELECT Data FROM Application WHERE ProjectId = ? AND UpdatedAt <= ? AND NOT (UpdatedAt = ? AND Id <= UUID_TO_BIN(?,true)) ORDER BY UpdatedAt DESC, Id ASC LIMIT 20",
 			wantErr:       false,
 		},
 		{
@@ -340,7 +340,7 @@ func TestBuildFindQuery(t *testing.T) {
 					return base64.StdEncoding.EncodeToString([]byte(`{"Id":"object-id","UpdatedAt":100}`))
 				}(),
 			},
-			expectedQuery: "SELECT Data FROM Application WHERE UpdatedAt <= ? AND NOT (UpdatedAt = ? AND Id <= UUID_TO_BIN(?, true)) ORDER BY UpdatedAt DESC, Id ASC",
+			expectedQuery: "SELECT Data FROM Application WHERE UpdatedAt <= ? AND NOT (UpdatedAt = ? AND Id <= UUID_TO_BIN(?,true)) ORDER BY UpdatedAt DESC, Id ASC",
 			wantErr:       false,
 		},
 		{

--- a/pkg/datastore/mysql/query_test.go
+++ b/pkg/datastore/mysql/query_test.go
@@ -319,7 +319,7 @@ func TestBuildFindQuery(t *testing.T) {
 					return base64.StdEncoding.EncodeToString([]byte(`{"Id":"object-id","UpdatedAt":100}`))
 				}(),
 			},
-			expectedQuery: "SELECT Data FROM Application WHERE ProjectId = ? AND UpdatedAt <= ? AND Id > UUID_TO_BIN(?,true) ORDER BY UpdatedAt DESC, Id ASC LIMIT 20",
+			expectedQuery: "SELECT Data FROM Application WHERE ProjectId = ? AND UpdatedAt <= ? AND NOT (UpdatedAt = ? AND Id <= UUID_TO_BIN(?, true)) ORDER BY UpdatedAt DESC, Id ASC LIMIT 20",
 			wantErr:       false,
 		},
 		{
@@ -340,7 +340,7 @@ func TestBuildFindQuery(t *testing.T) {
 					return base64.StdEncoding.EncodeToString([]byte(`{"Id":"object-id","UpdatedAt":100}`))
 				}(),
 			},
-			expectedQuery: "SELECT Data FROM Application WHERE UpdatedAt <= ? AND Id > UUID_TO_BIN(?,true) ORDER BY UpdatedAt DESC, Id ASC",
+			expectedQuery: "SELECT Data FROM Application WHERE UpdatedAt <= ? AND NOT (UpdatedAt = ? AND Id <= UUID_TO_BIN(?, true)) ORDER BY UpdatedAt DESC, Id ASC",
 			wantErr:       false,
 		},
 		{
@@ -413,33 +413,53 @@ func TestRefineFiltersValue(t *testing.T) {
 	}
 }
 
-func TestMakePaginationConditionOperator(t *testing.T) {
+func TestMakeCompareOperatorForOuterSet(t *testing.T) {
 	testcases := []struct {
 		name      string
-		order     datastore.Order
+		direction datastore.OrderDirection
 		expectOpe string
 	}{
 		{
-			name: "Id field as ordering field",
-			order: datastore.Order{
-				Field:     "Id",
-				Direction: datastore.Asc,
-			},
-			expectOpe: ">",
+			name:      "should return ope same direction with order direction: asc",
+			direction: datastore.Asc,
+			expectOpe: ">=",
 		},
 		{
-			name: "Not id field as ordering field",
-			order: datastore.Order{
-				Field:     "UpdatedAt",
-				Direction: datastore.Desc,
-			},
+			name:      "should return ope same direction with order direction: desc",
+			direction: datastore.Desc,
 			expectOpe: "<=",
 		},
 	}
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			ope := makePaginationConditionOperator(tc.order)
+			ope := makeCompareOperatorForOuterSet(tc.direction)
+			assert.Equal(t, tc.expectOpe, ope)
+		})
+	}
+}
+
+func TestMakeCompareOperatorForSubSet(t *testing.T) {
+	testcases := []struct {
+		name      string
+		direction datastore.OrderDirection
+		expectOpe string
+	}{
+		{
+			name:      "should return ope in revert direction with order direction: asc",
+			direction: datastore.Asc,
+			expectOpe: "<=",
+		},
+		{
+			name:      "should return ope in revert direction with order direction: desc",
+			direction: datastore.Desc,
+			expectOpe: ">=",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			ope := makeCompareOperatorForSubSet(tc.direction)
 			assert.Equal(t, tc.expectOpe, ope)
 		})
 	}

--- a/pkg/datastore/mysql/query_test.go
+++ b/pkg/datastore/mysql/query_test.go
@@ -344,6 +344,31 @@ func TestBuildFindQuery(t *testing.T) {
 			wantErr:       false,
 		},
 		{
+			name: "query with pagination cursor: more than 2 ordering fields",
+			kind: "Application",
+			listOptions: datastore.ListOptions{
+				Orders: []datastore.Order{
+					{
+						Field:     "UpdatedAt",
+						Direction: datastore.Desc,
+					},
+					{
+						Field:     "CreatedAt",
+						Direction: datastore.Desc,
+					},
+					{
+						Field:     "Id",
+						Direction: datastore.Asc,
+					},
+				},
+				Cursor: func() string {
+					return base64.StdEncoding.EncodeToString([]byte(`{"Id":"object-id","UpdatedAt":100,"CreatedAt":100}`))
+				}(),
+			},
+			expectedQuery: "SELECT Data FROM Application WHERE UpdatedAt <= ? AND CreatedAt <= ? AND NOT (UpdatedAt = ? AND CreatedAt = ? AND Id <= UUID_TO_BIN(?,true)) ORDER BY UpdatedAt DESC, CreatedAt DESC, Id ASC",
+			wantErr:       false,
+		},
+		{
 			name: "query with cursor: missing Id from ordering fields",
 			kind: "Project",
 			listOptions: datastore.ListOptions{


### PR DESCRIPTION
**What this PR does / why we need it**:

The previous implementation of MySQL pagination condition ( `UpdatedAt <= ? AND Id > UUID_TO_BIN(?,true)` ) leads to unexpected behavior: Instead of get `UpdatedAt <= ?` first then apply `Id > UUID_TO_BIN(?,true)` in the result set, MySQL makes intersection of 2 sets `UpdatedAt <= ?` and `Id > UUID_TO_BIN(?,true)`. This implementation resolve this issue by using an approximated variant.

ref: https://use-the-index-luke.com/sql/partial-results/fetch-next-page#sb-row-values

**Which issue(s) this PR fixes**:

Related to #1555 
Follow PR #1873 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
