### PR TITLE
Honor $HOME so that any user can write things in a unified way

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -129,10 +129,10 @@ load(
 
 container_pull(
     name = "piped-base",
-    digest = "sha256:41175b8a7cf8acf425808f6770cabcc43fef423a31b647957341ac2de4161a9e",
+    digest = "sha256:be303a0bc87480a26ee90c91288d47498e5742e90e7803cc4f2e11bfcbffb118",
     registry = "gcr.io",
     repository = "pipecd/piped-base",
-    tag = "0.2.1",
+    tag = "0.2.2",
 )
 
 container_pull(

--- a/docs/content/en/docs/operator-manual/piped/configuration-reference.md
+++ b/docs/content/en/docs/operator-manual/piped/configuration-reference.md
@@ -39,7 +39,7 @@ spec:
 |-|-|-|-|
 | username | string | The username that will be configured for `git` user. Default is `piped`. | No |
 | email | string | The email that will be configured for `git` user. Default is `pipecd.dev@gmail.com`. | No |
-| sshConfigFilePath | string | Where to write ssh config file. Default is `/etc/ssh/ssh_config`. | No |
+| sshConfigFilePath | string | Where to write ssh config file. Default is `$HOME/.ssh/config`. | No |
 | host | string | The host name. Default is `github.com`. | No |
 | hostName | string | The hostname or IP address of the remote git server. Default is the same value with Host. | No |
 | sshKeyFile | string | The path to the private ssh key file. This will be used to clone the source code of the specified git repositories. | No |

--- a/manifests/piped/values.yaml
+++ b/manifests/piped/values.yaml
@@ -81,6 +81,7 @@ secret:
 securityContext:
   runAsNonRoot: true
   runAsUser: 1000
+  runAsGroup: 1000
   fsGroup: 1000
 
 nodeSelector: {}

--- a/pkg/app/piped/cmd/piped/piped.go
+++ b/pkg/app/piped/cmd/piped/piped.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"os"
+	"path"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -73,9 +75,13 @@ type piped struct {
 }
 
 func NewCommand() *cobra.Command {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		panic(fmt.Sprintf("failed to detect the current user's home directory: %v", err))
+	}
 	p := &piped{
 		adminPort:   9085,
-		toolsDir:    "/tools",
+		toolsDir:    path.Join(home, ".piped", "tools"),
 		gracePeriod: 30 * time.Second,
 	}
 	cmd := &cobra.Command{

--- a/pkg/config/piped.go
+++ b/pkg/config/piped.go
@@ -172,7 +172,7 @@ type PipedGit struct {
 	// Default is "pipecd.dev@gmail.com".
 	Email string `json:"email"`
 	// Where to write ssh config file.
-	// Default is "/etc/ssh/ssh_config".
+	// Default is "$HOME/.ssh/config".
 	SSHConfigFilePath string `json:"sshConfigFilePath"`
 	// The host name.
 	// e.g. github.com, gitlab.com


### PR DESCRIPTION
**What this PR does / why we need it**:
We settled on putting all files to be touched by Piped into the home directory. The piped-base image is already changed to use them: https://github.com/pipe-cd/pipe/pull/1890

I know this PR includes a known issue. It can happen only if the Piped process was owned by a kind of user not in `/etc/passwd`. I just settled on putting this issue to https://github.com/pipe-cd/pipe/issues/1905. And I'd love to merge this PR for now because the latest version of piped doesn't work even if it's running by a user existing in `/ect/passwd`. We had better fix it as soon as possible.

**Which issue(s) this PR fixes**:

Fixes https://github.com/pipe-cd/pipe/issues/1885

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
