### PR TITLE
Support contains operator for MySQL

### DIFF
--- a/pkg/datastore/mysql/ensurer/indexes.sql
+++ b/pkg/datastore/mysql/ensurer/indexes.sql
@@ -87,6 +87,7 @@ CREATE INDEX event_key_name_project_id_created_at_desc ON Event (EventKey, Name,
 -- Piped table indexes
 --
 
--- index on `EnvIds` ASC
+-- index on `ProjectId` ASC and `EnvIds` ASC
 ALTER TABLE Piped ADD COLUMN EnvIds JSON GENERATED ALWAYS AS (IFNULL(data ->> "$.env_ids", '[]')) VIRTUAL NOT NULL;
-CREATE INDEX piped_project_id_env_ids_asc ON Piped (ProjectId, EnvIds);
+-- TODO: Create index on ProjectId and EnvIds
+-- CREATE INDEX piped_project_id_env_ids_asc ON Piped (ProjectId, (CAST(EnvIds->'$' AS BINARY(16) ARRAY)));

--- a/pkg/datastore/mysql/ensurer/indexes.sql
+++ b/pkg/datastore/mysql/ensurer/indexes.sql
@@ -82,3 +82,11 @@ CREATE INDEX event_project_id_created_at_asc ON Event (ProjectId, CreatedAt);
 -- index on `EventKey` ASC, `Name` ASC, `ProjectId` ASC and `CreatedAt` DESC
 ALTER TABLE Event ADD COLUMN EventKey VARCHAR(64) GENERATED ALWAYS AS (data->>"$.event_key") VIRTUAL NOT NULL, ADD COLUMN Name VARCHAR(50) GENERATED ALWAYS AS (data->>"$.name") VIRTUAL NOT NULL;
 CREATE INDEX event_key_name_project_id_created_at_desc ON Event (EventKey, Name, ProjectId, CreatedAt DESC);
+
+--
+-- Piped table indexes
+--
+
+-- index on `EnvIds` ASC
+ALTER TABLE Piped ADD COLUMN EnvIds JSON GENERATED ALWAYS AS (IFNULL(data ->> "$.env_ids", '[]')) VIRTUAL NOT NULL;
+CREATE INDEX piped_project_id_env_ids_asc ON Piped (ProjectId, EnvIds);

--- a/pkg/datastore/mysql/query.go
+++ b/pkg/datastore/mysql/query.go
@@ -75,7 +75,7 @@ func buildWhereClause(filters []datastore.ListFilter) string {
 			valLength := reflect.ValueOf(filter.Value).Len()
 			conds[i] = fmt.Sprintf("%s %s (?%s)", filter.Field, filter.Operator, strings.Repeat(",?", valLength-1))
 		case "JSON_CONTAINS":
-			conds[i] = fmt.Sprintf("%s(%s, '%q', '$')", filter.Operator, filter.Field, filter.Value)
+			conds[i] = fmt.Sprintf("%s(%s, ?, '$')", filter.Operator, filter.Field)
 		default:
 			conds[i] = fmt.Sprintf("%s %s ?", filter.Field, filter.Operator)
 		}

--- a/pkg/datastore/mysql/query.go
+++ b/pkg/datastore/mysql/query.go
@@ -74,6 +74,8 @@ func buildWhereClause(filters []datastore.ListFilter) string {
 			// Make string of (?,...) which contains the number of `?` equal to the element number of filter.Value
 			valLength := reflect.ValueOf(filter.Value).Len()
 			conds[i] = fmt.Sprintf("%s %s (?%s)", filter.Field, filter.Operator, strings.Repeat(",?", valLength-1))
+		case "JSON_CONTAINS":
+			conds[i] = fmt.Sprintf("%s(%s, '%q', '$')", filter.Operator, filter.Field, filter.Value)
 		default:
 			conds[i] = fmt.Sprintf("%s %s ?", filter.Field, filter.Operator)
 		}
@@ -213,8 +215,7 @@ func refineFiltersOperator(filters []datastore.ListFilter) ([]datastore.ListFilt
 		case datastore.OperatorNotIn:
 			filter.Operator = "NOT IN"
 		case datastore.OperatorContains:
-			// FIXME: Convert contains operator into one dedicated to MySQL
-			return nil, fmt.Errorf("unsupported operator %s", filter.Operator)
+			filter.Operator = "JSON_CONTAINS"
 		case datastore.OperatorNotEqual,
 			datastore.OperatorGreaterThan,
 			datastore.OperatorGreaterThanOrEqual,

--- a/pkg/datastore/mysql/query.go
+++ b/pkg/datastore/mysql/query.go
@@ -74,8 +74,8 @@ func buildWhereClause(filters []datastore.ListFilter) string {
 			// Make string of (?,...) which contains the number of `?` equal to the element number of filter.Value
 			valLength := reflect.ValueOf(filter.Value).Len()
 			conds[i] = fmt.Sprintf("%s %s (?%s)", filter.Field, filter.Operator, strings.Repeat(",?", valLength-1))
-		case "JSON_CONTAINS":
-			conds[i] = fmt.Sprintf("%s(%s, ?, '$')", filter.Operator, filter.Field)
+		case "MEMBER OF":
+			conds[i] = fmt.Sprintf("? %s (%s)", filter.Operator, filter.Field)
 		default:
 			conds[i] = fmt.Sprintf("%s %s ?", filter.Field, filter.Operator)
 		}
@@ -215,7 +215,7 @@ func refineFiltersOperator(filters []datastore.ListFilter) ([]datastore.ListFilt
 		case datastore.OperatorNotIn:
 			filter.Operator = "NOT IN"
 		case datastore.OperatorContains:
-			filter.Operator = "JSON_CONTAINS"
+			filter.Operator = "MEMBER OF"
 		case datastore.OperatorNotEqual,
 			datastore.OperatorGreaterThan,
 			datastore.OperatorGreaterThanOrEqual,

--- a/pkg/datastore/mysql/query_test.go
+++ b/pkg/datastore/mysql/query_test.go
@@ -273,6 +273,20 @@ func TestBuildFindQuery(t *testing.T) {
 			expectedQuery: "SELECT Data FROM Project WHERE Status IN (?,?,?)",
 		},
 		{
+			name: "query with MEMBER OF operator",
+			kind: "Piped",
+			listOptions: datastore.ListOptions{
+				Filters: []datastore.ListFilter{
+					{
+						Field:    "EnvIds",
+						Operator: datastore.OperatorContains,
+						Value:    "xxx",
+					},
+				},
+			},
+			expectedQuery: "SELECT Data FROM Piped WHERE ? MEMBER OF (EnvIds)",
+		},
+		{
 			name: "query with IN operator (one element)",
 			kind: "Project",
 			listOptions: datastore.ListOptions{


### PR DESCRIPTION
**What this PR does / why we need it**:
Indexing on a JSON column didn't go well. Though I'm in the middle of trying to do it, the query works fine without the index.
Let me merge it to support the environment deletion feature in the next version. It's no problem to add index after that version.

**Which issue(s) this PR fixes**:

Fixes https://github.com/pipe-cd/pipe/issues/2033

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
