### PR TITLE
Fix unable to disable entities in case of using MySQL store

### DIFF
--- a/pkg/datastore/mysql/ensurer/schema.sql
+++ b/pkg/datastore/mysql/ensurer/schema.sql
@@ -18,7 +18,7 @@ CREATE TABLE IF NOT EXISTS Application (
   Id BINARY(16) PRIMARY KEY,
   Data JSON NOT NULL,
   ProjectId VARCHAR(50) GENERATED ALWAYS AS (data->>"$.project_id") STORED NOT NULL,
-  Disabled BOOL GENERATED ALWAYS AS (IFNULL(data->>"$.disabled", False)) STORED NOT NULL, 
+  Disabled BOOL GENERATED ALWAYS AS (IF(data->>"$.disabled" = NULL, False, IF(data->>"$.disabled" = 'true', True, False))) STORED NOT NULL,
   Extra VARCHAR(100) GENERATED ALWAYS AS (data->>"$._extra") STORED,
   CreatedAt INT(11) GENERATED ALWAYS AS (data->>"$.created_at") STORED NOT NULL,
   UpdatedAt INT(11) GENERATED ALWAYS AS (data->>"$.updated_at") STORED NOT NULL
@@ -71,7 +71,7 @@ CREATE TABLE IF NOT EXISTS Piped (
   Id BINARY(16) PRIMARY KEY,
   Data JSON NOT NULL,
   ProjectId VARCHAR(50) GENERATED ALWAYS AS (data->>"$.project_id") STORED NOT NULL,
-  Disabled BOOL GENERATED ALWAYS AS (IFNULL(data->>"$.disabled", False)) STORED NOT NULL, 
+  Disabled BOOL GENERATED ALWAYS AS (IF(data->>"$.disabled" = NULL, False, IF(data->>"$.disabled" = 'true', True, False))) STORED NOT NULL,
   Extra VARCHAR(100) GENERATED ALWAYS AS (data->>"$._extra") STORED,
   CreatedAt INT(11) GENERATED ALWAYS AS (data->>"$.created_at") STORED NOT NULL,
   UpdatedAt INT(11) GENERATED ALWAYS AS (data->>"$.updated_at") STORED NOT NULL
@@ -85,7 +85,7 @@ CREATE TABLE IF NOT EXISTS APIKey (
   Id BINARY(16) PRIMARY KEY,
   Data JSON NOT NULL,
   ProjectId VARCHAR(50) GENERATED ALWAYS AS (data->>"$.project_id") STORED NOT NULL,
-  Disabled BOOL GENERATED ALWAYS AS (IFNULL(data->>"$.disabled", False)) STORED NOT NULL, 
+  Disabled BOOL GENERATED ALWAYS AS (IF(data->>"$.disabled" = NULL, False, IF(data->>"$.disabled" = 'true', True, False))) STORED NOT NULL,
   Extra VARCHAR(100) GENERATED ALWAYS AS (data->>"$._extra") STORED,
   CreatedAt INT(11) GENERATED ALWAYS AS (data->>"$.created_at") STORED NOT NULL,
   UpdatedAt INT(11) GENERATED ALWAYS AS (data->>"$.updated_at") STORED NOT NULL

--- a/pkg/datastore/mysql/ensurer/schema.sql
+++ b/pkg/datastore/mysql/ensurer/schema.sql
@@ -18,7 +18,7 @@ CREATE TABLE IF NOT EXISTS Application (
   Id BINARY(16) PRIMARY KEY,
   Data JSON NOT NULL,
   ProjectId VARCHAR(50) GENERATED ALWAYS AS (data->>"$.project_id") STORED NOT NULL,
-  Disabled BOOL GENERATED ALWAYS AS (IF(data->>"$.disabled" = NULL, False, IF(data->>"$.disabled" = 'true', True, False))) STORED NOT NULL,
+  Disabled BOOL GENERATED ALWAYS AS (IF(data->>"$.disabled" = 'true', True, False)) STORED NOT NULL,
   Extra VARCHAR(100) GENERATED ALWAYS AS (data->>"$._extra") STORED,
   CreatedAt INT(11) GENERATED ALWAYS AS (data->>"$.created_at") STORED NOT NULL,
   UpdatedAt INT(11) GENERATED ALWAYS AS (data->>"$.updated_at") STORED NOT NULL
@@ -71,7 +71,7 @@ CREATE TABLE IF NOT EXISTS Piped (
   Id BINARY(16) PRIMARY KEY,
   Data JSON NOT NULL,
   ProjectId VARCHAR(50) GENERATED ALWAYS AS (data->>"$.project_id") STORED NOT NULL,
-  Disabled BOOL GENERATED ALWAYS AS (IF(data->>"$.disabled" = NULL, False, IF(data->>"$.disabled" = 'true', True, False))) STORED NOT NULL,
+  Disabled BOOL GENERATED ALWAYS AS (IF(data->>"$.disabled" = 'true', True, False)) STORED NOT NULL,
   Extra VARCHAR(100) GENERATED ALWAYS AS (data->>"$._extra") STORED,
   CreatedAt INT(11) GENERATED ALWAYS AS (data->>"$.created_at") STORED NOT NULL,
   UpdatedAt INT(11) GENERATED ALWAYS AS (data->>"$.updated_at") STORED NOT NULL
@@ -85,7 +85,7 @@ CREATE TABLE IF NOT EXISTS APIKey (
   Id BINARY(16) PRIMARY KEY,
   Data JSON NOT NULL,
   ProjectId VARCHAR(50) GENERATED ALWAYS AS (data->>"$.project_id") STORED NOT NULL,
-  Disabled BOOL GENERATED ALWAYS AS (IF(data->>"$.disabled" = NULL, False, IF(data->>"$.disabled" = 'true', True, False))) STORED NOT NULL,
+  Disabled BOOL GENERATED ALWAYS AS (IF(data->>"$.disabled" = 'true', True, False)) STORED NOT NULL,
   Extra VARCHAR(100) GENERATED ALWAYS AS (data->>"$._extra") STORED,
   CreatedAt INT(11) GENERATED ALWAYS AS (data->>"$.created_at") STORED NOT NULL,
   UpdatedAt INT(11) GENERATED ALWAYS AS (data->>"$.updated_at") STORED NOT NULL


### PR DESCRIPTION
**What this PR does / why we need it**:

In case of access to JSON attribute of type boolean, MySQL datastore treats the value as a simple string value ('true' or 'false') which leads to `incorrect value type` error if we want to change the value of `Disable` column (of type boolean/tinyint(1)).

**Which issue(s) this PR fixes**:

Fixes #1895 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
