### PR TITLE
Ensure unchange the fields order of firestore indexes

### DIFF
--- a/pkg/app/ops/firestoreindexensurer/indexes.go
+++ b/pkg/app/ops/firestoreindexensurer/indexes.go
@@ -17,7 +17,6 @@ package firestoreindexensurer
 import (
 	"encoding/json"
 	"fmt"
-	"sort"
 	"strings"
 )
 
@@ -53,20 +52,11 @@ func (idx *index) validate() error {
 }
 
 // id builds a unique string based on its fields.
-func (idx *index) id() string {
+func (idx index) id() string {
 	var b strings.Builder
 	b.WriteString(fmt.Sprintf("%s/%s", idx.CollectionGroup, idx.QueryScope))
 
 	fields := idx.Fields
-	sort.Slice(fields, func(i, j int) bool {
-		if fields[i].FieldPath != fields[j].FieldPath {
-			return fields[i].FieldPath < fields[j].FieldPath
-		}
-		if fields[i].Order != fields[j].Order {
-			return fields[i].Order < fields[j].Order
-		}
-		return fields[i].ArrayConfig < fields[j].ArrayConfig
-	})
 	for _, f := range fields {
 		b.WriteString(fmt.Sprintf("/field-path:%s", f.FieldPath))
 		if f.Order != "" {

--- a/pkg/app/ops/firestoreindexensurer/indexes.go
+++ b/pkg/app/ops/firestoreindexensurer/indexes.go
@@ -52,7 +52,7 @@ func (idx *index) validate() error {
 }
 
 // id builds a unique string based on its fields.
-func (idx index) id() string {
+func (idx *index) id() string {
 	var b strings.Builder
 	b.WriteString(fmt.Sprintf("%s/%s", idx.CollectionGroup, idx.QueryScope))
 

--- a/pkg/app/ops/firestoreindexensurer/indexes_test.go
+++ b/pkg/app/ops/firestoreindexensurer/indexes_test.go
@@ -390,6 +390,57 @@ func TestFilterIndexes(t *testing.T) {
 			},
 			want: []index{},
 		},
+		{
+			name: "no exclude a composite index in case the fields order is changed",
+			indexes: []index{
+				{
+					CollectionGroup: "collection-group",
+					QueryScope:      "COLLECTION",
+					Fields: []field{
+						{
+							FieldPath: "field-path-1",
+							Order:     "ASCENDING",
+						},
+						{
+							FieldPath: "field-path-2",
+							Order:     "ASCENDING",
+						},
+					},
+				},
+			},
+			excludes: []index{
+				{
+					CollectionGroup: "collection-group",
+					QueryScope:      "COLLECTION",
+					Fields: []field{
+						{
+							FieldPath: "field-path-2",
+							Order:     "ASCENDING",
+						},
+						{
+							FieldPath: "field-path-1",
+							Order:     "ASCENDING",
+						},
+					},
+				},
+			},
+			want: []index{
+				{
+					CollectionGroup: "collection-group",
+					QueryScope:      "COLLECTION",
+					Fields: []field{
+						{
+							FieldPath: "field-path-1",
+							Order:     "ASCENDING",
+						},
+						{
+							FieldPath: "field-path-2",
+							Order:     "ASCENDING",
+						},
+					},
+				},
+			},
+		},
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -420,25 +471,7 @@ func TestIndexID(t *testing.T) {
 			want: "collection-group/COLLECTION/field-path:field-path/order:ASCENDING",
 		},
 		{
-			name: "two fields",
-			idx: index{
-				CollectionGroup: "collection-group",
-				QueryScope:      "COLLECTION",
-				Fields: []field{
-					{
-						FieldPath:   "field-path2",
-						ArrayConfig: "contains",
-					},
-					{
-						FieldPath: "field-path1",
-						Order:     "ASCENDING",
-					},
-				},
-			},
-			want: "collection-group/COLLECTION/field-path:field-path1/order:ASCENDING/field-path:field-path2/array-config:contains",
-		},
-		{
-			name: "ensure it's always sorted",
+			name: "ensure the fields order is not changed",
 			idx: index{
 				CollectionGroup: "collection-group",
 				QueryScope:      "COLLECTION",
@@ -457,7 +490,7 @@ func TestIndexID(t *testing.T) {
 					},
 				},
 			},
-			want: "collection-group/COLLECTION/field-path:field-path1/order:ASCENDING/field-path:field-path2/array-config:contains/field-path:field-path3/order:ASCENDING",
+			want: "collection-group/COLLECTION/field-path:field-path2/array-config:contains/field-path:field-path3/order:ASCENDING/field-path:field-path1/order:ASCENDING",
 		},
 	}
 	for _, tc := range testcases {


### PR DESCRIPTION
**What this PR does / why we need it**:

The fields' orders of Firestore indexes are different from the ones defined in the `indexes.json` file leads to an unexpected issue: making indexes which unable to be used by Firestore.

**Which issue(s) this PR fixes**:

Follow PR #1906 #1908 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
