### PR TITLE
Refine rollback deloyment state ECS

### DIFF
--- a/pkg/app/piped/cloudprovider/ecs/ecs.go
+++ b/pkg/app/piped/cloudprovider/ecs/ecs.go
@@ -37,7 +37,6 @@ type Client interface {
 	CreateService(ctx context.Context, service types.Service) (*types.Service, error)
 	UpdateService(ctx context.Context, service types.Service) (*types.Service, error)
 	RegisterTaskDefinition(ctx context.Context, taskDefinition types.TaskDefinition) (*types.TaskDefinition, error)
-	DeregisterTaskDefinition(ctx context.Context, taskDefinition types.TaskDefinition) (*types.TaskDefinition, error)
 	CreateTaskSet(ctx context.Context, service types.Service, taskDefinition types.TaskDefinition, percent float64) (*types.TaskSet, error)
 	DeleteTaskSet(ctx context.Context, service types.Service, taskSet types.TaskSet) (*types.TaskSet, error)
 	UpdateServicePrimaryTaskSet(ctx context.Context, service types.Service, taskSet types.TaskSet) (*types.TaskSet, error)

--- a/pkg/app/piped/executor/ecs/ecs.go
+++ b/pkg/app/piped/executor/ecs/ecs.go
@@ -122,9 +122,6 @@ func build(ctx context.Context, in *executor.Input, client provider.Client, task
 		return false
 	}
 	var service *types.Service
-	// if serviceDefinition.DeploymentController.Type != types.DeploymentControllerTypeExternal {
-	// 	serviceDefinition.TaskDefinition = td.TaskDefinitionArn
-	// }
 
 	// If the task definition is specificed in service definition, should use that sepecificed version.
 	// Consider check this before register new task definition revision.
@@ -144,9 +141,6 @@ func build(ctx context.Context, in *executor.Input, client provider.Client, task
 			return false
 		}
 	}
-	// service.TaskDefinition = td.TaskDefinitionArn
-	// service.LaunchType = serviceDefinition.LaunchType
-	// service.LoadBalancers = serviceDefinition.LoadBalancers
 
 	// Create a task set in the specified cluster and service and routing traffic to that task set.
 	// This is used when a service uses the EXTERNAL deployment controller type.

--- a/pkg/app/piped/executor/ecs/ecs.go
+++ b/pkg/app/piped/executor/ecs/ecs.go
@@ -149,6 +149,10 @@ func build(ctx context.Context, in *executor.Input, client provider.Client, task
 	// Note: The deployment controller type can also get from types.Service but this field is omitted if the service is using the ECS
 	// deployment controller type, so that we should use serviceDefinition.DeploymentController instead.
 	if serviceDefinition.DeploymentController.Type == types.DeploymentControllerTypeExternal {
+		if service.NetworkConfiguration == nil {
+			service.NetworkConfiguration = serviceDefinition.NetworkConfiguration
+		}
+
 		taskSet, err := client.CreateTaskSet(ctx, *service, *td, 100)
 		if err != nil {
 			in.LogPersister.Errorf("Failed to create ECS task set %s: %v", *serviceDefinition.ServiceName, err)

--- a/pkg/app/piped/executor/ecs/rollback.go
+++ b/pkg/app/piped/executor/ecs/rollback.go
@@ -88,30 +88,36 @@ func (e *rollbackExecutor) ensureRollback(ctx context.Context) model.StageStatus
 }
 
 func rollback(ctx context.Context, in *executor.Input, cloudProviderName string, cloudProviderCfg *config.CloudProviderECSConfig, taskDefinition types.TaskDefinition, serviceDefinition types.Service) bool {
-	in.LogPersister.Infof("Start rollback the ECS service and task definition: %s and %s to original stage", *serviceDefinition.ServiceName, *taskDefinition.TaskDefinitionArn)
+	in.LogPersister.Infof("Start rollback the ECS service and task definition: %s and %s to original stage", *serviceDefinition.ServiceName, *taskDefinition.Family)
 	client, err := provider.DefaultRegistry().Client(cloudProviderName, cloudProviderCfg, in.Logger)
 	if err != nil {
 		in.LogPersister.Errorf("Unable to create ECS client for the provider %s: %v", cloudProviderName, err)
 		return false
 	}
 
+	// TODO: Instead of re-register task definition to get TaskDefinitionArn, should store TaskDefinitionArn to meta data store before sync.
 	td, err := client.RegisterTaskDefinition(ctx, taskDefinition)
 	if err != nil {
-		in.LogPersister.Errorf("Failed to register ECS task definition %s: %v", *taskDefinition.TaskDefinitionArn, err)
+		in.LogPersister.Errorf("Failed to register ECS task definition %s: %v", *taskDefinition.Family, err)
 		return false
 	}
 	serviceDefinition.TaskDefinition = td.TaskDefinitionArn
+
 	// Rollback ECS service configuration to previous state.
 	if _, err := client.UpdateService(ctx, serviceDefinition); err != nil {
 		in.LogPersister.Errorf("Unable to rollback ECS service %s configuration to previous stage: %v", *serviceDefinition.ServiceName, err)
 		return false
 	}
 
-	if _, err := client.CreateTaskSet(ctx, serviceDefinition, taskDefinition, 100); err != nil {
-		in.LogPersister.Errorf("Failed to create ECS task set %s: %v", *serviceDefinition.ServiceName, err)
-		return false
+	// Rollback traffic to previous task set version directly in case service deployment controller is EXTERNAL
+	// If types of service deployment controller are used, traffic rotation will be handled by ECS itself.
+	if serviceDefinition.DeploymentController.Type == types.DeploymentControllerTypeExternal {
+		if _, err := client.CreateTaskSet(ctx, serviceDefinition, taskDefinition, 100); err != nil {
+			in.LogPersister.Errorf("Failed to create ECS task set %s: %v", *serviceDefinition.ServiceName, err)
+			return false
+		}
 	}
 
-	in.LogPersister.Infof("Rolled back the ECS service %s and task definition %s configuration to original stage", *serviceDefinition.ServiceName, *taskDefinition.TaskDefinitionArn)
+	in.LogPersister.Infof("Rolled back the ECS service %s and task definition %s configuration to original stage", *serviceDefinition.ServiceName, *taskDefinition.Family)
 	return true
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

- Remove unused ECS client method
- Suspend errors caused by `taskDefinition.TaskDefinitionArn` nullable reason
- Refine ECS rollback deployment state

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
