### PR TITLE
Add Helm value to control to modify /etc/passwd

### DIFF
--- a/manifests/piped/templates/deployment.yaml
+++ b/manifests/piped/templates/deployment.yaml
@@ -32,6 +32,7 @@ spec:
           - --enable-default-kubernetes-cloud-provider={{ .Values.args.enableDefaultKubernetesCloudProvider }}
           - --insecure={{ .Values.args.insecure }}
           - --log-encoding={{ .Values.args.logEncoding }}
+          - --add-login-user-to-passwd={{ .Values.args.addLoginUserToPasswd }}
           ports:
             - name: admin
               containerPort: 9085

--- a/manifests/piped/values.yaml
+++ b/manifests/piped/values.yaml
@@ -7,6 +7,9 @@ args:
   enableDefaultKubernetesCloudProvider: true
   insecure: false
   logEncoding: humanize
+  # Specifies whether it adds logged-in user to /etc/passwd at runtime.
+  # This is typically for applications running as a random user ID, such as OpenShift less than 4.2.
+  addLoginUserToPasswd: false
 
 service:
   enabled: true


### PR DESCRIPTION
**What this PR does / why we need it**:
Support a new Helm value `addLoginUserToPasswd` to enable `nss_wrapper`. Those who're using OpenShift < 4.2 would just need to enable this one and put `gcr.io/pipecd/piped-with-nss-wrapper` into `image.repository`.

**Which issue(s) this PR fixes**:

Ref https://github.com/pipe-cd/pipe/issues/1905

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
