### PR TITLE
Add a button to copy the environment id

### DIFF
--- a/pkg/app/web/src/components/copy-icon-button/index.stories.tsx
+++ b/pkg/app/web/src/components/copy-icon-button/index.stories.tsx
@@ -1,0 +1,19 @@
+import { CopyIconButton, CopyIconButtonProps } from "./";
+import { Story } from "@storybook/react/types-6-0";
+import { createDecoratorRedux } from "../../../.storybook/redux-decorator";
+
+export default {
+  title: "COMMON/CopyIconButton",
+  component: CopyIconButton,
+  decorators: [createDecoratorRedux({})],
+};
+
+const Template: Story<CopyIconButtonProps> = (args) => (
+  <CopyIconButton {...args} />
+);
+
+export const Overview = Template.bind({});
+Overview.args = {
+  name: "ID",
+  value: "id",
+};

--- a/pkg/app/web/src/components/copy-icon-button/index.tsx
+++ b/pkg/app/web/src/components/copy-icon-button/index.tsx
@@ -1,0 +1,34 @@
+import { IconButton } from "@material-ui/core";
+import copy from "copy-to-clipboard";
+import { FileCopyOutlined as CopyIcon } from "@material-ui/icons";
+import { FC, useCallback, memo } from "react";
+import { useDispatch } from "react-redux";
+import { addToast } from "../../modules/toasts";
+
+export interface CopyIconButtonProps {
+  name: string;
+  value: string;
+  size?: "small" | "medium";
+  className?: string;
+}
+
+export const CopyIconButton: FC<CopyIconButtonProps> = memo(
+  function CopyIconButton({ name, value, className, size }) {
+    const dispatch = useDispatch();
+    const handleCopy = useCallback(() => {
+      copy(value);
+      dispatch(addToast({ message: `${name} copied to clipboard.` }));
+    }, [dispatch, value, name]);
+
+    return (
+      <IconButton
+        className={className}
+        aria-label={`Copy ${name}`}
+        onClick={handleCopy}
+        size={size}
+      >
+        <CopyIcon fontSize={size === "small" ? "small" : "default"} />
+      </IconButton>
+    );
+  }
+);

--- a/pkg/app/web/src/components/deployment-config-form/index.tsx
+++ b/pkg/app/web/src/components/deployment-config-form/index.tsx
@@ -2,18 +2,14 @@ import {
   Box,
   Button,
   Divider,
-  IconButton,
   Link,
   makeStyles,
   MenuItem,
   TextField,
   Typography,
 } from "@material-ui/core";
-import CopyIcon from "@material-ui/icons/FileCopyOutlined";
 import OpenInNewIcon from "@material-ui/icons/OpenInNew";
