### PR TITLE
Add an operator page to show application counts of all projects

### DIFF
--- a/cmd/pipecd/ops.go
+++ b/cmd/pipecd/ops.go
@@ -32,6 +32,7 @@ import (
 	"github.com/pipe-cd/pipe/pkg/cli"
 	"github.com/pipe-cd/pipe/pkg/config"
 	"github.com/pipe-cd/pipe/pkg/datastore"
+	"github.com/pipe-cd/pipe/pkg/insight/insightstore"
 	"github.com/pipe-cd/pipe/pkg/model"
 	"github.com/pipe-cd/pipe/pkg/version"
 )
@@ -137,7 +138,7 @@ func (s *ops) run(ctx context.Context, t cli.Telemetry) error {
 
 	// Start running HTTP server.
 	{
-		handler := handler.NewHandler(s.httpPort, datastore.NewProjectStore(ds), cfg.SharedSSOConfigs, s.gracePeriod, t.Logger)
+		handler := handler.NewHandler(s.httpPort, datastore.NewProjectStore(ds), insightstore.NewStore(fs), cfg.SharedSSOConfigs, s.gracePeriod, t.Logger)
 		group.Go(func() error {
 			return handler.Run(ctx)
 		})

--- a/pkg/app/ops/handler/BUILD.bazel
+++ b/pkg/app/ops/handler/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -11,6 +11,7 @@ go_library(
     deps = [
         "//pkg/config:go_default_library",
         "//pkg/datastore:go_default_library",
+        "//pkg/insight/insightstore:go_default_library",
         "//pkg/model:go_default_library",
         "@org_uber_go_zap//:go_default_library",
     ],
@@ -26,4 +27,15 @@ go_embed_data(
     string = True,
     var = "Templates",
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    size = "small",
+    srcs = ["handler_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//pkg/model:go_default_library",
+        "@com_github_stretchr_testify//assert:go_default_library",
+    ],
 )

--- a/pkg/app/ops/handler/handler_test.go
+++ b/pkg/app/ops/handler/handler_test.go
@@ -18,8 +18,9 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/pipe-cd/pipe/pkg/model"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/pipe-cd/pipe/pkg/model"
 )
 
 func TestMakeApplicationCounts(t *testing.T) {

--- a/pkg/app/ops/handler/handler_test.go
+++ b/pkg/app/ops/handler/handler_test.go
@@ -1,0 +1,211 @@
+// Copyright 2021 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handler
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/pipe-cd/pipe/pkg/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMakeApplicationCounts(t *testing.T) {
+	testcases := []struct {
+		name           string
+		counts         []model.InsightApplicationCount
+		expectedTotal  int
+		expectedGroups map[string]int
+	}{
+		{
+			name:           "empty",
+			expectedGroups: map[string]int{},
+		},
+		{
+			name: "one count",
+			counts: []model.InsightApplicationCount{
+				{
+					Labels: map[string]string{
+						"KIND":            "KUBERNETES",
+						"ACTIVITY_STATUS": "ENABLED",
+					},
+					Count: 5,
+				},
+			},
+			expectedTotal: 5,
+			expectedGroups: map[string]int{
+				"KUBERNETES": 5,
+			},
+		},
+		{
+			name: "multiple counts",
+			counts: []model.InsightApplicationCount{
+				{
+					Labels: map[string]string{
+						"KIND":            "KUBERNETES",
+						"ACTIVITY_STATUS": "ENABLED",
+					},
+					Count: 5,
+				},
+				{
+					Labels: map[string]string{
+						"KIND":            "KUBERNETES",
+						"ACTIVITY_STATUS": "DISABLED",
+					},
+					Count: 3,
+				},
+				{
+					Labels: map[string]string{
+						"KIND":            "LAMBDA",
+						"ACTIVITY_STATUS": "ENABLED",
+					},
+					Count: 2,
+				},
+			},
+			expectedTotal: 10,
+			expectedGroups: map[string]int{
+				"KUBERNETES": 8,
+				"LAMBDA":     2,
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			total, groups := groupApplicationCounts(tc.counts)
+			assert.Equal(t, tc.expectedTotal, total)
+			assert.Equal(t, tc.expectedGroups, groups)
+		})
+	}
+}
+
+func TestApplicationCountsTmpl(t *testing.T) {
+	testcases := []struct {
+		name        string
+		data        []map[string]interface{}
+		expected    string
+		expectedErr error
+	}{
+		{
+			name: "ok",
+			data: []map[string]interface{}{
+				{
+					"Project": "one-count",
+					"Total":   5,
+					"Counts": map[string]int{
+						"KUBERNETES": 5,
+					},
+				},
+				{
+					"Project": "not-found",
+					"Error":   "No data for this project",
+				},
+				{
+					"Project": "multi-counts",
+					"Total":   20,
+					"Counts": map[string]int{
+						"KUBERNETES": 10,
+						"CLOUD_RUN":  2,
+						"LAMBDA":     8,
+					},
+				},
+			},
+			expected: `<!DOCTYPE html>
+<html>
+<head>
+<style>
+table {
+  font-family: arial, sans-serif;
+  border-collapse: collapse;
+  width: 100%;
+}
+
+td, th {
+  border: 1px solid #dddddd;
+  text-align: left;
+  padding: 8px;
+}
+
+tr:nth-child(1) {
+  background-color: #dddddd;
+}
+</style>
+</head>
+<body>
+
+<h2 style="text-align: center;"><a href="/">Welcome to PipeCD Owner Page!</a></h2>
+
+<h3>There are 3 registered projects</h3>
+<h4>0. one-count</h4>
+
+<table>
+  <tr>
+    <th>Application Kind</th>
+    <th>Count</th>
+  </tr>
+  <tr>
+    <td>KUBERNETES</td>
+    <td>5</td>
+  </tr>
+  <tr>
+    <td>TOTAL</td>
+    <td>5</td>
+  </tr>
+</table>
+
+<h4>1. not-found</h4>
+
+Unable to fetch application counts (No data for this project).
+
+<h4>2. multi-counts</h4>
+
+<table>
+  <tr>
+    <th>Application Kind</th>
+    <th>Count</th>
+  </tr>
+  <tr>
+    <td>CLOUD_RUN</td>
+    <td>2</td>
+  </tr>
+  <tr>
+    <td>KUBERNETES</td>
+    <td>10</td>
+  </tr>
+  <tr>
+    <td>LAMBDA</td>
+    <td>8</td>
+  </tr>
+  <tr>
+    <td>TOTAL</td>
+    <td>20</td>
+  </tr>
+</table>
+
+</body>
+</html>
+`,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			err := applicationCountsTmpl.Execute(&buf, tc.data)
+			assert.Equal(t, tc.expected, buf.String())
+			assert.Equal(t, tc.expectedErr, err)
+		})
+	}
+}

--- a/pkg/app/ops/handler/templates/ApplicationCounts
+++ b/pkg/app/ops/handler/templates/ApplicationCounts
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+table {
+  font-family: arial, sans-serif;
+  border-collapse: collapse;
+  width: 100%;
+}
+
+td, th {
+  border: 1px solid #dddddd;
+  text-align: left;
+  padding: 8px;
+}
+
+tr:nth-child(1) {
+  background-color: #dddddd;
+}
+</style>
+</head>
+<body>
+
+<h2 style="text-align: center;"><a href="/">Welcome to PipeCD Owner Page!</a></h2>
+
+<h3>There are {{ len . }} registered projects</h3>
+{{ range $index, $project := . -}}
+<h4>{{ $index }}. {{ $project.Project }}</h4>
+
+{{ if $project.Error -}}
+Unable to fetch application counts ({{ $project.Error }}).
+{{ else -}}
+<table>
+  <tr>
+    <th>Application Kind</th>
+    <th>Count</th>
+  </tr>
+{{- range $kind, $count := $project.Counts }}
+  <tr>
+    <td>{{ $kind }}</td>
+    <td>{{ $count }}</td>
+  </tr>
+{{- end }}
+  <tr>
+    <td>TOTAL</td>
+    <td>{{ $project.Total }}</td>
+  </tr>
+</table>
+{{ end }}
+{{ end -}}
+</body>
+</html>

--- a/pkg/app/ops/handler/templates/Top
+++ b/pkg/app/ops/handler/templates/Top
@@ -6,6 +6,7 @@
 
 <p><a href="/projects">List Projects</a></p>
 <p><a href="/projects/add">Add Project</a></p>
+<p><a href="/applicationcounts">Application Counts</a></p>
 
 </body>
 </html>


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #1511

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
The operator now can see the number of application of projects
```
