### PR TITLE
Fix alerting for deletion of environment

### DIFF
--- a/pkg/app/web/src/mocks/services/environment.ts
+++ b/pkg/app/web/src/mocks/services/environment.ts
@@ -1,14 +1,36 @@
-import { ListEnvironmentsResponse } from "pipe/pkg/app/web/api_client/service_pb";
+import { StatusCode } from "grpc-web";
+import {
+  ListEnvironmentsResponse,
+  DeleteEnvironmentResponse,
+} from "pipe/pkg/app/web/api_client/service_pb";
 import {
   createEnvFromObject,
   dummyEnv,
 } from "../../__fixtures__/dummy-environment";
-import { createHandler } from "../create-handler";
+import { createHandler, createHandlerWithError } from "../create-handler";
 
-export const environmentHandlers = [
-  createHandler<ListEnvironmentsResponse>("/ListEnvironments", () => {
+export const deleteEnvironmentHandler = createHandler<
+  DeleteEnvironmentResponse
+>("/DeleteEnvironment", () => {
+  const response = new DeleteEnvironmentResponse();
+  return response;
+});
+
+export const deleteEnvironmentFailedHandler = createHandlerWithError(
+  "/DeleteEnvironment",
+  StatusCode.FAILED_PRECONDITION
+);
+
+export const listEnvironmentHandler = createHandler<ListEnvironmentsResponse>(
+  "/ListEnvironments",
+  () => {
     const response = new ListEnvironmentsResponse();
     response.setEnvironmentsList([createEnvFromObject(dummyEnv)]);
     return response;
-  }),
+  }
+);
+
+export const environmentHandlers = [
+  listEnvironmentHandler,
+  deleteEnvironmentHandler,
 ];

--- a/pkg/app/web/src/pages/settings/environment/components/delete-confirm-dialog/index.tsx
+++ b/pkg/app/web/src/pages/settings/environment/components/delete-confirm-dialog/index.tsx
@@ -11,16 +11,19 @@ import {
 import { Link as RouterLink } from "react-router-dom";
 import { Alert } from "@material-ui/lab";
 import { FC, memo, useCallback } from "react";
-import { UI_TEXT_CANCEL, UI_TEXT_DELETE } from "../../../../constants/ui-text";
+import {
+  UI_TEXT_CANCEL,
+  UI_TEXT_DELETE,
+} from "../../../../../constants/ui-text";
 import { red } from "@material-ui/core/colors";
 import { shallowEqual } from "react-redux";
 import { useEffect } from "react";
 import {
   fetchApplicationsByEnv,
   selectApplicationsByEnvId,
-} from "../../../../modules/applications";
-import { useAppDispatch, useAppSelector } from "../../../../hooks/redux";
-import { clearTargetEnv } from "../../../../modules/deleting-env";
+} from "../../../../../modules/applications";
+import { useAppDispatch, useAppSelector } from "../../../../../hooks/redux";
+import { clearTargetEnv } from "../../../../../modules/deleting-env";
 
 const useStyles = makeStyles((theme) => ({
   targetName: {

--- a/pkg/app/web/src/pages/settings/environment/index.test.tsx
+++ b/pkg/app/web/src/pages/settings/environment/index.test.tsx
@@ -1,0 +1,92 @@
+import userEvent from "@testing-library/user-event";
+import { render, screen, createReduxStore } from "../../../../test-utils";
+import { SettingsEnvironmentPage } from "./index";
+import { setupServer } from "msw/node";
+import {
+  deleteEnvironmentHandler,
+  listEnvironmentHandler,
+  deleteEnvironmentFailedHandler,
+} from "../../../mocks/services/environment";
+import { waitFor } from "@testing-library/react";
+import { listApplicationsHandler } from "../../../mocks/services/application";
+import { MemoryRouter } from "react-router-dom";
+import { dummyEnv } from "../../../__fixtures__/dummy-environment";
+import { Toasts } from "../../../components/toasts";
+import { DELETE_ENVIRONMENT_SUCCESS } from "../../../constants/toast-text";
+const server = setupServer();
+
+beforeAll(() => {
+  server.listen();
+});
+
+beforeEach(() => {
+  server.use(listEnvironmentHandler, listApplicationsHandler);
+});
+
+afterEach(() => {
+  server.resetHandlers();
+});
+
+afterAll(() => {
+  server.close();
+});
+
+test("Deletion", async () => {
+  server.use(deleteEnvironmentHandler);
+  const store = createReduxStore();
+
+  render(
+    <MemoryRouter>
+      <SettingsEnvironmentPage />
+      <Toasts />
+    </MemoryRouter>,
+    {
+      store,
+    }
+  );
+
+  await waitFor(() => expect(screen.getByText("staging")));
+  userEvent.click(screen.getByRole("button", { name: "open menu" }));
+  const deleteButton = await screen.findByRole("menuitem", { name: /delete/i });
+  userEvent.click(deleteButton);
+
+  await waitFor(() => expect(screen.getByText("Deleting Environment")));
+  expect(
+    screen.getByRole("link", { name: /view applications/i })
+  ).toHaveAttribute("href", `/applications?envId=${dummyEnv.id}`);
+  userEvent.click(await screen.findByRole("button", { name: /delete/i }));
+
+  await waitFor(() =>
+    expect(screen.getByText(DELETE_ENVIRONMENT_SUCCESS)).toBeInTheDocument()
+  );
+});
+
+test("Deletion failure", async () => {
+  server.use(deleteEnvironmentFailedHandler);
+  const store = createReduxStore();
+
+  render(
+    <MemoryRouter>
+      <SettingsEnvironmentPage />
+      <Toasts />
+    </MemoryRouter>,
+    {
+      store,
+    }
+  );
+
+  await waitFor(() => expect(screen.getByText("staging")));
+  userEvent.click(screen.getByRole("button", { name: "open menu" }));
+  const deleteButton = await screen.findByRole("menuitem", { name: /delete/i });
+  userEvent.click(deleteButton);
+
+  await waitFor(() => expect(screen.getByText("Deleting Environment")));
+  userEvent.click(await screen.findByRole("button", { name: /delete/i }));
+
+  await waitFor(() =>
+    expect(screen.getByText("Error Message")).toBeInTheDocument()
+  );
+  expect(
+    screen.queryByText(DELETE_ENVIRONMENT_SUCCESS)
+  ).not.toBeInTheDocument();
+});

--- a/pkg/app/web/src/pages/settings/environment/index.tsx
+++ b/pkg/app/web/src/pages/settings/environment/index.tsx
@@ -12,6 +12,8 @@ import {
   Toolbar,
 } from "@material-ui/core";
 import { Add as AddIcon } from "@material-ui/icons";
+import { unwrapResult } from "@reduxjs/toolkit";
+import { useEffect } from "react";
 import { FC, memo, useCallback, useState } from "react";
 import { AddEnvForm } from "../../../components/add-env-form";
 import { EnvironmentListItem } from "../../../components/environment-list-item";
@@ -48,13 +50,24 @@ export const SettingsEnvironmentPage: FC = memo(
 
     const handleDelete = useCallback(
       async (environmentId: string) => {
-        await dispatch(deleteEnvironment({ environmentId }));
-        dispatch(
-          addToast({ message: DELETE_ENVIRONMENT_SUCCESS, severity: "success" })
-        );
+        dispatch(deleteEnvironment({ environmentId }))
+          .then(unwrapResult)
+          .then(() => {
+            dispatch(
+              addToast({
+                message: DELETE_ENVIRONMENT_SUCCESS,
+                severity: "success",
+              })
+            );
+          })
+          .catch(() => null);
       },
       [dispatch]
     );
+
+    useEffect(() => {
+      dispatch(fetchEnvironments());
+    }, [dispatch]);
 
     return (
       <>

--- a/pkg/app/web/test-utils.tsx
+++ b/pkg/app/web/test-utils.tsx
@@ -14,21 +14,22 @@ import configureMockStore from "redux-mock-store";
 import { reducers } from "./src/modules";
 import type { AppState } from "./src/store";
 import { theme } from "./src/theme";
+import { thunkErrorHandler } from "./src/middlewares/thunk-error-handler";
 
-const middlewares = getDefaultMiddleware({
-  immutableCheck: false,
-  serializableCheck: false,
-});
+const middlewares = [
+  ...getDefaultMiddleware({
+    immutableCheck: false,
+    serializableCheck: false,
+  }),
+  thunkErrorHandler,
+];
 
 export const createReduxStore = (
   preloadedState?: Partial<AppState>
 ): EnhancedStore<AppState, AnyAction, typeof middlewares> => {
   return configureStore({
     reducer: reducers,
-    middleware: getDefaultMiddleware({
-      immutableCheck: false,
-      serializableCheck: false,
-    }),
+    middleware: middlewares,
     preloadedState,
   });
 };

--- a/pkg/app/web/test-utils.tsx
+++ b/pkg/app/web/test-utils.tsx
@@ -16,20 +16,17 @@ import type { AppState } from "./src/store";
 import { theme } from "./src/theme";
 import { thunkErrorHandler } from "./src/middlewares/thunk-error-handler";
 
-const middlewares = [
-  ...getDefaultMiddleware({
-    immutableCheck: false,
-    serializableCheck: false,
-  }),
-  thunkErrorHandler,
-];
+const middlewares = getDefaultMiddleware({
+  immutableCheck: false,
+  serializableCheck: false,
+});
 
 export const createReduxStore = (
   preloadedState?: Partial<AppState>
 ): EnhancedStore<AppState, AnyAction, typeof middlewares> => {
   return configureStore({
     reducer: reducers,
-    middleware: middlewares,
+    middleware: [...middlewares, thunkErrorHandler],
     preloadedState,
   });
 };


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #2036

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Fix success alerts appear when deleting an environment returns failed.
```
