### PR TITLE
Add a new piped image dedicated to OKD

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -136,6 +136,14 @@ container_pull(
 )
 
 container_pull(
+    name = "piped-base-okd",
+    digest = "sha256:54f11a2701a5ad8c9d9fbf1f1c3232fa02f30c4fa399c98e7c2df1640fdb4f0d",
+    registry = "gcr.io",
+    repository = "pipecd/piped-base-okd",
+    tag = "0.1.0",
+)
+
+container_pull(
     name = "debug-base",
     digest = "sha256:b0ec52fbde95be09074badc8298b6e94d61a9066e9637d75610267f1646fb0a1",
     registry = "gcr.io",

--- a/cmd/image.bzl
+++ b/cmd/image.bzl
@@ -1,6 +1,7 @@
 def all_images():
     cmds = {
         "piped": "piped",
+        "piped": "piped_okd",
         "pipecd": "pipecd",
         "pipectl": "pipectl",
         "helloworld": "helloworld",

--- a/cmd/image.bzl
+++ b/cmd/image.bzl
@@ -1,14 +1,14 @@
 def all_images():
-    cmds = {
-        "piped": "piped",
-        "pipecd": "pipecd",
-        "pipectl": "pipectl",
-        "helloworld": "helloworld",
+    targets = {
+        "//cmd/piped:piped_app_image": "piped",
+        "//cmd/piped:piped_okd_app_image": "piped_okd",
+        "//cmd/pipecd:pipecd_app_image": "pipecd",
+        "//cmd/pipectl:pipectl_app_image": "pipectl",
+        "//cmd/helloworld:helloworld_app_image": "helloworld",
     }
     images = {}
 
-    for cmd, repo in cmds.items():
-        images["$(DOCKER_REGISTRY)/%s:{STABLE_VERSION}" % repo] = "//cmd/%s:%s_app_image" % (cmd, repo)
+    for target, repo in targets.items():
+        images["$(DOCKER_REGISTRY)/%s:{STABLE_VERSION}" % repo] = target
 
-    images["$(DOCKER_REGISTRY)/piped_okd:{STABLE_VERSION}"] = "//cmd/piped:piped_okd_app_image"
     return images

--- a/cmd/image.bzl
+++ b/cmd/image.bzl
@@ -1,7 +1,6 @@
 def all_images():
     cmds = {
         "piped": "piped",
-        "piped": "piped_okd",
         "pipecd": "pipecd",
         "pipectl": "pipectl",
         "helloworld": "helloworld",
@@ -11,4 +10,5 @@ def all_images():
     for cmd, repo in cmds.items():
         images["$(DOCKER_REGISTRY)/%s:{STABLE_VERSION}" % repo] = "//cmd/%s:%s_app_image" % (cmd, repo)
 
+    images["$(DOCKER_REGISTRY)/piped_okd:{STABLE_VERSION}"] = "//cmd/piped:piped_okd_app_image"
     return images

--- a/cmd/piped/BUILD.bazel
+++ b/cmd/piped/BUILD.bazel
@@ -25,3 +25,11 @@ app_image(
     repository = "piped",
     visibility = ["//visibility:public"],
 )
+
+app_image(
+    name = "piped_okd_app",
+    base = "@piped-base-okd//image",
+    binary = "//cmd/piped:piped",
+    repository = "piped-okd",
+    visibility = ["//visibility:public"],
+)

--- a/cmd/piped/BUILD.bazel
+++ b/cmd/piped/BUILD.bazel
@@ -29,7 +29,7 @@ app_image(
 app_image(
     name = "piped_okd_app",
     base = "@piped-base-okd//image",
-    binary = "//cmd/piped:piped",
+    binary = ":piped",
     repository = "piped-okd",
     visibility = ["//visibility:public"],
 )

--- a/dockers/piped-base-okd/README.md
+++ b/dockers/piped-base-okd/README.md
@@ -1,0 +1,5 @@
+# piped-base-okd
+This directory contains the Piped docker image packing with [nss_wrapper](https://cwrap.org/nss_wrapper.html) to add an random UID to "passwd" at runtime without having to directly modify `/etc/passwd`.
+This mainly aims to workaround to deal with some issues due to random UID on OpenShift less than 4.2.
+
+For more why it got needed, see: https://github.com/pipe-cd/pipe/issues/1905

--- a/dockers/piped-base-okd/README.md
+++ b/dockers/piped-base-okd/README.md
@@ -1,5 +1,5 @@
 # piped-base-okd
-This directory contains the Piped docker image packing with [nss_wrapper](https://cwrap.org/nss_wrapper.html) to add an random UID to "passwd" at runtime without having to directly modify `/etc/passwd`.
+This directory contains the Piped docker image packing with [nss_wrapper](https://cwrap.org/nss_wrapper.html) to add a random UID to "passwd" at runtime without having to directly modify `/etc/passwd`.
 This mainly aims to workaround to deal with some issues due to random UID on OpenShift less than 4.2.
 
 For more why it got needed, see: https://github.com/pipe-cd/pipe/issues/1905

--- a/dockers/piped-base-okd/README.md
+++ b/dockers/piped-base-okd/README.md
@@ -1,5 +1,5 @@
 # piped-base-okd
-This directory contains the Piped docker image packing with [nss_wrapper](https://cwrap.org/nss_wrapper.html) to add a random UID to "passwd" at runtime without having to directly modify `/etc/passwd`.
+This directory contains the Piped docker image packing with [nss_wrapper](https://cwrap.org/nss_wrapper.html) to add the logged-in UID to "passwd" at runtime without having to directly modify `/etc/passwd`.
 This mainly aims to workaround to deal with some issues due to random UID on OpenShift less than 4.2.
 
 For more why it got needed, see: https://github.com/pipe-cd/pipe/issues/1905


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes it available to use a brand new independent piped packing with `nss_wrapper`. Aside from making a new directory underneath `cmd/`, if someone knows anything else way, tell me what to do.

**Which issue(s) this PR fixes**:

Ref https://github.com/pipe-cd/pipe/issues/1905

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
