### PR TITLE
Filter deleted env to show only active environments on the web

### DIFF
--- a/pkg/app/web/src/__fixtures__/dummy-environment.ts
+++ b/pkg/app/web/src/__fixtures__/dummy-environment.ts
@@ -10,6 +10,8 @@ export const createEnvFromObject = (o: Environment.AsObject): Environment => {
   env.setUpdatedAt(o.updatedAt);
   env.setDeletedAt(o.deletedAt);
   env.setId(o.id);
+  env.setDeleted(o.deleted);
+  env.setDisabled(o.disabled);
   return env;
 };
 
@@ -25,4 +27,11 @@ export const dummyEnv: Environment.AsObject = {
   deletedAt: deletedAt.unix(),
   updatedAt: updatedAt.unix(),
   createdAt: createdAt.unix(),
+};
+
+export const deletedDummyEnv: Environment.AsObject = {
+  ...dummyEnv,
+  id: randomUUID(),
+  deleted: true,
+  disabled: true,
 };

--- a/pkg/app/web/src/components/environment-list-item/index.tsx
+++ b/pkg/app/web/src/components/environment-list-item/index.tsx
@@ -75,7 +75,7 @@ export const EnvironmentListItem: FC<EnvironmentListItemProps> = memo(
       }
     }, [dispatch, env, closeMenu]);
 
-    if (!env || env.deleted) {
+    if (!env) {
       return null;
     }
 

--- a/pkg/app/web/src/mocks/services/environment.ts
+++ b/pkg/app/web/src/mocks/services/environment.ts
@@ -2,18 +2,38 @@ import { StatusCode } from "grpc-web";
 import {
   ListEnvironmentsResponse,
   DeleteEnvironmentResponse,
+  AddEnvironmentResponse,
 } from "pipe/pkg/app/web/api_client/service_pb";
 import {
   createEnvFromObject,
+  deletedDummyEnv,
   dummyEnv,
 } from "../../__fixtures__/dummy-environment";
 import { createHandler, createHandlerWithError } from "../create-handler";
 
+export const listEnvironmentHandler = createHandler<ListEnvironmentsResponse>(
+  "/ListEnvironments",
+  () => {
+    const response = new ListEnvironmentsResponse();
+    response.setEnvironmentsList([
+      createEnvFromObject(dummyEnv),
+      createEnvFromObject(deletedDummyEnv),
+    ]);
+    return response;
+  }
+);
+
+export const addEnvironmentHandler = createHandler<AddEnvironmentResponse>(
+  "/AddEnvironment",
+  () => {
+    return new AddEnvironmentResponse();
+  }
+);
+
 export const deleteEnvironmentHandler = createHandler<
   DeleteEnvironmentResponse
 >("/DeleteEnvironment", () => {
-  const response = new DeleteEnvironmentResponse();
-  return response;
+  return new DeleteEnvironmentResponse();
 });
 
 export const deleteEnvironmentFailedHandler = createHandlerWithError(
@@ -21,16 +41,8 @@ export const deleteEnvironmentFailedHandler = createHandlerWithError(
   StatusCode.FAILED_PRECONDITION
 );
 
-export const listEnvironmentHandler = createHandler<ListEnvironmentsResponse>(
-  "/ListEnvironments",
-  () => {
-    const response = new ListEnvironmentsResponse();
-    response.setEnvironmentsList([createEnvFromObject(dummyEnv)]);
-    return response;
-  }
-);
-
 export const environmentHandlers = [
   listEnvironmentHandler,
   deleteEnvironmentHandler,
+  addEnvironmentHandler,
 ];

--- a/pkg/app/web/src/modules/environments.ts
+++ b/pkg/app/web/src/modules/environments.ts
@@ -63,16 +63,13 @@ export const environmentsSlice = createSlice({
   extraReducers: (builder) => {
     builder
       .addCase(fetchEnvironments.fulfilled, (state, action) => {
-        environmentsAdapter.addMany(state, action.payload);
+        environmentsAdapter.addMany(
+          state,
+          action.payload.filter((env) => env.deleted === false)
+        );
       })
       .addCase(deleteEnvironment.fulfilled, (state, action) => {
-        environmentsAdapter.updateOne(state, {
-          id: action.meta.arg.environmentId,
-          changes: {
-            deleted: true,
-            disabled: true,
-          },
-        });
+        environmentsAdapter.removeOne(state, action.meta.arg.environmentId);
       });
   },
 });


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Fix showing deleted environments on deployments/applications' filter list
```
