### PR TITLE
Use native clipboard API for copy text on the web

### DIFF
--- a/pkg/app/web/jest.setup.js
+++ b/pkg/app/web/jest.setup.js
@@ -1,5 +1,13 @@
 "use strict";
 
+Object.defineProperty(navigator, "clipboard", {
+  value: {
+    writeText: (content) => {
+      return Promise.resolve(content);
+    },
+  },
+});
+
 let mockHistory = null;
 jest.mock("./src/history.ts", () => ({
   __setMockHistory(his) {

--- a/pkg/app/web/package.json
+++ b/pkg/app/web/package.json
@@ -78,7 +78,6 @@
     "@types/dagre": "^0.7.44",
     "@types/yup": "^0.29.9",
     "clsx": "^1.1.1",
-    "copy-to-clipboard": "^3.3.1",
     "dagre": "^0.8.5",
     "dayjs": "^1.8.28",
     "dotenv": "^8.2.0",

--- a/pkg/app/web/src/components/copy-icon-button/index.test.tsx
+++ b/pkg/app/web/src/components/copy-icon-button/index.test.tsx
@@ -1,0 +1,24 @@
+import { waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { render, screen, createStore } from "../../../test-utils";
+import { addToast } from "../../modules/toasts";
+import { CopyIconButton } from "./";
+
+test("copy text", async () => {
+  const store = createStore();
+  jest.spyOn(navigator.clipboard, "writeText");
+  render(<CopyIconButton name="ID" value="id" />, { store });
+  userEvent.click(screen.getByRole("button"));
+
+  expect(navigator.clipboard.writeText).toHaveBeenCalledWith("id");
+  await waitFor(() =>
+    expect(store.getActions()).toEqual([
+      {
+        payload: {
+          message: "ID copied to clipboard.",
+        },
+        type: addToast.type,
+      },
+    ])
+  );
+});

--- a/pkg/app/web/src/components/copy-icon-button/index.tsx
+++ b/pkg/app/web/src/components/copy-icon-button/index.tsx
@@ -1,5 +1,4 @@
 import { IconButton } from "@material-ui/core";
-import copy from "copy-to-clipboard";
 import { FileCopyOutlined as CopyIcon } from "@material-ui/icons";
 import { FC, useCallback, memo } from "react";
 import { useDispatch } from "react-redux";
@@ -16,8 +15,9 @@ export const CopyIconButton: FC<CopyIconButtonProps> = memo(
   function CopyIconButton({ name, value, className, size }) {
     const dispatch = useDispatch();
     const handleCopy = useCallback(() => {
-      copy(value);
-      dispatch(addToast({ message: `${name} copied to clipboard.` }));
+      navigator.clipboard.writeText(value).then(() => {
+        dispatch(addToast({ message: `${name} copied to clipboard.` }));
+      });
     }, [dispatch, value, name]);
 
     return (


### PR DESCRIPTION
**What this PR does / why we need it**:

Use `Clipboard API` instead of `copy-to-clipboard` to copy text.

https://developer.mozilla.org/en-US/docs/Web/API/Clipboard/writeText

Browser compatibility seems to be fine.

![image](https://user-images.githubusercontent.com/6136383/118108852-767dba80-b41b-11eb-98dc-6050fe4fcc70.png)


**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
