### PR TITLE
Fix type error for web mock utils

### DIFF
--- a/pkg/app/web/src/mocks/create-handler.ts
+++ b/pkg/app/web/src/mocks/create-handler.ts
@@ -14,15 +14,18 @@ export function createHandler<T extends { serializeBinary(): Uint8Array }>(
   serviceName: string,
   getResponseMessage: (requestData: Uint8Array) => T
 ): HandlerType {
-  return rest.post(createMask(serviceName), (req, res, ctx) => {
-    const arr: Uint8Array =
-      typeof req.body === "string" ? encoder.encode(req.body) : req.body;
-    const message = getResponseMessage(arr.slice(5));
-    const data = serialize(message.serializeBinary());
-    return res(
-      ctx.status(200),
-      ctx.set("Content-Type", "application/grpc-web+proto"),
-      ctx.body(data)
-    );
-  });
+  return rest.post<Uint8Array | string>(
+    createMask(serviceName),
+    (req, res, ctx) => {
+      const arr: Uint8Array =
+        typeof req.body === "string" ? encoder.encode(req.body) : req.body;
+      const message = getResponseMessage(arr.slice(5));
+      const data = serialize(message.serializeBinary());
+      return res(
+        ctx.status(200),
+        ctx.set("Content-Type", "application/grpc-web+proto"),
+        ctx.body(data)
+      );
+    }
+  );
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix the following error.

```
Type 'Record<string, any> | undefined' is not assignable to type 'Uint8Array'.
  Type 'undefined' is not assignable to type 'Uint8Array'.
```

![image](https://user-images.githubusercontent.com/6136383/118808434-7af71700-b8e4-11eb-8dbd-1e73c8dccdbf.png)

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
