### PR TITLE
Add copy buttons for generated settings values

### DIFF
--- a/pkg/app/web/src/components/generated-api-key-dialog/index.tsx
+++ b/pkg/app/web/src/components/generated-api-key-dialog/index.tsx
@@ -1,17 +1,15 @@
-import { FC, useCallback, memo } from "react";
 import {
+  Button,
   Dialog,
   DialogActions,
-  DialogTitle,
   DialogContent,
+  DialogTitle,
   Typography,
-  Button,
 } from "@material-ui/core";
-import { addToast } from "../../modules/toasts";
+import { FC, memo, useCallback } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { AppState } from "../../modules";
 import { clearGeneratedKey } from "../../modules/api-keys";
-import { COPY_API_KEY } from "../../constants/toast-text";
 import { TextWithCopyButton } from "../text-with-copy-button";
 
 const DIALOG_TITLE = "Generated API Key";
@@ -24,10 +22,6 @@ export const GeneratedAPIKeyDialog: FC = memo(function GeneratedAPIKeyDialog() {
   );
   const open = Boolean(generatedKey);
 
-  const handleOnClickCopy = useCallback((): void => {
-    dispatch(addToast({ message: COPY_API_KEY }));
-  }, [dispatch]);
-
   const handleClose = useCallback(() => {
     dispatch(clearGeneratedKey());
   }, [dispatch]);
@@ -39,9 +33,9 @@ export const GeneratedAPIKeyDialog: FC = memo(function GeneratedAPIKeyDialog() {
         <Typography variant="caption">{VALUE_CAPTION}</Typography>
         {generatedKey ? (
           <TextWithCopyButton
+            name="API Key"
             label="Copy API Key"
             value={generatedKey}
-            onCopy={handleOnClickCopy}
           />
         ) : null}
       </DialogContent>

--- a/pkg/app/web/src/components/sealed-secret-dialog/index.tsx
+++ b/pkg/app/web/src/components/sealed-secret-dialog/index.tsx
@@ -21,7 +21,6 @@ import {
   clearSealedSecret,
   generateSealedSecret,
 } from "../../modules/sealed-secret";
-import { addToast } from "../../modules/toasts";
 import { AppDispatch } from "../../store";
 import { TextWithCopyButton } from "../text-with-copy-button";
 
@@ -101,10 +100,6 @@ export const SealedSecretDialog: FC<SealedSecretDialogProps> = memo(
       dispatch(clearSealedSecret());
     }, [dispatch, onClose]);
 
-    const handleOnClickCopy = useCallback(() => {
-      dispatch(addToast({ message: "Secret copied to clipboard" }));
-    }, [dispatch]);
-
     if (!application) {
       return null;
     }
@@ -119,9 +114,9 @@ export const SealedSecretDialog: FC<SealedSecretDialogProps> = memo(
                 Encrypted secret data
               </Typography>
               <TextWithCopyButton
+                name="Encrypted secret"
                 label="Copy secret"
                 value={sealedSecret}
-                onCopy={handleOnClickCopy}
               />
             </DialogContent>
             <DialogActions>

--- a/pkg/app/web/src/components/text-with-copy-button/index.stories.tsx
+++ b/pkg/app/web/src/components/text-with-copy-button/index.stories.tsx
@@ -1,16 +1,16 @@
-import { action } from "@storybook/addon-actions";
-import * as React from "react";
-import { TextWithCopyButton } from "./";
+import { Story } from "@storybook/react/types-6-0";
+import { createDecoratorRedux } from "../../../.storybook/redux-decorator";
+import { TextWithCopyButton, TextWithCopyButtonProps } from "./";
 
 export default {
   title: "TextWithCopyButton",
   component: TextWithCopyButton,
+  decorators: [createDecoratorRedux({})],
 };
 
-export const overview: React.FC = () => (
-  <TextWithCopyButton
-    value="hello"
-    onCopy={action("onCopy")}
-    label="Copy text"
-  />
+const Template: Story<TextWithCopyButtonProps> = (args) => (
+  <TextWithCopyButton {...args} />
 );
+
+export const Overview = Template.bind({});
+Overview.args = { name: "Value", label: "Copy value", value: "value" };

--- a/pkg/app/web/src/components/text-with-copy-button/index.tsx
+++ b/pkg/app/web/src/components/text-with-copy-button/index.tsx
@@ -1,46 +1,59 @@
-import { FC, useCallback } from "react";
-import { Box, IconButton, makeStyles } from "@material-ui/core";
+import { FC, memo, useCallback } from "react";
+import { IconButton, makeStyles } from "@material-ui/core";
 import CopyIcon from "@material-ui/icons/FileCopyOutlined";
 import copy from "copy-to-clipboard";
+import { useDispatch } from "react-redux";
+import { addToast } from "../../modules/toasts";
 
 const useStyles = makeStyles((theme) => ({
-  root: { backgroundColor: theme.palette.background.paper },
-  input: { border: "none", fontSize: 14, flex: 1, textOverflow: "ellipsis" },
+  root: {
+    display: "flex",
+    height: 64,
+    backgroundColor: theme.palette.background.paper,
+    marginTop: theme.spacing(1),
+    marginBottom: theme.spacing(0.5),
+    borderRadius: theme.shape.borderRadius,
+    borderWidth: 1,
+    borderStyle: "solid",
+  },
+  input: {
+    border: "none",
+    fontSize: 16,
+    flex: 1,
+    textOverflow: "ellipsis",
+    paddingLeft: theme.spacing(1),
+  },
 }));
 
 export interface TextWithCopyButtonProps {
+  name: string;
   label: string;
   value: string;
-  onCopy: () => void;
 }
 
-export const TextWithCopyButton: FC<TextWithCopyButtonProps> = ({
-  label,
-  value,
-  onCopy,
-}) => {
-  const classes = useStyles();
-  const handleCopy = useCallback(() => {
-    copy(value);
-    onCopy();
-  }, [value, onCopy]);
-  return (
-    <Box
-      display="flex"
-      p={1}
-      border={1}
-      borderColor="divider"
-      className={classes.root}
-    >
-      <input readOnly value={value} className={classes.input} />
-      <IconButton
-        size="small"
-        style={{ marginLeft: 8 }}
-        aria-label={label}
-        onClick={handleCopy}
-      >
-        <CopyIcon style={{ fontSize: 20 }} />
-      </IconButton>
-    </Box>
-  );
-};
+export const TextWithCopyButton: FC<TextWithCopyButtonProps> = memo(
+  function TextWithCopyButton({ name, label, value }) {
+    const classes = useStyles();
+    const dispatch = useDispatch();
+    const handleCopy = useCallback(() => {
+      copy(value);
+      dispatch(addToast({ message: `${name} copied to clipboard.` }));
+    }, [value, name, dispatch]);
+    return (
+      <fieldset className={classes.root}>
+        <input readOnly value={value} className={classes.input} />
+        <legend>{name}</legend>
+        <div>
+          <IconButton
+            size="small"
+            style={{ marginLeft: 8 }}
+            aria-label={label}
+            onClick={handleCopy}
+          >
+            <CopyIcon style={{ fontSize: 20 }} />
+          </IconButton>
+        </div>
+      </fieldset>
+    );
+  }
+);

--- a/pkg/app/web/src/components/toasts/index.tsx
+++ b/pkg/app/web/src/components/toasts/index.tsx
@@ -1,6 +1,6 @@
-import { Button, Snackbar } from "@material-ui/core";
+import { Button, Snackbar, SnackbarCloseReason } from "@material-ui/core";
 import MuiAlert from "@material-ui/lab/Alert";
-import { FC } from "react";
+import { FC, memo, SyntheticEvent } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { Link as RouterLink } from "react-router-dom";
 import { AppState } from "../../modules";
@@ -8,7 +8,7 @@ import { IToast, removeToast, selectAll } from "../../modules/toasts";
 
 const AUTO_HIDE_DURATION = 5000;
 
-export const Toasts: FC = () => {
+export const Toasts: FC = memo(function Toasts() {
   const dispatch = useDispatch();
   const toasts = useSelector<AppState, IToast[]>((state) =>
     selectAll(state.toasts)
@@ -17,7 +17,13 @@ export const Toasts: FC = () => {
   return (
     <>
       {toasts.map((item) => {
-        const handleClose = (): void => {
+        const handleClose = (
+          _: SyntheticEvent<unknown, Event>,
+          reason?: SnackbarCloseReason
+        ): void => {
+          if (reason === "clickaway") {
+            return;
+          }
           dispatch(removeToast({ id: item.id }));
         };
         return (
@@ -59,4 +65,4 @@ export const Toasts: FC = () => {
       })}
     </>
   );
-};
+});

--- a/pkg/app/web/src/constants/toast-text.ts
+++ b/pkg/app/web/src/constants/toast-text.ts
@@ -6,7 +6,6 @@ export const UPDATE_SSO_SUCCESS = "Successfully updated SSO configurations.";
 // API Key
 export const GENERATE_API_KEY_SUCCESS = "Successfully generated API Key.";
 export const DISABLE_API_KEY_SUCCESS = "Successfully disabled API Key.";
-export const COPY_API_KEY = "API Key copied to clipboard.";
 
 // Piped
 export const ADD_PIPED_SUCCESS = "Successfully added Piped.";

--- a/pkg/app/web/src/mocks/services/piped.ts
+++ b/pkg/app/web/src/mocks/services/piped.ts
@@ -2,12 +2,13 @@ import {
   GenerateApplicationSealedSecretResponse,
   ListPipedsResponse,
   RecreatePipedKeyResponse,
+  RegisterPipedResponse,
 } from "pipe/pkg/app/web/api_client/service_pb";
 import {
   createPipedFromObject,
   dummyPiped,
 } from "../../__fixtures__/dummy-piped";
-import { randomKeyHash } from "../../__fixtures__/utils";
+import { randomKeyHash, randomUUID } from "../../__fixtures__/utils";
 import { createHandler } from "../create-handler";
 
 export const generateApplicationSealedSecretHandler = createHandler<
@@ -19,6 +20,12 @@ export const generateApplicationSealedSecretHandler = createHandler<
 });
 
 export const pipedHandlers = [
+  createHandler<RegisterPipedResponse>("/RegisterPiped", () => {
+    const response = new RegisterPipedResponse();
+    response.setId(randomUUID());
+    response.setKey(randomKeyHash());
+    return response;
+  }),
   createHandler<RecreatePipedKeyResponse>("/RecreatePipedKey", () => {
     const response = new RecreatePipedKeyResponse();
     response.setKey(randomKeyHash());

--- a/pkg/app/web/src/pages/settings/piped/index.tsx
+++ b/pkg/app/web/src/pages/settings/piped/index.tsx
@@ -13,7 +13,6 @@ import {
   TableContainer,
   TableHead,
   TableRow,
-  TextField,
   Toolbar,
 } from "@material-ui/core";
 import {
@@ -27,6 +26,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { AddPipedDrawer } from "../../../components/add-piped-drawer";
 import { EditPipedDrawer } from "../../../components/edit-piped-drawer";
 import { FilterValues, PipedFilter } from "../../../components/piped-filter";
+import { TextWithCopyButton } from "../../../components/text-with-copy-button";
 import {
   UI_TEXT_ADD,
   UI_TEXT_CLOSE,
@@ -189,22 +189,18 @@ export const SettingsPipedPage: FC = memo(function SettingsPipedPage() {
       <AddPipedDrawer open={isOpenForm} onClose={handleClose} />
       <EditPipedDrawer pipedId={editPipedId} onClose={handleEditClose} />
 
-      <Dialog open={Boolean(registeredPiped)}>
+      <Dialog fullWidth open={Boolean(registeredPiped)}>
         <DialogTitle>Piped registered</DialogTitle>
         <DialogContent>
-          <TextField
-            label="id"
-            variant="outlined"
+          <TextWithCopyButton
+            name="Piped Id"
+            label="Copy piped id"
             value={registeredPiped?.id || ""}
-            fullWidth
-            margin="dense"
           />
-          <TextField
-            label="secret key"
-            variant="outlined"
+          <TextWithCopyButton
+            name="Secret Key"
+            label="Copy secret key"
             value={registeredPiped?.key || ""}
-            fullWidth
-            margin="dense"
           />
           <Box display="flex" justifyContent="flex-end" m={1} mt={2}>
             <Button color="primary" onClick={handleClosePipedInfo}>


### PR DESCRIPTION
**What this PR does / why we need it**:

![image](https://user-images.githubusercontent.com/6136383/116070907-1fac7d00-a6c8-11eb-820d-720ee9ac58ff.png)

- Also fixes a copy button bug
  - It is not show the toast after clicked the copy button.

**Which issue(s) this PR fixes**:

Refs #1894 

This issue is also a request to add a copy button to the table field, so we'll leave it open.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Add copy buttons for the generated piped id/password
```
