### PR TITLE
Add required index for Event model

### DIFF
--- a/pkg/app/ops/firestoreindexensurer/indexes.json
+++ b/pkg/app/ops/firestoreindexensurer/indexes.json
@@ -260,6 +260,22 @@
         "fieldPath": "CreatedAt",
         "order": "ASCENDING",
         "arrayConfig": ""
+      }
+    ]
+  },
+  {
+    "collectionGroup": "Event",
+    "queryScope": "COLLECTION",
+    "fields": [
+      {
+        "fieldPath": "ProjectId",
+        "order": "ASCENDING",
+        "arrayConfig": ""
+      },
+      {
+        "fieldPath": "CreatedAt",
+        "order": "ASCENDING",
+        "arrayConfig": ""
       },
       {
         "fieldPath": "Id",

--- a/pkg/app/ops/firestoreindexensurer/indexes_test.go
+++ b/pkg/app/ops/firestoreindexensurer/indexes_test.go
@@ -285,6 +285,22 @@ func TestParseIndexes(t *testing.T) {
 					Order:       "ASCENDING",
 					ArrayConfig: "",
 				},
+			},
+		},
+		{
+			CollectionGroup: "Event",
+			QueryScope:      "COLLECTION",
+			Fields: []field{
+				{
+					FieldPath:   "ProjectId",
+					Order:       "ASCENDING",
+					ArrayConfig: "",
+				},
+				{
+					FieldPath:   "CreatedAt",
+					Order:       "ASCENDING",
+					ArrayConfig: "",
+				},
 				{
 					FieldPath:   "Id",
 					Order:       "ASCENDING",


### PR DESCRIPTION
**What this PR does / why we need it**:

Index `ProjectId: ASC CreatedAt:ASC` is required by the current piped agent query.

**Which issue(s) this PR fixes**:

Follow PR #1908 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
