### PR TITLE
Allow to skip cert verification when adding the chart repo

### DIFF
--- a/docs/content/en/docs/operator-manual/piped/configuration-reference.md
+++ b/docs/content/en/docs/operator-manual/piped/configuration-reference.md
@@ -60,7 +60,7 @@ spec:
 | address | string | The address to the Helm chart repository. | Yes |
 | username | string | Username used for the repository backed by HTTP basic authentication. | No |
 | password | string | Password used for the repository backed by HTTP basic authentication. | No |
-| insecure | bool | Insecure specifies whether to verify the repository certificate. | No |
+| insecure | bool | Whether to skip TLS certificate checks for the repository or not. | No |
 
 ## CLoudProvider
 

--- a/docs/content/en/docs/operator-manual/piped/configuration-reference.md
+++ b/docs/content/en/docs/operator-manual/piped/configuration-reference.md
@@ -60,6 +60,7 @@ spec:
 | address | string | The address to the Helm chart repository. | Yes |
 | username | string | Username used for the repository backed by HTTP basic authentication. | No |
 | password | string | Password used for the repository backed by HTTP basic authentication. | No |
+| insecure | bool | Insecure specifies whether to verify the repository certificate. | No |
 
 ## CLoudProvider
 

--- a/pkg/app/piped/chartrepo/chartrepo.go
+++ b/pkg/app/piped/chartrepo/chartrepo.go
@@ -44,6 +44,9 @@ func Add(ctx context.Context, repos []config.HelmChartRepository, reg registry, 
 
 	for _, repo := range repos {
 		args := []string{"repo", "add", repo.Name, repo.Address}
+		if repo.Insecure {
+			args = append(args, "--insecure-skip-tls-verify")
+		}
 		if repo.Username != "" || repo.Password != "" {
 			args = append(args, "--username", repo.Username, "--password", repo.Password)
 		}

--- a/pkg/app/piped/cloudprovider/kubernetes/helm.go
+++ b/pkg/app/piped/cloudprovider/kubernetes/helm.go
@@ -121,6 +121,7 @@ type helmRemoteChart struct {
 	Repository string
 	Name       string
 	Version    string
+	Insecure   bool
 }
 
 func (c *Helm) TemplateRemoteChart(ctx context.Context, appName, appDir, namespace string, chart helmRemoteChart, opts *config.InputHelmOptions) (string, error) {
@@ -135,6 +136,10 @@ func (c *Helm) TemplateRemoteChart(ctx context.Context, appName, appDir, namespa
 		releaseName,
 		fmt.Sprintf("%s/%s", chart.Repository, chart.Name),
 		fmt.Sprintf("--version=%s", chart.Version),
+	}
+
+	if chart.Insecure {
+		args = append(args, "--insecure-skip-tls-verify")
 	}
 
 	if namespace != "" {

--- a/pkg/app/piped/cloudprovider/kubernetes/kubernetes.go
+++ b/pkg/app/piped/cloudprovider/kubernetes/kubernetes.go
@@ -180,6 +180,7 @@ func (p *provider) LoadManifests(ctx context.Context) (manifests []Manifest, err
 				Repository: p.input.HelmChart.Repository,
 				Name:       p.input.HelmChart.Name,
 				Version:    p.input.HelmChart.Version,
+				Insecure:   p.input.HelmChart.Insecure,
 			}
 			data, err = p.helm.TemplateRemoteChart(ctx,
 				p.appName,

--- a/pkg/app/piped/controller/planner.go
+++ b/pkg/app/piped/controller/planner.go
@@ -164,6 +164,7 @@ func (p *planner) Run(ctx context.Context) error {
 	in := pln.Input{
 		Deployment:                     p.deployment,
 		MostRecentSuccessfulCommitHash: p.lastSuccessfulCommitHash,
+		PipedConfig:                    p.pipedConfig,
 		AppManifestsCache:              p.appManifestsCache,
 		RegexPool:                      regexpool.DefaultPool(),
 		Logger:                         p.logger,

--- a/pkg/app/piped/driftdetector/kubernetes/detector.go
+++ b/pkg/app/piped/driftdetector/kubernetes/detector.go
@@ -356,6 +356,14 @@ func (d *detector) loadDeploymentConfiguration(repoPath string, app *model.Appli
 	if appKind, ok := config.ToApplicationKind(cfg.Kind); !ok || appKind != app.Kind {
 		return nil, fmt.Errorf("application in deployment configuration file is not match, got: %s, expected: %s", appKind, app.Kind)
 	}
+
+	if cfg.KubernetesDeploymentSpec != nil && cfg.KubernetesDeploymentSpec.Input.HelmChart != nil {
+		chartRepoName := cfg.KubernetesDeploymentSpec.Input.HelmChart.Repository
+		if chartRepoName != "" {
+			cfg.KubernetesDeploymentSpec.Input.HelmChart.Insecure = d.config.IsInsecureChartRepository(chartRepoName)
+		}
+	}
+
 	return cfg, nil
 }
 

--- a/pkg/app/piped/executor/kubernetes/kubernetes.go
+++ b/pkg/app/piped/executor/kubernetes/kubernetes.go
@@ -90,7 +90,7 @@ func (e *deployExecutor) Execute(sig executor.StopSignal) model.StageStatus {
 
 	chartRepoName := e.deployCfg.Input.HelmChart.Repository
 	if chartRepoName != "" {
-		e.deployCfg.Input.HelmChart.Insecure = ds.DeploymentConfig.PipedSpec.IsInsecureChartRepository(chartRepoName)
+		e.deployCfg.Input.HelmChart.Insecure = e.PipedConfig.IsInsecureChartRepository(chartRepoName)
 	}
 
 	e.provider = provider.NewProvider(e.Deployment.ApplicationName, ds.AppDir, ds.RepoDir, e.Deployment.GitPath.ConfigFilename, e.deployCfg.Input, e.Logger)

--- a/pkg/app/piped/executor/kubernetes/kubernetes.go
+++ b/pkg/app/piped/executor/kubernetes/kubernetes.go
@@ -88,9 +88,11 @@ func (e *deployExecutor) Execute(sig executor.StopSignal) model.StageStatus {
 		return model.StageStatus_STAGE_FAILURE
 	}
 
-	chartRepoName := e.deployCfg.Input.HelmChart.Repository
-	if chartRepoName != "" {
-		e.deployCfg.Input.HelmChart.Insecure = e.PipedConfig.IsInsecureChartRepository(chartRepoName)
+	if e.deployCfg.Input.HelmChart != nil {
+		chartRepoName := e.deployCfg.Input.HelmChart.Repository
+		if chartRepoName != "" {
+			e.deployCfg.Input.HelmChart.Insecure = e.PipedConfig.IsInsecureChartRepository(chartRepoName)
+		}
 	}
 
 	e.provider = provider.NewProvider(e.Deployment.ApplicationName, ds.AppDir, ds.RepoDir, e.Deployment.GitPath.ConfigFilename, e.deployCfg.Input, e.Logger)

--- a/pkg/app/piped/executor/kubernetes/kubernetes.go
+++ b/pkg/app/piped/executor/kubernetes/kubernetes.go
@@ -88,6 +88,11 @@ func (e *deployExecutor) Execute(sig executor.StopSignal) model.StageStatus {
 		return model.StageStatus_STAGE_FAILURE
 	}
 
+	chartRepoName := e.deployCfg.Input.HelmChart.Repository
+	if chartRepoName != "" {
+		e.deployCfg.Input.HelmChart.Insecure = ds.DeploymentConfig.PipedSpec.IsInsecureChartRepository(chartRepoName)
+	}
+
 	e.provider = provider.NewProvider(e.Deployment.ApplicationName, ds.AppDir, ds.RepoDir, e.Deployment.GitPath.ConfigFilename, e.deployCfg.Input, e.Logger)
 	e.Logger.Info("start executing kubernetes stage",
 		zap.String("stage-name", e.Stage.Name),

--- a/pkg/app/piped/executor/kubernetes/rollback.go
+++ b/pkg/app/piped/executor/kubernetes/rollback.go
@@ -67,6 +67,11 @@ func (e *rollbackExecutor) ensureRollback(ctx context.Context) model.StageStatus
 		return model.StageStatus_STAGE_FAILURE
 	}
 
+	chartRepoName := deployCfg.Input.HelmChart.Repository
+	if chartRepoName != "" {
+		deployCfg.Input.HelmChart.Insecure = ds.DeploymentConfig.PipedSpec.IsInsecureChartRepository(chartRepoName)
+	}
+
 	p := provider.NewProvider(e.Deployment.ApplicationName, ds.AppDir, ds.RepoDir, e.Deployment.GitPath.ConfigFilename, deployCfg.Input, e.Logger)
 	e.Logger.Info("start executing kubernetes stage",
 		zap.String("stage-name", e.Stage.Name),

--- a/pkg/app/piped/executor/kubernetes/rollback.go
+++ b/pkg/app/piped/executor/kubernetes/rollback.go
@@ -69,7 +69,7 @@ func (e *rollbackExecutor) ensureRollback(ctx context.Context) model.StageStatus
 
 	chartRepoName := deployCfg.Input.HelmChart.Repository
 	if chartRepoName != "" {
-		deployCfg.Input.HelmChart.Insecure = ds.DeploymentConfig.PipedSpec.IsInsecureChartRepository(chartRepoName)
+		deployCfg.Input.HelmChart.Insecure = e.PipedConfig.IsInsecureChartRepository(chartRepoName)
 	}
 
 	p := provider.NewProvider(e.Deployment.ApplicationName, ds.AppDir, ds.RepoDir, e.Deployment.GitPath.ConfigFilename, deployCfg.Input, e.Logger)

--- a/pkg/app/piped/executor/kubernetes/rollback.go
+++ b/pkg/app/piped/executor/kubernetes/rollback.go
@@ -67,9 +67,11 @@ func (e *rollbackExecutor) ensureRollback(ctx context.Context) model.StageStatus
 		return model.StageStatus_STAGE_FAILURE
 	}
 
-	chartRepoName := deployCfg.Input.HelmChart.Repository
-	if chartRepoName != "" {
-		deployCfg.Input.HelmChart.Insecure = e.PipedConfig.IsInsecureChartRepository(chartRepoName)
+	if deployCfg.Input.HelmChart != nil {
+		chartRepoName := deployCfg.Input.HelmChart.Repository
+		if chartRepoName != "" {
+			deployCfg.Input.HelmChart.Insecure = e.PipedConfig.IsInsecureChartRepository(chartRepoName)
+		}
 	}
 
 	p := provider.NewProvider(e.Deployment.ApplicationName, ds.AppDir, ds.RepoDir, e.Deployment.GitPath.ConfigFilename, deployCfg.Input, e.Logger)

--- a/pkg/app/piped/planner/kubernetes/kubernetes.go
+++ b/pkg/app/piped/planner/kubernetes/kubernetes.go
@@ -63,6 +63,13 @@ func (p *Planner) Plan(ctx context.Context, in planner.Input) (out planner.Outpu
 		return
 	}
 
+	if cfg.Input.HelmChart != nil {
+		chartRepoName := cfg.Input.HelmChart.Repository
+		if chartRepoName != "" {
+			cfg.Input.HelmChart.Insecure = in.PipedConfig.IsInsecureChartRepository(chartRepoName)
+		}
+	}
+
 	manifestCache := provider.AppManifestsCache{
 		AppID:  in.Deployment.ApplicationId,
 		Cache:  in.AppManifestsCache,

--- a/pkg/app/piped/planner/planner.go
+++ b/pkg/app/piped/planner/planner.go
@@ -40,6 +40,7 @@ type Input struct {
 	// Readonly deployment model.
 	Deployment                     *model.Deployment
 	MostRecentSuccessfulCommitHash string
+	PipedConfig                    *config.PipedSpec
 	TargetDSP                      deploysource.Provider
 	RunningDSP                     deploysource.Provider
 	AppManifestsCache              cache.Cache

--- a/pkg/config/deployment_kubernetes.go
+++ b/pkg/config/deployment_kubernetes.go
@@ -85,6 +85,9 @@ type InputHelmChart struct {
 	Repository string `json:"repository"`
 	Name       string `json:"name"`
 	Version    string `json:"version"`
+	// Whether to skip TLS certificate checks for the repository or not.
+	// This option will automatically set the value of HelmChartRepository.Insecure.
+	Insecure bool `json:"-"`
 }
 
 type InputHelmOptions struct {

--- a/pkg/config/piped.go
+++ b/pkg/config/piped.go
@@ -211,6 +211,8 @@ type HelmChartRepository struct {
 	Username string `json:"username"`
 	// Password used for the repository backed by HTTP basic authentication.
 	Password string `json:"password"`
+	// Insecure specifies whether to verify the repository certificate.
+	Insecure bool `json:"insecure"`
 }
 
 type PipedCloudProvider struct {

--- a/pkg/config/piped.go
+++ b/pkg/config/piped.go
@@ -211,7 +211,7 @@ type HelmChartRepository struct {
 	Username string `json:"username"`
 	// Password used for the repository backed by HTTP basic authentication.
 	Password string `json:"password"`
-	// Insecure specifies whether to verify the repository certificate.
+	// Whether to skip TLS certificate checks for the repository or not.
 	Insecure bool `json:"insecure"`
 }
 

--- a/pkg/config/piped.go
+++ b/pkg/config/piped.go
@@ -164,6 +164,15 @@ func (s *PipedSpec) GetAnalysisProvider(name string) (PipedAnalysisProvider, boo
 	return PipedAnalysisProvider{}, false
 }
 
+func (s *PipedSpec) IsInsecureChartRepository(name string) bool {
+	for _, cr := range s.ChartRepositories {
+		if cr.Name == name {
+			return cr.Insecure
+		}
+	}
+	return false
+}
+
 type PipedGit struct {
 	// The username that will be configured for `git` user.
 	// Default is "piped".

--- a/pkg/config/piped_test.go
+++ b/pkg/config/piped_test.go
@@ -70,6 +70,7 @@ func TestPipedConfig(t *testing.T) {
 						Address:  "https://private-charts.com",
 						Username: "basic-username",
 						Password: "basic-password",
+						Insecure: true,
 					},
 				},
 				CloudProviders: []PipedCloudProvider{

--- a/pkg/config/testdata/piped/piped-config.yaml
+++ b/pkg/config/testdata/piped/piped-config.yaml
@@ -28,6 +28,7 @@ spec:
       address: https://private-charts.com
       username: basic-username
       password: basic-password
+      insecure: true
 
   cloudProviders:
     - name: kubernetes-default


### PR DESCRIPTION
**What this PR does / why we need it**:
Add insecure option to allow connection to chart repositries with self-signed certificate.

It has passed the test, but I haven't actually configure and run it yet.
I'll do it after Monday.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Added insecure to ChartRepository so that certificate verification can be skipped
```
