### PR TITLE
Prefix the bazel rules of app_image to allow specifying multiple apps inside the same directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,8 @@ build-images:
 
 .PHONY: push
 push:
-	bazelisk ${BAZEL_FLAGS} run ${BAZEL_COMMAND_FLAGS} --config=linux --config=stamping -- //cmd/pipecd:push
-	bazelisk ${BAZEL_FLAGS} run ${BAZEL_COMMAND_FLAGS} --config=linux --config=stamping -- //cmd/piped:push
+	bazelisk ${BAZEL_FLAGS} run ${BAZEL_COMMAND_FLAGS} --config=linux --config=stamping -- //cmd/pipecd:pipecd_app_push
+	bazelisk ${BAZEL_FLAGS} run ${BAZEL_COMMAND_FLAGS} --config=linux --config=stamping -- //cmd/piped:piped_app_push
 
 .PHONY: render-manifests
 render-manifests:
@@ -38,7 +38,7 @@ render-manifests:
 
 .PHONY: load-piped-image
 load-piped-image:
-	bazelisk ${BAZEL_FLAGS} run ${BAZEL_COMMAND_FLAGS} --config=linux --config=stamping -- //cmd/piped:image --norun
+	bazelisk ${BAZEL_FLAGS} run ${BAZEL_COMMAND_FLAGS} --config=linux --config=stamping -- //cmd/piped:piped_app_image --norun
 
 .PHONY: test
 test:

--- a/bazel/image.bzl
+++ b/bazel/image.bzl
@@ -18,22 +18,21 @@ load("@io_bazel_rules_docker//contrib:push-all.bzl", "docker_push")
 
 def app_image(name, binary, repository, base = None, **kwargs):
     go_image(
-        name = "image",
+        name = "%s_image" % name,
         binary = binary,
         base = base,
         **kwargs
     )
 
     container_bundle(
-        name = "bundle",
+        name = "%s_bundle" % name,
         images = {
-            "$(DOCKER_REGISTRY)/%s:{STABLE_VERSION}" % repository: ":image",
-            "$(DOCKER_REGISTRY)/%s:{STABLE_GIT_COMMIT}" % repository: ":image",
+            "$(DOCKER_REGISTRY)/%s:{STABLE_VERSION}" % repository: ":%s_image" % name,
         },
     )
 
     docker_push(
-        name = "push",
-        bundle = ":bundle",
+        name = "%s_push" % name,
+        bundle = ":%s_bundle" % name,
         **kwargs
     )

--- a/cmd/image.bzl
+++ b/cmd/image.bzl
@@ -8,6 +8,6 @@ def all_images():
     images = {}
 
     for cmd, repo in cmds.items():
-        images["$(DOCKER_REGISTRY)/%s:{STABLE_VERSION}" % repo] = "//cmd/%s:image" % cmd
+        images["$(DOCKER_REGISTRY)/%s:{STABLE_VERSION}" % repo] = "//cmd/%s:%s_app_image" % (cmd, cmd)
 
     return images


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR helps to deal with the problem from  https://github.com/pipe-cd/pipe/pull/1959 in an easier way.
Don't have to create a new cmd directory.

So you can add something like this into the same `cmd/piped` directory.

```
app_image(
    name = "piped_okd_app",
    base = "@piped-base-okd//image",
    binary = "//cmd/piped:piped",
    repository = "piped-okd",
    visibility = ["//visibility:public"],
)
```

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