-import copy from "copy-to-clipboard";
-import { FC, useEffect, useState, memo } from "react";
-import * as React from "react";
+import { FC, memo, useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { AppState } from "../../modules";
 import {
@@ -21,7 +17,7 @@ import {
   fetchTemplateList,
   selectTemplatesByAppId,
 } from "../../modules/deployment-configs";
-import { addToast } from "../../modules/toasts";
+import { CopyIconButton } from "../copy-icon-button";
 
 const useStyles = makeStyles((theme) => ({
   title: {
@@ -63,11 +59,6 @@ export const DeploymentConfigForm: FC<DeploymentConfigFormProps> = memo(
     >((state) => selectTemplatesByAppId(state.deploymentConfigs) || []);
 
     const template = templates[templateIndex];
-
-    const handleOnClickCopy = (): void => {
-      copy(configValue);
-      dispatch(addToast({ message: "Deployment config copied to clipboard" }));
-    };
 
     const handleTemplateChange = (
       e: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>
@@ -123,13 +114,11 @@ export const DeploymentConfigForm: FC<DeploymentConfigFormProps> = memo(
             <Typography variant="subtitle1" className={classes.filename}>
               {TEXT.CONFIGURATION_FILENAME}
             </Typography>
-            <IconButton
+            <CopyIconButton
+              name="Deployment config"
               size="small"
-              aria-label="Copy deployment config"
-              onClick={handleOnClickCopy}
-            >
-              <CopyIcon fontSize="small" />
-            </IconButton>
+              value={configValue}
+            />
           </Box>
           <TextField
             multiline

--- a/pkg/app/web/src/components/environment-list-item/index.tsx
+++ b/pkg/app/web/src/components/environment-list-item/index.tsx
@@ -1,4 +1,5 @@
 import {
+  Box,
   Button,
   Dialog,
   DialogActions,
@@ -24,10 +25,19 @@ import {
   UI_TEXT_SAVE,
 } from "../../constants/ui-text";
 import { selectEnvById } from "../../modules/environments";
+import { CopyIconButton } from "../copy-icon-button";
 
 const useStyles = makeStyles((theme) => ({
   item: {
     backgroundColor: theme.palette.background.paper,
+  },
+  idCell: {
+    "& button": {
+      visibility: "hidden",
+    },
+    "&:hover button": {
+      visibility: "visible",
+    },
   },
 }));
 
@@ -85,7 +95,12 @@ export const EnvironmentListItem: FC<EnvironmentListItemProps> = memo(
             </Typography>
           </TableCell>
           <TableCell colSpan={2}>{env.desc || TEXT_NO_DESCRIPTION}</TableCell>
-          <TableCell>{env.id}</TableCell>
+          <TableCell className={classes.idCell}>
+            <Box display="flex" alignItems="center" fontFamily="fontFamilyMono">
+              {env.id}
+              <CopyIconButton name="Environment ID" value={env.id} />
+            </Box>
+          </TableCell>
           <TableCell align="right" style={{ height: 61 }}>
             <IconButton
               edge="end"

--- a/pkg/app/web/src/components/generated-api-key-dialog/index.tsx
+++ b/pkg/app/web/src/components/generated-api-key-dialog/index.tsx
@@ -32,11 +32,7 @@ export const GeneratedAPIKeyDialog: FC = memo(function GeneratedAPIKeyDialog() {
       <DialogContent>
         <Typography variant="caption">{VALUE_CAPTION}</Typography>
         {generatedKey ? (
-          <TextWithCopyButton
-            name="API Key"
-            label="Copy API Key"
-            value={generatedKey}
-          />
+          <TextWithCopyButton name="API Key" value={generatedKey} />
         ) : null}
       </DialogContent>
       <DialogActions>

--- a/pkg/app/web/src/components/sealed-secret-dialog/index.tsx
+++ b/pkg/app/web/src/components/sealed-secret-dialog/index.tsx
@@ -115,7 +115,6 @@ export const SealedSecretDialog: FC<SealedSecretDialogProps> = memo(
               </Typography>
               <TextWithCopyButton
                 name="Encrypted secret"
-                label="Copy secret"
                 value={sealedSecret}
               />
             </DialogContent>

--- a/pkg/app/web/src/components/text-with-copy-button/index.stories.tsx
+++ b/pkg/app/web/src/components/text-with-copy-button/index.stories.tsx
@@ -3,7 +3,7 @@ import { createDecoratorRedux } from "../../../.storybook/redux-decorator";
 import { TextWithCopyButton, TextWithCopyButtonProps } from "./";
 
 export default {
-  title: "TextWithCopyButton",
+  title: "COMMON/TextWithCopyButton",
   component: TextWithCopyButton,
   decorators: [createDecoratorRedux({})],
 };
@@ -13,4 +13,4 @@ const Template: Story<TextWithCopyButtonProps> = (args) => (
 );
 
 export const Overview = Template.bind({});
-Overview.args = { name: "Value", label: "Copy value", value: "value" };
+Overview.args = { name: "Value", value: "value" };

--- a/pkg/app/web/src/components/text-with-copy-button/index.tsx
+++ b/pkg/app/web/src/components/text-with-copy-button/index.tsx
@@ -1,9 +1,6 @@
-import { FC, memo, useCallback } from "react";
-import { IconButton, makeStyles } from "@material-ui/core";
-import CopyIcon from "@material-ui/icons/FileCopyOutlined";
-import copy from "copy-to-clipboard";
-import { useDispatch } from "react-redux";
-import { addToast } from "../../modules/toasts";
+import { makeStyles } from "@material-ui/core";
+import { FC, memo } from "react";
+import { CopyIconButton } from "../copy-icon-button";
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -23,35 +20,30 @@ const useStyles = makeStyles((theme) => ({
     textOverflow: "ellipsis",
     paddingLeft: theme.spacing(1),
   },
+  copyButton: {
+    marginLeft: theme.spacing(2),
+  },
 }));
 
 export interface TextWithCopyButtonProps {
   name: string;
-  label: string;
   value: string;
 }
 
 export const TextWithCopyButton: FC<TextWithCopyButtonProps> = memo(
-  function TextWithCopyButton({ name, label, value }) {
+  function TextWithCopyButton({ name, value }) {
     const classes = useStyles();
-    const dispatch = useDispatch();
-    const handleCopy = useCallback(() => {
-      copy(value);
-      dispatch(addToast({ message: `${name} copied to clipboard.` }));
-    }, [value, name, dispatch]);
     return (
       <fieldset className={classes.root}>
         <input readOnly value={value} className={classes.input} />
         <legend>{name}</legend>
         <div>
-          <IconButton
+          <CopyIconButton
+            name={name}
+            value={value}
             size="small"
-            style={{ marginLeft: 8 }}
-            aria-label={label}
-            onClick={handleCopy}
-          >
-            <CopyIcon style={{ fontSize: 20 }} />
-          </IconButton>
+            className={classes.copyButton}
+          />
         </div>
       </fieldset>
     );

--- a/pkg/app/web/src/constants/toast-text.ts
+++ b/pkg/app/web/src/constants/toast-text.ts
@@ -10,7 +10,6 @@ export const DISABLE_API_KEY_SUCCESS = "Successfully disabled API Key.";
 // Piped
 export const ADD_PIPED_SUCCESS = "Successfully added Piped.";
 export const UPDATE_PIPED_SUCCESS = "Successfully updated Piped.";
-export const COPY_PIPED_ID = "Piped ID copied to clipboard.";
 export const DELETE_OLD_PIPED_KEY_SUCCESS =
   "Successfully deleted old Piped key.";
 

--- a/pkg/app/web/src/pages/settings/piped/index.tsx
+++ b/pkg/app/web/src/pages/settings/piped/index.tsx
@@ -196,12 +196,10 @@ export const SettingsPipedPage: FC = memo(function SettingsPipedPage() {
         <DialogContent>
           <TextWithCopyButton
             name="Piped Id"
-            label="Copy piped id"
             value={registeredPiped?.id || ""}
           />
           <TextWithCopyButton
             name="Piped Key"
-            label="Copy piped key"
             value={registeredPiped?.key || ""}
           />
           <Box display="flex" justifyContent="flex-end" m={1} mt={2}>

--- a/pkg/app/web/src/pages/settings/piped/piped-table-row.tsx
+++ b/pkg/app/web/src/pages/settings/piped/piped-table-row.tsx
@@ -14,21 +14,14 @@ import {
   Button,
   DialogContentText,
 } from "@material-ui/core";
-import {
-  FileCopyOutlined as CopyIcon,
-  MoreVert as MoreVertIcon,
-} from "@material-ui/icons";
+import { MoreVert as MoreVertIcon } from "@material-ui/icons";
 import clsx from "clsx";
-import copy from "copy-to-clipboard";
 import dayjs from "dayjs";
 import * as React from "react";
 import { FC, memo, useCallback, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { AppDispatch } from "../../../store";
-import {
-  COPY_PIPED_ID,
-  DELETE_OLD_PIPED_KEY_SUCCESS,
-} from "../../../constants/toast-text";
+import { DELETE_OLD_PIPED_KEY_SUCCESS } from "../../../constants/toast-text";
 import {
   UI_TEXT_ADD_NEW_KEY,
   UI_TEXT_DELETE_OLD_KEY,
@@ -43,15 +36,17 @@ import {
   selectPipedById,
 } from "../../../modules/pipeds";
 import { addToast } from "../../../modules/toasts";
+import { CopyIconButton } from "../../../components/copy-icon-button";
 
 const useStyles = makeStyles((theme) => ({
   disabledItem: {
     background: theme.palette.grey[200],
   },
-  copyButton: {
-    marginLeft: theme.spacing(1),
-    visibility: "hidden",
-    "tr:hover &": {
+  idCell: {
+    "& button": {
+      visibility: "hidden",
+    },
+    "&:hover button": {
       visibility: "visible",
     },
   },
@@ -137,13 +132,6 @@ export const PipedTableRow: FC<Props> = memo(function PipedTableRow({
     onDisable(pipedId);
   }, [pipedId, onDisable]);
 
-  const handleCopy = useCallback(() => {
-    if (piped) {
-      copy(piped.id);
-      dispatch(addToast({ message: COPY_PIPED_ID }));
-    }
-  }, [dispatch, piped]);
-
   if (!piped) {
     return null;
   }
@@ -157,16 +145,10 @@ export const PipedTableRow: FC<Props> = memo(function PipedTableRow({
         <TableCell>
           <Typography variant="subtitle2">{piped.name}</Typography>
         </TableCell>
-        <TableCell title={piped.id}>
+        <TableCell title={piped.id} className={classes.idCell}>
           <Box display="flex" alignItems="center" fontFamily="fontFamilyMono">
             {piped.id}
-            <IconButton
-              className={classes.copyButton}
-              aria-label="Copy piped id"
-              onClick={handleCopy}
-            >
-              <CopyIcon />
-            </IconButton>
+            <CopyIconButton name="Piped ID" value={piped.id} />
           </Box>
         </TableCell>
         <TableCell>{piped.version}</TableCell>


### PR DESCRIPTION
**What this PR does / why we need it**:

Create and use the copy button component.

Add a copy button to the environment id as well as the piped id.
<img width="1330" alt="Screen Shot 2021-05-12 at 20 40 47" src="https://user-images.githubusercontent.com/6136383/117969467-6655d480-b362-11eb-9a71-cf0937de9119.png">


**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Add a button to copy the environment id
```
