### PR TITLE
Make it possible to delete piped keys from the web

### DIFF
--- a/pkg/app/web/src/__fixtures__/dummy-piped.ts
+++ b/pkg/app/web/src/__fixtures__/dummy-piped.ts
@@ -1,4 +1,4 @@
-import { Piped } from "../modules/pipeds";
+import { Piped, PipedKey } from "../modules/pipeds";
 import { dummyEnv } from "./dummy-environment";
 import { createApplicationGitRepository, dummyRepo } from "./dummy-repo";
 import { createRandTimes, randomText, randomUUID } from "./utils";
@@ -29,7 +29,10 @@ export const dummyPiped: Piped.AsObject = {
   version: "v0.1",
   status: Piped.ConnectionStatus.ONLINE,
   keyHash: "12345",
-  keysList: [],
+  keysList: [
+    { hash: "key-1", creator: "user", createdAt: createdAt.unix() },
+    { hash: "key-2", creator: "user", createdAt: createdAt.unix() },
+  ],
   envIdsList: [dummyEnv.id],
   sealedSecretEncryption: {
     encryptServiceAccount: "",
@@ -45,6 +48,14 @@ function createCloudProviderFromObject(
   cp.setName(o.name);
   cp.setType(o.type);
   return cp;
+}
+
+function createPipedKeyFromObject(o: PipedKey.AsObject): PipedKey {
+  const key = new PipedKey();
+  key.setHash(o.hash);
+  key.setCreator(o.creator);
+  key.setCreatedAt(o.createdAt);
+  return key;
 }
 
 export function createPipedFromObject(o: Piped.AsObject): Piped {
@@ -65,5 +76,6 @@ export function createPipedFromObject(o: Piped.AsObject): Piped {
   piped.setCloudProvidersList(
     o.cloudProvidersList.map(createCloudProviderFromObject)
   );
+  piped.setKeysList(o.keysList.map(createPipedKeyFromObject));
   return piped;
 }

--- a/pkg/app/web/src/api/piped.ts
+++ b/pkg/app/web/src/api/piped.ts
@@ -14,6 +14,8 @@ import {
   GenerateApplicationSealedSecretResponse,
   UpdatePipedRequest,
   UpdatePipedResponse,
+  DeleteOldPipedKeysRequest,
+  DeleteOldPipedKeysResponse,
 } from "pipe/pkg/app/web/api_client/service_pb";
 
 export const getPipeds = ({
@@ -60,6 +62,16 @@ export const recreatePipedKey = ({
   const req = new RecreatePipedKeyRequest();
   req.setId(id);
   return apiRequest(req, apiClient.recreatePipedKey);
+};
+
+export const deleteOldPipedKey = ({
+  pipedId,
+}: DeleteOldPipedKeysRequest.AsObject): Promise<
+  DeleteOldPipedKeysResponse.AsObject
+> => {
+  const req = new DeleteOldPipedKeysRequest();
+  req.setPipedId(pipedId);
+  return apiRequest(req, apiClient.deleteOldPipedKeys);
 };
 
 export const generateApplicationSealedSecret = ({

--- a/pkg/app/web/src/constants/toast-text.ts
+++ b/pkg/app/web/src/constants/toast-text.ts
@@ -11,6 +11,8 @@ export const DISABLE_API_KEY_SUCCESS = "Successfully disabled API Key.";
 export const ADD_PIPED_SUCCESS = "Successfully added Piped.";
 export const UPDATE_PIPED_SUCCESS = "Successfully updated Piped.";
 export const COPY_PIPED_ID = "Piped ID copied to clipboard.";
+export const DELETE_OLD_PIPED_KEY_SUCCESS =
+  "Successfully deleted old Piped key.";
 
 // Application
 export const DELETE_APPLICATION_SUCCESS = "Successfully deleted Application.";

--- a/pkg/app/web/src/constants/ui-text.ts
+++ b/pkg/app/web/src/constants/ui-text.ts
@@ -5,7 +5,6 @@ export const UI_TEXT_EDIT = "Edit";
 export const UI_TEXT_DISCARD = "Discard";
 export const UI_TEXT_DISABLE = "Disable";
 export const UI_TEXT_ENABLE = "Enable";
-export const UI_TEXT_RECREATE_KEY = "Recreate Key";
 export const UI_TEXT_REFRESH = "REFRESH";
 export const UI_TEXT_CLOSE = "Close";
 export const UI_TEXT_DELETE = "Delete";
@@ -14,3 +13,6 @@ export const UI_TEXT_FILTERED = "FILTERED";
 export const UI_TEXT_HIDE_FILTER = "HIDE FILTER";
 export const UI_TEXT_CLEAR = "CLEAR";
 export const UI_TEXT_NOT_AVAILABLE_TEXT = "N/A";
+// piped
+export const UI_TEXT_ADD_NEW_KEY = "Add new Key";
+export const UI_TEXT_DELETE_OLD_KEY = "Delete old Key";

--- a/pkg/app/web/src/mocks/services/piped.ts
+++ b/pkg/app/web/src/mocks/services/piped.ts
@@ -3,6 +3,7 @@ import {
   ListPipedsResponse,
   RecreatePipedKeyResponse,
   RegisterPipedResponse,
+  DeleteOldPipedKeysResponse,
 } from "pipe/pkg/app/web/api_client/service_pb";
 import {
   createPipedFromObject,
@@ -29,6 +30,10 @@ export const pipedHandlers = [
   createHandler<RecreatePipedKeyResponse>("/RecreatePipedKey", () => {
     const response = new RecreatePipedKeyResponse();
     response.setKey(randomKeyHash());
+    return response;
+  }),
+  createHandler<DeleteOldPipedKeysResponse>("/DeleteOldPipedKeys", () => {
+    const response = new DeleteOldPipedKeysResponse();
     return response;
   }),
   generateApplicationSealedSecretHandler,

--- a/pkg/app/web/src/modules/pipeds.test.ts
+++ b/pkg/app/web/src/modules/pipeds.test.ts
@@ -4,7 +4,7 @@ import {
   clearRegisteredPipedInfo,
   addPiped,
   fetchPipeds,
-  recreatePipedKey,
+  addNewPipedKey,
   selectPipedsByEnv,
   Piped,
   editPiped,
@@ -55,6 +55,7 @@ describe("pipedsSlice reducer", () => {
           registeredPiped: {
             id: "piped-1",
             key: "piped-key",
+            isNewKey: false,
           },
         },
         {
@@ -72,6 +73,7 @@ describe("pipedsSlice reducer", () => {
           payload: {
             id: "piped-1",
             key: "piped-key",
+            isNewKey: false,
           },
         })
       ).toEqual({
@@ -79,6 +81,7 @@ describe("pipedsSlice reducer", () => {
         registeredPiped: {
           id: "piped-1",
           key: "piped-key",
+          isNewKey: false,
         },
       });
     });
@@ -100,11 +103,11 @@ describe("pipedsSlice reducer", () => {
   });
 
   describe("recreatePipedKey", () => {
-    it(`should handle ${recreatePipedKey.fulfilled.type}`, () => {
+    it(`should handle ${addNewPipedKey.fulfilled.type}`, () => {
       expect(
         pipedsSlice.reducer(baseState, {
-          type: recreatePipedKey.fulfilled.type,
-          payload: "recreated-piped-key",
+          type: addNewPipedKey.fulfilled.type,
+          payload: "add-new-piped-key",
           meta: {
             arg: {
               pipedId: "piped-1",
@@ -115,7 +118,8 @@ describe("pipedsSlice reducer", () => {
         ...baseState,
         registeredPiped: {
           id: "piped-1",
-          key: "recreated-piped-key",
+          key: "add-new-piped-key",
+          isNewKey: true,
         },
       });
     });

--- a/pkg/app/web/src/pages/settings/piped/index.tsx
+++ b/pkg/app/web/src/pages/settings/piped/index.tsx
@@ -20,6 +20,7 @@ import {
   Close as CloseIcon,
   FilterList as FilterIcon,
 } from "@material-ui/icons";
+import Alert from "@material-ui/lab/Alert";
 import { createSelector } from "@reduxjs/toolkit";
 import { FC, memo, useCallback, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
@@ -40,7 +41,6 @@ import {
   enablePiped,
   fetchPipeds,
   Piped,
-  recreatePipedKey,
   RegisteredPiped,
   selectAllPipeds,
 } from "../../../modules/pipeds";
@@ -74,6 +74,9 @@ const selectFilteredPipeds = createSelector<
   }
 );
 
+const OLD_KEY_ALERT_MESSAGE =
+  "The old key is still there.\nTo add a new key, you need to delete the old one first.";
+
 export const SettingsPipedPage: FC = memo(function SettingsPipedPage() {
   const classes = useStyles();
   const [openFilter, setOpenFilter] = useState(false);
@@ -104,13 +107,6 @@ export const SettingsPipedPage: FC = memo(function SettingsPipedPage() {
       dispatch(enablePiped({ pipedId: id })).then(() => {
         dispatch(fetchPipeds(true));
       });
-    },
-    [dispatch]
-  );
-
-  const handleRecreate = useCallback(
-    (id: string) => {
-      dispatch(recreatePipedKey({ pipedId: id }));
     },
     [dispatch]
   );
@@ -172,7 +168,6 @@ export const SettingsPipedPage: FC = memo(function SettingsPipedPage() {
                   key={piped.id}
                   pipedId={piped.id}
                   onEdit={handleEdit}
-                  onRecreateKey={handleRecreate}
                   onDisable={handleDisable}
                   onEnable={handleEnable}
                 />
@@ -190,7 +185,14 @@ export const SettingsPipedPage: FC = memo(function SettingsPipedPage() {
       <EditPipedDrawer pipedId={editPipedId} onClose={handleEditClose} />
 
       <Dialog fullWidth open={Boolean(registeredPiped)}>
-        <DialogTitle>Piped registered</DialogTitle>
+        <DialogTitle>
+          {registeredPiped?.isNewKey
+            ? "Added a new piped key"
+            : "Piped registered"}
+        </DialogTitle>
+        {registeredPiped?.isNewKey ? (
+          <Alert severity="info">{OLD_KEY_ALERT_MESSAGE}</Alert>
+        ) : null}
         <DialogContent>
           <TextWithCopyButton
             name="Piped Id"

--- a/pkg/app/web/src/pages/settings/piped/index.tsx
+++ b/pkg/app/web/src/pages/settings/piped/index.tsx
@@ -75,7 +75,7 @@ const selectFilteredPipeds = createSelector<
 );
 
 const OLD_KEY_ALERT_MESSAGE =
-  "The old key is still there.\nTo add a new key, you need to delete the old one first.";
+  "The old key is still there.\nDo not forget to delete it once you update your Piped to use this new key.";
 
 export const SettingsPipedPage: FC = memo(function SettingsPipedPage() {
   const classes = useStyles();
@@ -200,8 +200,8 @@ export const SettingsPipedPage: FC = memo(function SettingsPipedPage() {
             value={registeredPiped?.id || ""}
           />
           <TextWithCopyButton
-            name="Secret Key"
-            label="Copy secret key"
+            name="Piped Key"
+            label="Copy piped key"
             value={registeredPiped?.key || ""}
           />
           <Box display="flex" justifyContent="flex-end" m={1} mt={2}>

--- a/pkg/app/web/src/pages/settings/piped/piped-table-row.tsx
+++ b/pkg/app/web/src/pages/settings/piped/piped-table-row.tsx
@@ -224,7 +224,7 @@ export const PipedTableRow: FC<Props> = memo(function PipedTableRow({
       </Menu>
 
       <Dialog open={openOldKeyAlert} onClose={handleAlertClose}>
-        <DialogTitle>An old key exists</DialogTitle>
+        <DialogTitle>There are already 2 keys for this piped</DialogTitle>
         <DialogContent>
           <DialogContentText>
             Before adding a new key, you need to delete the old one. <br />


### PR DESCRIPTION
**What this PR does / why we need it**:

*Add delete menu item to the piped menu*
![image](https://user-images.githubusercontent.com/6136383/117934704-e6b60e80-b33d-11eb-95d6-5d54dd62e1ec.png)

*Disable the menu item if old key is not exists.*
![image](https://user-images.githubusercontent.com/6136383/117934724-eb7ac280-b33d-11eb-8508-7495db5474df.png)


*Show alert if click add new key when an old key exists*
![image](https://user-images.githubusercontent.com/6136383/117934414-a22a7300-b33d-11eb-826b-8121327fe7d2.png)


*Show information after added a new key*
<img width="609" alt="Screen Shot 2021-05-12 at 16 13 14" src="https://user-images.githubusercontent.com/6136383/117934294-7c04d300-b33d-11eb-83aa-567c84dc7809.png">


**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Make it possible to delete piped keys from the web
```
