### PR TITLE
Add the ability to display deployment without environment

### DIFF
--- a/pkg/app/web/src/components/deployment-item/index.tsx
+++ b/pkg/app/web/src/components/deployment-item/index.tsx
@@ -1,4 +1,5 @@
 import { Box, ListItem, makeStyles, Typography } from "@material-ui/core";
+import Skeleton from "@material-ui/lab/Skeleton/Skeleton";
 import dayjs from "dayjs";
 import { FC, memo } from "react";
 import { Link as RouterLink } from "react-router-dom";
@@ -52,7 +53,7 @@ export const DeploymentItem: FC<DeploymentItemProps> = memo(
     );
     const env = useAppSelector(selectEnvById(deployment?.envId));
 
-    if (!deployment || !env) {
+    if (!deployment) {
       return null;
     }
 
@@ -86,13 +87,17 @@ export const DeploymentItem: FC<DeploymentItemProps> = memo(
             <Typography variant="h6" component="span">
               {deployment.applicationName}
             </Typography>
-            <Typography
-              variant="subtitle2"
-              className={classes.info}
-              component="span"
-            >
-              {env.name}
-            </Typography>
+            {env ? (
+              <Typography
+                variant="subtitle2"
+                className={classes.info}
+                component="span"
+              >
+                {env.name}
+              </Typography>
+            ) : (
+              <Skeleton height={21} width={80} className={classes.info} />
+            )}
             <Typography
               variant="body2"
               color="textSecondary"


### PR DESCRIPTION
**What this PR does / why we need it**:

![image](https://user-images.githubusercontent.com/6136383/120766418-32329580-c555-11eb-9265-cd4b5f77890c.png)

I use the `Skelton` component when the environment is not loaded.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Add the ability to display deployment without environment
```
