### PR TITLE
Stop publishing images with tagged by commit ID

### DIFF
--- a/cmd/image.bzl
+++ b/cmd/image.bzl
@@ -9,6 +9,5 @@ def all_images():
 
     for cmd, repo in cmds.items():
         images["$(DOCKER_REGISTRY)/%s:{STABLE_VERSION}" % repo] = "//cmd/%s:image" % cmd
-        images["$(DOCKER_REGISTRY)/%s:{STABLE_GIT_COMMIT}" % repo] = "//cmd/%s:image" % cmd
 
     return images


### PR DESCRIPTION
**What this PR does / why we need it**:

From the beginning, we started publishing both images tagged by semantic version and commit ID.
But, currently, we are only using the ones tagged by the semantic version.
So this PR stops tagging by Git commit ID.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
