### PR TITLE
Allow setting of env vars for containers

### DIFF
--- a/manifests/piped/templates/deployment.yaml
+++ b/manifests/piped/templates/deployment.yaml
@@ -53,6 +53,10 @@ spec:
               readOnly: true
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          {{- with .Values.containerEnv }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       volumes:
         - name: piped-secret
           secret:

--- a/manifests/piped/templates/deployment.yaml
+++ b/manifests/piped/templates/deployment.yaml
@@ -53,7 +53,7 @@ spec:
               readOnly: true
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-          {{- with .Values.containerEnv }}
+          {{- with .Values.envs }}
           env:
             {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/manifests/piped/values.yaml
+++ b/manifests/piped/values.yaml
@@ -78,7 +78,7 @@ secret:
     fileName: datadog-application-key
     data: ""
 
-containerEnv: {}
+envs: []
 
 securityContext:
   runAsNonRoot: true

--- a/manifests/piped/values.yaml
+++ b/manifests/piped/values.yaml
@@ -78,6 +78,8 @@ secret:
     fileName: datadog-application-key
     data: ""
 
+containerEnv: {}
+
 securityContext:
   runAsNonRoot: true
   runAsUser: 1000


### PR DESCRIPTION
**What this PR does / why we need it**:
#1946
>  I can set the KUBECONFIG environment variable as a workaround.

I want to be able to set environment variables to do this workaround.
In addition, I need to be able to mount kubeconfig, but I'm still working on how to specify this in values.yaml, so I'll do a separate PR.

**Which issue(s) this PR fixes**:

Related to #1946 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
