### PR TITLE
Destructure array values passed to startAfter function

### DIFF
--- a/pkg/datastore/firestore/firestore.go
+++ b/pkg/datastore/firestore/firestore.go
@@ -112,7 +112,7 @@ func (s *FireStore) Find(ctx context.Context, kind string, opts datastore.ListOp
 		if err != nil {
 			return nil, err
 		}
-		q = q.StartAfter(values)
+		q = q.StartAfter(values...)
 	}
 
 	if opts.Limit > 0 {


### PR DESCRIPTION
**What this PR does / why we need it**:

Suspend `firestore: number of field values in StartAt/StartAfter/EndAt/EndBefore does not match number of OrderBy fields` error.

**Which issue(s) this PR fixes**:

Follow PR #1917

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
