### PR TITLE
Allow kubeconfig to be added to the secret

### DIFF
--- a/manifests/piped/templates/secret.yaml
+++ b/manifests/piped/templates/secret.yaml
@@ -32,4 +32,9 @@ data:
 {{- if .Values.secret.datadogApplicationKey.data }}
   {{ .Values.secret.datadogApplicationKey.fileName }}: {{ .Values.secret.datadogApplicationKey.data | b64enc | quote }}
 {{- end }}
+{{- if .Values.secret.kubeConfigs }}
+{{- range .Values.secret.kubeConfigs }}
+  {{ .fileName | quote }}: {{ .data | b64enc | quote }}
+{{- end }}
+{{- end }}
 {{- end }}

--- a/manifests/piped/values.yaml
+++ b/manifests/piped/values.yaml
@@ -77,6 +77,8 @@ secret:
   datadogApplicationKey:
     fileName: datadog-application-key
     data: ""
+  # The list of kubeConfig should be embedded in the Secret to be used by Piped.
+  # Each item of this list has 2 fields "fileName" and "data".
   kubeConfigs: []
 
 securityContext:

--- a/manifests/piped/values.yaml
+++ b/manifests/piped/values.yaml
@@ -77,6 +77,7 @@ secret:
   datadogApplicationKey:
     fileName: datadog-application-key
     data: ""
+  kubeConfigs: []
 
 securityContext:
   runAsNonRoot: true


### PR DESCRIPTION
**What this PR does / why we need it**:
Added support for adding kubeconfig to the Secret resource.

There are a few things to consider

* Should we be able to add multiple kubeconfigs?
* Is it appropriate for the name kubeconfig to appear here?
  * Would a name like `general` be better?

**Which issue(s) this PR fixes**:

Fixes #1946
Related to #1960

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
