### PR TITLE
Fix unable to delete Application in case of using MySQL datastore

### DIFF
--- a/pkg/datastore/mysql/ensurer/indexes.sql
+++ b/pkg/datastore/mysql/ensurer/indexes.sql
@@ -15,7 +15,7 @@ CREATE INDEX application_name_updated_at_desc ON Application (Name, UpdatedAt DE
 
 -- index on `Deleted` and `CreatedAt` ASC
 -- TODO: Reconsider make this Deleted column as STORED GENERATED COLUMN
-ALTER TABLE Application ADD COLUMN Deleted BOOL GENERATED ALWAYS AS (IFNULL(data->>"$.deleted", False)) VIRTUAL NOT NULL;
+ALTER TABLE Application ADD COLUMN Deleted BOOL GENERATED ALWAYS AS (IF(data->>"$.deleted" = 'true', True, False)) VIRTUAL NOT NULL;
 CREATE INDEX application_deleted_created_at_asc ON Application (Deleted, CreatedAt);
 
 -- index on `Kind` ASC and `UpdatedAt` DESC


### PR DESCRIPTION
**What this PR does / why we need it**:

Same error as issue #1895 but for `Deleted` column of Application table.

**Which issue(s) this PR fixes**:

Related PR #1920

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
