### PR TITLE
Update installation instruction of pipectl image

### DIFF
--- a/docs/content/en/docs/user-guide/command-line-tool.md
+++ b/docs/content/en/docs/user-guide/command-line-tool.md
@@ -42,11 +42,11 @@ You can use pipectl to add and sync applications, wait for a deployment status.
     ```
 
 ### Docker
-
-We are storing every version of docker image for pipectl on Google Cloud Container Registry. You can use it with the following address:
+We are storing every version of docker image for pipectl on Google Cloud Container Registry.
+Available versions are [here](https://github.com/pipe-cd/pipe/releases).
 
 ```
-gcr.io/pipecd/pipectl:VERSION
+docker run --rm gcr.io/pipecd/pipectl:VERSION -h
 ```
 
 ## Authentication


### PR DESCRIPTION
**What this PR does / why we need it**:
Current most users can be supposed to Docker users. Even if they use podman, all flags can be pass-through.
Anyway, the current installation instruction is a little bit unkind.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
