### PR TITLE
Empower Piped to add login user to /etc/passwd

### DIFF
--- a/dockers/piped-base/DOCKER_BUILD
+++ b/dockers/piped-base/DOCKER_BUILD
@@ -1,2 +1,2 @@
-version: 0.2.2
+version: 0.2.3
 registry: gcr.io/pipecd/piped-base

--- a/dockers/piped-base/Dockerfile
+++ b/dockers/piped-base/Dockerfile
@@ -13,6 +13,7 @@ COPY install-helm.sh /installer/install-helm.sh
 COPY install-kubectl.sh /installer/install-kubectl.sh
 COPY install-kustomize.sh /installer/install-kustomize.sh
 COPY install-terraform.sh /installer/install-terraform.sh
+COPY install-nss-wrapper.sh /installer/install-nss-wrapper.sh
 
 RUN \
     addgroup -S -g $PIPED_GID $PIPED_USER_GROUP && \
@@ -22,7 +23,17 @@ RUN \
         git \
         openssh \
         curl \
-        bash && \
+        bash \
+        gcc \
+        #musl-dev \
+        libc-dev \
+        make \
+        cmake && \
+
+    wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub && \
+    wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.33-r0/glibc-2.33-r0.apk && \
+    apk add glibc-2.33-r0.apk && \
+
     update-ca-certificates && \
     mkdir -p ${PIPED_TOOLS_DIR} && \
     # Pre-install the default version of helm.
@@ -33,6 +44,9 @@ RUN \
     /installer/install-kustomize.sh && \
     # Pre-install the default version of terraform.
     /installer/install-terraform.sh && \
+    # Install nss_wrapper to add an random UID to "passwd" without having to directly modify /etc/passwd.
+    # This is for those whose Piped's user isn't in /etc/passwd
+    /installer/install-nss-wrapper.sh && \
     # Delete installer directory.
     rm -rf /installer && \
     rm -f /var/cache/apk/* && \

--- a/dockers/piped-base/install-nss-wrapper.sh
+++ b/dockers/piped-base/install-nss-wrapper.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 The PipeCD Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+BASE_URL="https://ftp.samba.org/pub/cwrap/nss_wrapper"
+VERSION="1.1.11"
+
+echo "Installing nss_wrapper-${VERSION} into ${PIPED_TOOLS_DIR}/nss_wrapper..."
+curl -L ${BASE_URL}-${VERSION}.tar.gz | tar xvz
+
+cd nss_wrapper-${VERSION}
+mkdir build
+cd build
+cmake -D CMAKE_INSTALL_PREFIX=/usr/local -D CMAKE_BUILD_TYPE=Release ..
+#make
+make install
+chmod +x ${PIPED_TOOLS_DIR}/nss_wrapper
+echo "Successfully installed nss_wrapper-${VERSION} into ${PIPED_TOOLS_DIR}/nss_wrapper"

--- a/manifests/piped/templates/deployment.yaml
+++ b/manifests/piped/templates/deployment.yaml
@@ -32,6 +32,7 @@ spec:
           - --enable-default-kubernetes-cloud-provider={{ .Values.args.enableDefaultKubernetesCloudProvider }}
           - --insecure={{ .Values.args.insecure }}
           - --log-encoding={{ .Values.args.logEncoding }}
+          - --add-login-user-to-passwd={{ .Values.args.addLoginUserToPasswd }}
           ports:
             - name: admin
               containerPort: 9085

--- a/manifests/piped/values.yaml
+++ b/manifests/piped/values.yaml
@@ -7,6 +7,7 @@ args:
   enableDefaultKubernetesCloudProvider: true
   insecure: false
   logEncoding: humanize
+  addLoginUserToPasswd: false
 
 service:
   enabled: true


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes https://github.com/pipe-cd/pipe/issues/1905

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Add the `--add-login-user-to-passwd` flag to add login user to /etc/passwd when starting Piped
```
