### PR TITLE
Don't use Deleted as a filtering field

### DIFF
--- a/pkg/app/api/grpcapi/web_api.go
+++ b/pkg/app/api/grpcapi/web_api.go
@@ -158,11 +158,6 @@ func (a *WebAPI) ListEnvironments(ctx context.Context, req *webservice.ListEnvir
 				Operator: datastore.OperatorEqual,
 				Value:    claims.Role.ProjectId,
 			},
-			{
-				Field:    "Deleted",
-				Operator: datastore.OperatorEqual,
-				Value:    false,
-			},
 		},
 	}
 	envs, err := a.environmentStore.ListEnvironments(ctx, opts)
@@ -253,11 +248,6 @@ func (a *WebAPI) DeleteEnvironment(ctx context.Context, req *webservice.DeleteEn
 				Field:    "EnvId",
 				Operator: datastore.OperatorEqual,
 				Value:    req.EnvironmentId,
-			},
-			{
-				Field:    "Deleted",
-				Operator: datastore.OperatorEqual,
-				Value:    false,
 			},
 		},
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:
Deleted field is a newly added one; anything doesn't match with any queries because some entities doesn't have that field. This should be filtered by the web client.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
