### PR TITLE
Add Helm value to pass kubeconfig

### DIFF
--- a/manifests/piped/templates/secret.yaml
+++ b/manifests/piped/templates/secret.yaml
@@ -11,6 +11,9 @@ data:
 {{- if .Values.secret.sshKey.data }}
   {{ .Values.secret.sshKey.fileName }}: {{ .Values.secret.sshKey.data | b64enc | quote }}
 {{- end }}
+{{- if .Values.secret.kubeConfig.data }}
+  {{ .Values.secret.kubeConfig.fileName }}: {{ .Values.secret.kubeConfig.data | b64enc | quote }}
+{{- end }}
 {{- if .Values.secret.sealedSecretSealingKey.publicKey.data }}
   {{ .Values.secret.sealedSecretSealingKey.publicKey.fileName }}: {{ .Values.secret.sealedSecretSealingKey.publicKey.data | b64enc | quote }}
 {{- end }}

--- a/manifests/piped/values.yaml
+++ b/manifests/piped/values.yaml
@@ -57,6 +57,11 @@ secret:
     fileName: ssh-key
     # Configuration data when create is true.
     data: ""
+  kubeConfig:
+    # The name of the kubeconfig file.
+    fileName: kubeconfig
+    # Configuration data when create is true.
+    data: ""
   sealedSecretSealingKey:
     publicKey:
       fileName: sealed-secret-sealingkey-public-key


### PR DESCRIPTION
**What this PR does / why we need it**:
For those whose environment can use neither in-cluster config nor master URL, this is needed.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
