### PR TITLE
Using array-contains instead of array-contains-any

### DIFF
--- a/pkg/datastore/datastore.go
+++ b/pkg/datastore/datastore.go
@@ -36,7 +36,7 @@ const (
 	OperatorGreaterThanOrEqual Operator = ">="
 	OperatorLessThan           Operator = "<"
 	OperatorLessThanOrEqual    Operator = "<="
-	OperatorContains           Operator = "array-contains-any"
+	OperatorContains           Operator = "array-contains"
 )
 
 var (


### PR DESCRIPTION
**What this PR does / why we need it**:

Using `array-contains` instead of `array-contains-any` since the value which be used is a simple string. 

ref: 
- https://github.com/pipe-cd/pipe/blob/master/pkg/app/api/grpcapi/web_api.go#L203-L207
- https://firebase.google.com/docs/firestore/query-data/queries#array_membership

**Which issue(s) this PR fixes**:

Follow PR #2029 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
