### PR TITLE
Remove redundant firestore indexes

### DIFF
--- a/pkg/app/ops/firestoreindexensurer/indexes.json
+++ b/pkg/app/ops/firestoreindexensurer/indexes.json
@@ -108,22 +108,6 @@
         "fieldPath": "UpdatedAt",
         "order": "DESCENDING",
         "arrayConfig": ""
-      }
-    ]
-  },
-  {
-    "collectionGroup": "Application",
-    "queryScope": "COLLECTION",
-    "fields": [
-      {
-        "fieldPath": "ProjectId",
-        "order": "ASCENDING",
-        "arrayConfig": ""
-      },
-      {
-        "fieldPath": "UpdatedAt",
-        "order": "DESCENDING",
-        "arrayConfig": ""
       },
       {
         "fieldPath": "Id",
@@ -154,22 +138,6 @@
     "fields": [
       {
         "fieldPath": "ApplicationId",
-        "order": "ASCENDING",
-        "arrayConfig": ""
-      },
-      {
-        "fieldPath": "UpdatedAt",
-        "order": "DESCENDING",
-        "arrayConfig": ""
-      }
-    ]
-  },
-  {
-    "collectionGroup": "Deployment",
-    "queryScope": "COLLECTION",
-    "fields": [
-      {
-        "fieldPath": "ProjectId",
         "order": "ASCENDING",
         "arrayConfig": ""
       },

--- a/pkg/app/ops/firestoreindexensurer/indexes_test.go
+++ b/pkg/app/ops/firestoreindexensurer/indexes_test.go
@@ -133,22 +133,6 @@ func TestParseIndexes(t *testing.T) {
 					Order:       "DESCENDING",
 					ArrayConfig: "",
 				},
-			},
-		},
-		{
-			CollectionGroup: "Application",
-			QueryScope:      "COLLECTION",
-			Fields: []field{
-				{
-					FieldPath:   "ProjectId",
-					Order:       "ASCENDING",
-					ArrayConfig: "",
-				},
-				{
-					FieldPath:   "UpdatedAt",
-					Order:       "DESCENDING",
-					ArrayConfig: "",
-				},
 				{
 					FieldPath:   "Id",
 					Order:       "ASCENDING",
@@ -178,22 +162,6 @@ func TestParseIndexes(t *testing.T) {
 			Fields: []field{
 				{
 					FieldPath:   "ApplicationId",
-					Order:       "ASCENDING",
-					ArrayConfig: "",
-				},
-				{
-					FieldPath:   "UpdatedAt",
-					Order:       "DESCENDING",
-					ArrayConfig: "",
-				},
-			},
-		},
-		{
-			CollectionGroup: "Deployment",
-			QueryScope:      "COLLECTION",
-			Fields: []field{
-				{
-					FieldPath:   "ProjectId",
 					Order:       "ASCENDING",
 					ArrayConfig: "",
 				},


### PR DESCRIPTION
**What this PR does / why we need it**:
Those indexes should be covered by the newly defined `ProjectId - UpdatedAt - Id` indexes.

**Which issue(s) this PR fixes**:

Follow PR #1906 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
