### PR TITLE
Unify component story writing style

### DIFF
--- a/pkg/app/web/.scaffdog/component.md
+++ b/pkg/app/web/.scaffdog/component.md
@@ -32,7 +32,7 @@ export const {{ inputs.name | pascal }}: FC<{{ inputs.name | pascal }}Props> = (
 
 ```tsx
 import { {{ inputs.name | pascal }}, {{ inputs.name | pascal }}Props } from "./";
-import { Story } from "@storybook/react/types-6-0";
+import { Story } from "@storybook/react";
 
 export default {
   title: "{{ inputs.name | pascal }}",

--- a/pkg/app/web/src/components/add-application-drawer/index.stories.tsx
+++ b/pkg/app/web/src/components/add-application-drawer/index.stories.tsx
@@ -1,9 +1,8 @@
-import * as React from "react";
-import { AddApplicationDrawer } from "./";
-import { action } from "@storybook/addon-actions";
+import { AddApplicationDrawer, AddApplicationDrawerProps } from "./";
 import { createDecoratorRedux } from "../../../.storybook/redux-decorator";
 import { dummyEnv } from "../../__fixtures__/dummy-environment";
 import { dummyPiped } from "../../__fixtures__/dummy-piped";
+import { Story } from "@storybook/react";
 
 export default {
   title: "APPLICATION/AddApplicationDrawer",
@@ -24,8 +23,18 @@ export default {
       },
     }),
   ],
+  argTypes: {
+    onClose: {
+      action: "onClose",
+    },
+  },
 };
 
-export const overview: React.FC = () => (
-  <AddApplicationDrawer open onClose={action("onClose")} />
+const Template: Story<AddApplicationDrawerProps> = (args) => (
+  <AddApplicationDrawer {...args} />
 );
+
+export const Overview = Template.bind({});
+Overview.args = {
+  open: true,
+};

--- a/pkg/app/web/src/components/add-env-form/index.stories.tsx
+++ b/pkg/app/web/src/components/add-env-form/index.stories.tsx
@@ -1,16 +1,22 @@
-import * as React from "react";
-import { AddEnvForm } from "./";
-import { action } from "@storybook/addon-actions";
+import { Story } from "@storybook/react";
+import { AddEnvForm, AddEnvFormProps } from "./";
 
 export default {
-  title: "SETTINGS/AddEnvForm",
+  title: "Setting/AddEnvForm",
   component: AddEnvForm,
+  argTypes: {
+    onCancel: {
+      action: "onCancel",
+    },
+    onSubmit: {
+      action: "onSubmit",
+    },
+  },
 };
 
-export const overview: React.FC = () => (
-  <AddEnvForm
-    onCancel={action("onCancel")}
-    onSubmit={action("onSubmit")}
-    projectName="project-name"
-  />
-);
+const Template: Story<AddEnvFormProps> = (args) => <AddEnvForm {...args} />;
+
+export const Overview = Template.bind({});
+Overview.args = {
+  projectName: "project-name",
+};

--- a/pkg/app/web/src/components/add-piped-drawer/index.stories.tsx
+++ b/pkg/app/web/src/components/add-piped-drawer/index.stories.tsx
@@ -1,13 +1,12 @@
-import { action } from "@storybook/addon-actions";
-import * as React from "react";
+import { Story } from "@storybook/react";
 import { createDecoratorRedux } from "../../../.storybook/redux-decorator";
 import { dummyEnv } from "../../__fixtures__/dummy-environment";
-import { AddPipedDrawer } from "./";
+import { AddPipedDrawer, AddPipedDrawerProps } from "./";
 
 const env2 = { ...dummyEnv, id: "env-2", name: "development" };
 
 export default {
-  title: "SETTINGS/Piped/AddPipedDrawer",
+  title: "Setting/Piped/AddPipedDrawer",
   component: AddPipedDrawer,
   decorators: [
     createDecoratorRedux({
@@ -20,8 +19,15 @@ export default {
       },
     }),
   ],
+  argTypes: {
+    onClose: {
+      action: "onClose",
+    },
+  },
 };
 
-export const overview: React.FC = () => (
-  <AddPipedDrawer open onClose={action("onClose")} />
+const Template: Story<AddPipedDrawerProps> = (args) => (
+  <AddPipedDrawer {...args} />
 );
+export const Overview = Template.bind({});
+Overview.args = { open: true };

--- a/pkg/app/web/src/components/app-live-state/index.stories.tsx
+++ b/pkg/app/web/src/components/app-live-state/index.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { Story } from "@storybook/react";
 import { Provider } from "react-redux";
 import { createStore } from "../../../test-utils";
 import { dummyApplication } from "../../__fixtures__/dummy-application";
@@ -10,7 +10,7 @@ export default {
   component: AppLiveState,
 };
 
-export const overview: React.FC = () => (
+export const Overview: Story = () => (
   <Provider
     store={createStore({
       applicationLiveState: {
@@ -27,7 +27,7 @@ export const overview: React.FC = () => (
   </Provider>
 );
 
-export const loading: React.FC = () => (
+export const loading: Story = () => (
   <Provider
     store={createStore({
       applicationLiveState: {
@@ -44,7 +44,7 @@ export const loading: React.FC = () => (
   </Provider>
 );
 
-export const refresh: React.FC = () => (
+export const refresh: Story = () => (
   <Provider
     store={createStore({
       applicationLiveState: {
@@ -63,7 +63,7 @@ export const refresh: React.FC = () => (
   </Provider>
 );
 
-export const notAvailable: React.FC = () => (
+export const notAvailable: Story = () => (
   <Provider
     store={createStore({
       applicationLiveState: {

--- a/pkg/app/web/src/components/app-sync-status/index.stories.tsx
+++ b/pkg/app/web/src/components/app-sync-status/index.stories.tsx
@@ -1,25 +1,28 @@
-import * as React from "react";
+import { Story } from "@storybook/react";
 import { dummyApplicationSyncState } from "../../__fixtures__/dummy-application";
 
-import { AppSyncStatus } from "./";
+import { AppSyncStatus, AppSyncStatusProps } from "./";
 
 export default {
   title: "application/AppSyncStatus",
   component: AppSyncStatus,
 };
 
-export const overview: React.FC = () => (
-  <AppSyncStatus deploying={false} syncState={dummyApplicationSyncState} />
+const Template: Story<AppSyncStatusProps> = (args) => (
+  <AppSyncStatus {...args} />
 );
+export const Overview = Template.bind({});
+Overview.args = { deploying: false, syncState: dummyApplicationSyncState };
 
-export const large: React.FC = () => (
-  <AppSyncStatus
-    deploying={false}
-    size="large"
-    syncState={dummyApplicationSyncState}
-  />
-);
+export const Large = Template.bind({});
+Large.args = {
+  deploying: false,
+  size: "large",
+  syncState: dummyApplicationSyncState,
+};
 
-export const deploying: React.FC = () => (
-  <AppSyncStatus deploying={true} syncState={dummyApplicationSyncState} />
-);
+export const Deploying = Template.bind({});
+Large.args = {
+  deploying: true,
+  syncState: dummyApplicationSyncState,
+};

--- a/pkg/app/web/src/components/application-count/index.stories.tsx
+++ b/pkg/app/web/src/components/application-count/index.stories.tsx
@@ -1,4 +1,4 @@
-import { Story } from "@storybook/react/types-6-0";
+import { Story } from "@storybook/react";
 import { ApplicationCount, ApplicationCountProps } from "./";
 
 export default {

--- a/pkg/app/web/src/components/application-detail/index.stories.tsx
+++ b/pkg/app/web/src/components/application-detail/index.stories.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { Provider } from "react-redux";
 import { ApplicationSyncStatus } from "pipe/pkg/app/web/model/application_pb";
 import { createStore } from "../../../test-utils";
@@ -8,7 +7,7 @@ import { dummyEnv } from "../../__fixtures__/dummy-environment";
 import { dummyPiped } from "../../__fixtures__/dummy-piped";
 import { ApplicationDetail } from "./";
 import type { AppState } from "../../store";
-import type { Story } from "@storybook/react/types-6-0";
+import { Story } from "@storybook/react";
 
 const dummyStore: Partial<AppState> = {
   applications: {
@@ -144,7 +143,7 @@ export const LoadingLiveState: Story = () => (
   </Provider>
 );
 
-export const NotAvailable: React.FC = () => (
+export const NotAvailable: Story = () => (
   <Provider
     store={createStore({
       ...dummyStore,

--- a/pkg/app/web/src/components/application-filter/index.stories.tsx
+++ b/pkg/app/web/src/components/application-filter/index.stories.tsx
@@ -1,7 +1,6 @@
-import * as React from "react";
-import { ApplicationFilter } from "./";
-import { action } from "@storybook/addon-actions";
+import { ApplicationFilter, ApplicationFilterProps } from "./";
 import { createDecoratorRedux } from "../../../.storybook/redux-decorator";
+import { Story } from "@storybook/react";
 
 export default {
   title: "APPLICATION/ApplicationFilter",
@@ -26,12 +25,14 @@ export default {
       },
     }),
   ],
+  argTypes: {
+    onChange: { action: "onChange" },
+    onClear: { action: "onClear" },
+  },
 };
 
-export const overview: React.FC = () => (
-  <ApplicationFilter
-    options={{}}
-    onChange={action("onChange")}
-    onClear={action("onClear")}
-  />
+const Template: Story<ApplicationFilterProps> = (args) => (
+  <ApplicationFilter {...args} />
 );
+export const Overview = Template.bind({});
+Overview.args = { options: {} };

--- a/pkg/app/web/src/components/application-list/index.stories.tsx
+++ b/pkg/app/web/src/components/application-list/index.stories.tsx
@@ -2,7 +2,7 @@ import { ApplicationList, ApplicationListProps } from "./";
 import { createDecoratorRedux } from "../../../.storybook/redux-decorator";
 import { dummyApplication } from "../../__fixtures__/dummy-application";
 import { dummyEnv } from "../../__fixtures__/dummy-environment";
-import { Story } from "@storybook/react/types-6-0";
+import { Story } from "@storybook/react";
 
 export default {
   title: "APPLICATION/ApplicationList",

--- a/pkg/app/web/src/components/application-state-view/index.stories.tsx
+++ b/pkg/app/web/src/components/application-state-view/index.stories.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import { ApplicationStateView } from "./";
+import { Story } from "@storybook/react";
 import { createDecoratorRedux } from "../../../.storybook/redux-decorator";
 import { dummyApplicationLiveState } from "../../__fixtures__/dummy-application-live-state";
+import { ApplicationStateView, ApplicationStateViewProps } from "./";
 
 export default {
   title: "APPLICATION/ApplicationStateView",
@@ -18,6 +18,8 @@ export default {
   ],
 };
 
-export const overview: React.FC = () => (
-  <ApplicationStateView applicationId="application-1" />
+const Template: Story<ApplicationStateViewProps> = (args) => (
+  <ApplicationStateView {...args} />
 );
+export const Overview = Template.bind({});
+Overview.args = { applicationId: dummyApplicationLiveState.applicationId };

--- a/pkg/app/web/src/components/approval-stage/index.stories.tsx
+++ b/pkg/app/web/src/components/approval-stage/index.stories.tsx
@@ -1,17 +1,16 @@
-import { action } from "@storybook/addon-actions";
-import * as React from "react";
-import { ApprovalStage } from "./";
+import { Story } from "@storybook/react";
+import { ApprovalStage, ApprovalStageProps } from "./";
 
 export default {
   title: "DEPLOYMENT/Pipeline/ApprovalStage",
   component: ApprovalStage,
+  argTypes: {
+    onClick: { action: "onClick" },
+  },
 };
 
-export const overview: React.FC = () => (
-  <ApprovalStage
-    id="stage-1"
-    name="K8S_CANARY_ROLLOUT"
-    onClick={action("onClick")}
-    active={false}
-  />
+const Template: Story<ApprovalStageProps> = (args) => (
+  <ApprovalStage {...args} />
 );
+export const Overview = Template.bind({});
+Overview.args = { id: "stage-1", name: "K8S_CANARY_ROLLOUT", active: false };

--- a/pkg/app/web/src/components/change-failure-rate-chart/index.stories.tsx
+++ b/pkg/app/web/src/components/change-failure-rate-chart/index.stories.tsx
@@ -1,5 +1,5 @@
 import { Box } from "@material-ui/core";
-import { Story } from "@storybook/react/types-6-0";
+import { Story } from "@storybook/react";
 import { ChangeFailureRateChart, ChangeFailureRateChartProps } from ".";
 
 export default {

--- a/pkg/app/web/src/components/chart-base/index.stories.tsx
+++ b/pkg/app/web/src/components/chart-base/index.stories.tsx
@@ -1,5 +1,5 @@
 import { ChartBase, ChartBaseProps } from "./";
-import { Story } from "@storybook/react/types-6-0";
+import { Story } from "@storybook/react";
 import chartColor from "@material-ui/core/colors/indigo";
 
 export default {

--- a/pkg/app/web/src/components/copy-icon-button/index.stories.tsx
+++ b/pkg/app/web/src/components/copy-icon-button/index.stories.tsx
@@ -1,5 +1,5 @@
 import { CopyIconButton, CopyIconButtonProps } from "./";
-import { Story } from "@storybook/react/types-6-0";
+import { Story } from "@storybook/react";
 import { createDecoratorRedux } from "../../../.storybook/redux-decorator";
 
 export default {

--- a/pkg/app/web/src/components/delete-application-dialog/index.stories.tsx
+++ b/pkg/app/web/src/components/delete-application-dialog/index.stories.tsx
@@ -1,4 +1,4 @@
-import { Story } from "@storybook/react/types-6-0";
+import { Story } from "@storybook/react";
 import { createDecoratorRedux } from "../../../.storybook/redux-decorator";
 import { dummyApplication } from "../../__fixtures__/dummy-application";
 import { DeleteApplicationDialog, DeleteApplicationDialogProps } from "./";

--- a/pkg/app/web/src/components/deployment-config-form/index.stories.tsx
+++ b/pkg/app/web/src/components/deployment-config-form/index.stories.tsx
@@ -1,16 +1,16 @@
-import * as React from "react";
 import { DeploymentConfigForm } from "./";
 import { action } from "@storybook/addon-actions";
 import { createStore } from "../../../test-utils";
 import { Provider } from "react-redux";
 import { dummyDeploymentConfigTemplates } from "../../__fixtures__/dummy-deployment-config";
+import { Story } from "@storybook/react";
 
 export default {
   title: "DEPLOYMENT/DeploymentConfigForm",
   component: DeploymentConfigForm,
 };
 
-export const overview: React.FC = () => (
+export const Overview: Story = () => (
   <Provider
     store={createStore({
       deploymentConfigs: {
@@ -25,7 +25,7 @@ export const overview: React.FC = () => (
   </Provider>
 );
 
-export const loading: React.FC = () => (
+export const loading: Story = () => (
   <Provider store={createStore({})}>
     <DeploymentConfigForm onSkip={action("onSkip")} />
   </Provider>

--- a/pkg/app/web/src/components/deployment-detail/index.stories.tsx
+++ b/pkg/app/web/src/components/deployment-detail/index.stories.tsx
@@ -1,10 +1,10 @@
-import * as React from "react";
 import { createDecoratorRedux } from "../../../.storybook/redux-decorator";
 import { dummyDeployment } from "../../__fixtures__/dummy-deployment";
-import { DeploymentDetail } from "./";
+import { DeploymentDetail, DeploymentDetailProps } from "./";
 import { dummyEnv } from "../../__fixtures__/dummy-environment";
 import { dummyPiped } from "../../__fixtures__/dummy-piped";
 import { DeploymentStatus } from "../../modules/deployments";
+import { Story } from "@storybook/react";
 
 export default {
   title: "DEPLOYMENT/DeploymentDetail",
@@ -40,10 +40,11 @@ export default {
   ],
 };
 
-export const overview: React.FC = () => (
-  <DeploymentDetail deploymentId={dummyDeployment.id} />
+const Template: Story<DeploymentDetailProps> = (args) => (
+  <DeploymentDetail {...args} />
 );
+export const Overview = Template.bind({});
+Overview.args = { deploymentId: dummyDeployment.id };
 
-export const Running: React.FC = () => (
-  <DeploymentDetail deploymentId={dummyDeployment.id + 1} />
-);
+export const Running = Template.bind({});
+Running.args = { deploymentId: dummyDeployment.id + 1 };

--- a/pkg/app/web/src/components/deployment-filter/index.stories.tsx
+++ b/pkg/app/web/src/components/deployment-filter/index.stories.tsx
@@ -1,9 +1,8 @@
-import * as React from "react";
-import { DeploymentFilter } from "./";
+import { DeploymentFilter, DeploymentFilterProps } from "./";
 import { createDecoratorRedux } from "../../../.storybook/redux-decorator";
 import { dummyEnv } from "../../__fixtures__/dummy-environment";
 import { dummyApplication } from "../../__fixtures__/dummy-application";
-import { action } from "@storybook/addon-actions";
+import { Story } from "@storybook/react";
 
 export default {
   title: "DEPLOYMENT/DeploymentFilter",
@@ -25,17 +24,25 @@ export default {
       },
     }),
   ],
+  argTypes: {
+    onChange: {
+      action: "onChange",
+    },
+    onClear: {
+      action: "onClear",
+    },
+  },
 };
 
-export const overview: React.FC = () => (
-  <DeploymentFilter
-    onChange={action("onChange")}
-    onClear={action("onClear")}
-    options={{
-      applicationId: undefined,
-      envId: undefined,
-      kind: undefined,
-      status: undefined,
-    }}
-  />
+const Template: Story<DeploymentFilterProps> = (args) => (
+  <DeploymentFilter {...args} />
 );
+export const Overview = Template.bind({});
+Overview.args = {
+  options: {
+    applicationId: undefined,
+    envId: undefined,
+    kind: undefined,
+    status: undefined,
+  },
+};

--- a/pkg/app/web/src/components/deployment-frequency-chart/index.stories.tsx
+++ b/pkg/app/web/src/components/deployment-frequency-chart/index.stories.tsx
@@ -1,5 +1,5 @@
 import { Box } from "@material-ui/core";
-import { Story } from "@storybook/react/types-6-0";
+import { Story } from "@storybook/react";
 import { DeploymentFrequencyChart, DeploymentFrequencyChartProps } from "./";
 
 export default {

--- a/pkg/app/web/src/components/deployment-item/index.stories.tsx
+++ b/pkg/app/web/src/components/deployment-item/index.stories.tsx
@@ -1,17 +1,17 @@
-import * as React from "react";
 import { DeploymentItem } from "./";
 import { dummyDeployment } from "../../__fixtures__/dummy-deployment";
 import { dummyApplication } from "../../__fixtures__/dummy-application";
 import { dummyEnv } from "../../__fixtures__/dummy-environment";
 import { Provider } from "react-redux";
 import { createStore } from "../../../test-utils";
+import { Story } from "@storybook/react";
 
 export default {
   title: "DEPLOYMENT/DeploymentItem",
   component: DeploymentItem,
 };
 
-export const overview: React.FC = () => (
+export const Overview: Story = () => (
   <Provider
     store={createStore({
       deployments: {
@@ -38,7 +38,7 @@ export const overview: React.FC = () => (
   </Provider>
 );
 
-export const noDescription: React.FC = () => (
+export const noDescription: Story = () => (
   <Provider
     store={createStore({
       deployments: {

--- a/pkg/app/web/src/components/deployment-status-icon/index.stories.tsx
+++ b/pkg/app/web/src/components/deployment-status-icon/index.stories.tsx
@@ -1,19 +1,30 @@
-import * as React from "react";
-import { DeploymentStatusIcon } from "./";
-import { DeploymentStatus } from "pipe/pkg/app/web/model/deployment_pb";
+import { DeploymentStatusIcon, DeploymentStatusIconProps } from "./";
+import { Story } from "@storybook/react";
+import { DeploymentStatus } from "../../modules/deployments";
 
 export default {
   title: "DEPLOYMENT/StatusIcon",
   component: DeploymentStatusIcon,
 };
 
-export const overview: React.FC = () => (
-  <>
-    <DeploymentStatusIcon status={DeploymentStatus.DEPLOYMENT_SUCCESS} />
-    <DeploymentStatusIcon status={DeploymentStatus.DEPLOYMENT_FAILURE} />
-    <DeploymentStatusIcon status={DeploymentStatus.DEPLOYMENT_CANCELLED} />
-    <DeploymentStatusIcon status={DeploymentStatus.DEPLOYMENT_PENDING} />
-    <DeploymentStatusIcon status={DeploymentStatus.DEPLOYMENT_PLANNED} />
-    <DeploymentStatusIcon status={DeploymentStatus.DEPLOYMENT_RUNNING} />
-  </>
+const Template: Story<DeploymentStatusIconProps> = (args) => (
+  <DeploymentStatusIcon {...args} />
 );
+
+export const Success = Template.bind({});
+Success.args = { status: DeploymentStatus.DEPLOYMENT_SUCCESS };
+
+export const Failure = Template.bind({});
+Failure.args = { status: DeploymentStatus.DEPLOYMENT_FAILURE };
+
+export const Cancelled = Template.bind({});
+Cancelled.args = { status: DeploymentStatus.DEPLOYMENT_CANCELLED };
+
+export const Pending = Template.bind({});
+Pending.args = { status: DeploymentStatus.DEPLOYMENT_PENDING };
+
+export const Planned = Template.bind({});
+Planned.args = { status: DeploymentStatus.DEPLOYMENT_PLANNED };
+
+export const Running = Template.bind({});
+Running.args = { status: DeploymentStatus.DEPLOYMENT_RUNNING };

--- a/pkg/app/web/src/components/detail-table-row/index.stories.tsx
+++ b/pkg/app/web/src/components/detail-table-row/index.stories.tsx
@@ -1,11 +1,13 @@
-import * as React from "react";
-import { DetailTableRow } from "./";
+import { Story } from "@storybook/react";
+import { DetailTableRow, DetailTableRowProps } from "./";
 
 export default {
   title: "COMMON/DetailTableRow",
   component: DetailTableRow,
 };
 
-export const overview: React.FC = () => (
-  <DetailTableRow label="piped" value="hello-world" />
+const Template: Story<DetailTableRowProps> = (args) => (
+  <DetailTableRow {...args} />
 );
+export const Overview = Template.bind({});
+Overview.args = { label: "piped", value: "hello-world" };

--- a/pkg/app/web/src/components/diff-view/index.stories.tsx
+++ b/pkg/app/web/src/components/diff-view/index.stories.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import { DiffView } from "./";
+import { Story } from "@storybook/react";
+import { DiffView, DiffViewProps } from "./";
 
 export default {
   title: "DiffView",
@@ -13,4 +13,6 @@ normal
   indent
 `;
 
-export const overview: React.FC = () => <DiffView content={content} />;
+const Template: Story<DiffViewProps> = (args) => <DiffView {...args} />;
+export const Overview = Template.bind({});
+Overview.args = { content };

--- a/pkg/app/web/src/components/disable-api-key-confirm-dialog/index.stories.tsx
+++ b/pkg/app/web/src/components/disable-api-key-confirm-dialog/index.stories.tsx
@@ -1,11 +1,13 @@
-import { action } from "@storybook/addon-actions";
-import * as React from "react";
+import { Story } from "@storybook/react";
 import { createDecoratorRedux } from "../../../.storybook/redux-decorator";
 import { dummyAPIKey } from "../../__fixtures__/dummy-api-key";
-import { DisableAPIKeyConfirmDialog } from "./";
+import {
+  DisableAPIKeyConfirmDialog,
+  DisableAPIKeyConfirmDialogProps,
+} from "./";
 
 export default {
-  title: "SETTINGS/APIKey/DisableAPIKeyConfirmDialog",
+  title: "Setting/APIKey/DisableAPIKeyConfirmDialog",
   component: DisableAPIKeyConfirmDialog,
   decorators: [
     createDecoratorRedux({
@@ -15,12 +17,20 @@ export default {
       },
     }),
   ],
+  argTypes: {
+    onCancel: {
+      action: "onCancel",
+    },
+    onDisable: {
+      action: "onDisable",
+    },
+  },
 };
 
-export const overview: React.FC = () => (
-  <DisableAPIKeyConfirmDialog
-    apiKeyId={dummyAPIKey.id}
-    onCancel={action("onCancel")}
-    onDisable={action("onDisable")}
-  />
+const Template: Story<DisableAPIKeyConfirmDialogProps> = (args) => (
+  <DisableAPIKeyConfirmDialog {...args} />
 );
+export const Overview = Template.bind({});
+Overview.args = {
+  apiKeyId: dummyAPIKey.id,
+};

--- a/pkg/app/web/src/components/edit-application-drawer/index.stories.tsx
+++ b/pkg/app/web/src/components/edit-application-drawer/index.stories.tsx
@@ -1,4 +1,4 @@
-import { Story } from "@storybook/react/types-6-0";
+import { Story } from "@storybook/react";
 import { createDecoratorRedux } from "../../../.storybook/redux-decorator";
 import { dummyApplication } from "../../__fixtures__/dummy-application";
 import { dummyEnv } from "../../__fixtures__/dummy-environment";

--- a/pkg/app/web/src/components/edit-piped-drawer/index.stories.tsx
+++ b/pkg/app/web/src/components/edit-piped-drawer/index.stories.tsx
@@ -1,14 +1,13 @@
-import { action } from "@storybook/addon-actions";
-import * as React from "react";
+import { Story } from "@storybook/react";
 import { createDecoratorRedux } from "../../../.storybook/redux-decorator";
 import { dummyEnv } from "../../__fixtures__/dummy-environment";
 import { dummyPiped } from "../../__fixtures__/dummy-piped";
-import { EditPipedDrawer } from "./";
+import { EditPipedDrawer, EditPipedDrawerProps } from "./";
 
 const env2 = { ...dummyEnv, id: "env-2", name: "development" };
 
 export default {
-  title: "SETTINGS/Piped/EditPipedDrawer",
+  title: "Setting/Piped/EditPipedDrawer",
   component: EditPipedDrawer,
   decorators: [
     createDecoratorRedux({
@@ -27,8 +26,15 @@ export default {
       },
     }),
   ],
+  argTypes: {
+    onClose: {
+      action: "onClose",
+    },
+  },
 };
 
-export const overview: React.FC = () => (
-  <EditPipedDrawer pipedId={dummyPiped.id} onClose={action("onClose")} />
+const Template: Story<EditPipedDrawerProps> = (args) => (
+  <EditPipedDrawer {...args} />
 );
+export const Overview = Template.bind({});
+Overview.args = { pipedId: dummyPiped.id };

--- a/pkg/app/web/src/components/environment-list-item/index.stories.tsx
+++ b/pkg/app/web/src/components/environment-list-item/index.stories.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import { EnvironmentListItem } from "./";
+import { EnvironmentListItem, EnvironmentListItemProps } from "./";
 import { createDecoratorRedux } from "../../../.storybook/redux-decorator";
 import { dummyEnv } from "../../__fixtures__/dummy-environment";
+import { Story } from "@storybook/react";
 
 export default {
   title: "EnvironmentListItem",
@@ -16,8 +16,10 @@ export default {
   ],
 };
 
-export const overview: React.FC = () => (
+const Template: Story<EnvironmentListItemProps> = (args) => (
   <ul style={{ listStyle: "none" }}>
-    <EnvironmentListItem id={dummyEnv.id} />
+    <EnvironmentListItem {...args} />
   </ul>
 );
+export const Overview = Template.bind({});
+Overview.args = { id: dummyEnv.id };

--- a/pkg/app/web/src/components/filter-view/index.stories.tsx
+++ b/pkg/app/web/src/components/filter-view/index.stories.tsx
@@ -1,12 +1,16 @@
-import { action } from "@storybook/addon-actions";
-import * as React from "react";
-import { FilterView } from "./";
+import { Story } from "@storybook/react";
+import { FilterView, FilterViewProps } from "./";
 
 export default {
   title: "FilterView",
   component: FilterView,
+  argTypes: {
+    onClear: {
+      action: "onClear",
+    },
+  },
 };
 
-export const overview: React.FC = () => (
-  <FilterView onClear={action("onClear")}>filter</FilterView>
-);
+const Template: Story<FilterViewProps> = (args) => <FilterView {...args} />;
+export const Overview = Template.bind({});
+Overview.args = {};

--- a/pkg/app/web/src/components/generate-api-key-dialog/index.stories.tsx
+++ b/pkg/app/web/src/components/generate-api-key-dialog/index.stories.tsx
@@ -1,16 +1,21 @@
-import { action } from "@storybook/addon-actions";
-import * as React from "react";
-import { GenerateAPIKeyDialog } from "./";
+import { Story } from "@storybook/react";
+import { GenerateAPIKeyDialog, GenerateAPIKeyDialogProps } from "./";
 
 export default {
-  title: "SETTINGS/APIKey/GenerateAPIKeyDialog",
+  title: "Setting/APIKey/GenerateAPIKeyDialog",
   component: GenerateAPIKeyDialog,
+  argTypes: {
+    onClose: {
+      action: "onClose",
+    },
+    onSubmit: {
+      action: "onSubmit",
+    },
+  },
 };
 
-export const overview: React.FC = () => (
-  <GenerateAPIKeyDialog
-    open
-    onClose={action("onClose")}
-    onSubmit={action("onSubmit")}
-  />
+const Template: Story<GenerateAPIKeyDialogProps> = (args) => (
+  <GenerateAPIKeyDialog {...args} />
 );
+export const Overview = Template.bind({});
+Overview.args = { open: true };

--- a/pkg/app/web/src/components/generated-api-key-dialog/index.stories.tsx
+++ b/pkg/app/web/src/components/generated-api-key-dialog/index.stories.tsx
@@ -1,9 +1,9 @@
-import * as React from "react";
+import { Story } from "@storybook/react";
 import { createDecoratorRedux } from "../../../.storybook/redux-decorator";
 import { GeneratedAPIKeyDialog } from "./";
 
 export default {
-  title: "SETTINGS/APIKey/GeneratedAPIKeyDialog",
+  title: "Setting/APIKey/GeneratedAPIKeyDialog",
   component: GeneratedAPIKeyDialog,
   decorators: [
     createDecoratorRedux({
@@ -21,4 +21,6 @@ export default {
   ],
 };
 
-export const overview: React.FC = () => <GeneratedAPIKeyDialog />;
+const Template: Story = (args) => <GeneratedAPIKeyDialog {...args} />;
+export const Overview = Template.bind({});
+Overview.args = {};

--- a/pkg/app/web/src/components/github-sso-form/index.stories.tsx
+++ b/pkg/app/web/src/components/github-sso-form/index.stories.tsx
@@ -1,11 +1,13 @@
-import * as React from "react";
+import { Story } from "@storybook/react";
 import { createDecoratorRedux } from "../../../.storybook/redux-decorator";
 import { GithubSSOForm } from "./";
 
 export default {
-  title: "SETTINGS/GithubSSOForm",
+  title: "Setting/GithubSSOForm",
   component: GithubSSOForm,
   decorators: [createDecoratorRedux({})],
 };
 
-export const overview: React.FC = () => <GithubSSOForm />;
+const Template: Story = (args) => <GithubSSOForm {...args} />;
+export const Overview = Template.bind({});
+Overview.args = {};

--- a/pkg/app/web/src/components/header/index.stories.tsx
+++ b/pkg/app/web/src/components/header/index.stories.tsx
@@ -1,36 +1,32 @@
-import * as React from "react";
 import { Header } from "./";
 import { createStore } from "../../../test-utils";
 import { Provider } from "react-redux";
 import { Role } from "../../../../../../bazel-bin/pkg/app/web/model/role_pb";
+import { Story } from "@storybook/react";
 
 export default {
   title: "COMMON/Header",
   component: Header,
 };
 
-export const overview: React.FC = () => {
-  const store = createStore({});
-  return (
-    <Provider store={store}>
-      <Header />
-    </Provider>
-  );
-};
+export const Overview: Story = () => (
+  <Provider store={createStore()}>
+    <Header />
+  </Provider>
+);
 
-export const loggedIn: React.FC = () => {
-  const store = createStore({
-    me: {
-      avatarUrl: "",
-      isLogin: true,
-      projectId: "pipecd",
-      projectRole: Role.ProjectRole.ADMIN,
-      subject: "",
-    },
-  });
-  return (
-    <Provider store={store}>
-      <Header />
-    </Provider>
-  );
-};
+export const LoggedIn: Story = () => (
+  <Provider
+    store={createStore({
+      me: {
+        avatarUrl: "",
+        isLogin: true,
+        projectId: "pipecd",
+        projectRole: Role.ProjectRole.ADMIN,
+        subject: "",
+      },
+    })}
+  >
+    <Header />
+  </Provider>
+);

--- a/pkg/app/web/src/components/health-status-icon/index.stories.tsx
+++ b/pkg/app/web/src/components/health-status-icon/index.stories.tsx
@@ -1,12 +1,17 @@
-import * as React from "react";
-import { KubernetesResourceHealthStatusIcon } from "./";
+import {
+  KubernetesResourceHealthStatusIcon,
+  KubernetesResourceHealthStatusIconProps,
+} from "./";
 import { HealthStatus } from "../../modules/applications-live-state";
+import { Story } from "@storybook/react";
 
 export default {
   title: "APPLICATION/HealthStatusIcon",
   component: KubernetesResourceHealthStatusIcon,
 };
 
-export const overview: React.FC = () => (
-  <KubernetesResourceHealthStatusIcon health={HealthStatus.HEALTHY} />
+const Template: Story<KubernetesResourceHealthStatusIconProps> = (args) => (
+  <KubernetesResourceHealthStatusIcon {...args} />
 );
+export const Overview = Template.bind({});
+Overview.args = { health: HealthStatus.HEALTHY };

--- a/pkg/app/web/src/components/health-status-icon/index.tsx
+++ b/pkg/app/web/src/components/health-status-icon/index.tsx
@@ -20,30 +20,38 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-export const KubernetesResourceHealthStatusIcon: FC<{
+export interface KubernetesResourceHealthStatusIconProps {
   health: HealthStatus;
-}> = memo(function HealthStatusIcon({ health }) {
-  const classes = useStyles();
-  switch (health) {
-    case HealthStatus.UNKNOWN:
-      return <UnknownIcon fontSize="small" className={classes.unknown} />;
-    case HealthStatus.HEALTHY:
-      return <FavoriteIcon fontSize="small" className={classes.healthy} />;
-    case HealthStatus.OTHER:
-      return <OtherIcon fontSize="small" className={classes.other} />;
-  }
-});
+}
 
-export const ApplicationHealthStatusIcon: FC<{
-  health: ApplicationLiveStateSnapshot.Status;
-}> = memo(function HealthStatusIcon({ health }) {
-  const classes = useStyles();
-  switch (health) {
-    case ApplicationLiveStateSnapshot.Status.UNKNOWN:
-      return <UnknownIcon className={classes.unknown} />;
-    case ApplicationLiveStateSnapshot.Status.HEALTHY:
-      return <FavoriteIcon className={classes.healthy} />;
-    case ApplicationLiveStateSnapshot.Status.OTHER:
-      return <OtherIcon className={classes.other} />;
+export const KubernetesResourceHealthStatusIcon: FC<KubernetesResourceHealthStatusIconProps> = memo(
+  function HealthStatusIcon({ health }) {
+    const classes = useStyles();
+    switch (health) {
+      case HealthStatus.UNKNOWN:
+        return <UnknownIcon fontSize="small" className={classes.unknown} />;
+      case HealthStatus.HEALTHY:
+        return <FavoriteIcon fontSize="small" className={classes.healthy} />;
+      case HealthStatus.OTHER:
+        return <OtherIcon fontSize="small" className={classes.other} />;
+    }
   }
-});
+);
+
+export interface ApplicationHealthStatusIconProps {
+  health: ApplicationLiveStateSnapshot.Status;
+}
+
+export const ApplicationHealthStatusIcon: FC<ApplicationHealthStatusIconProps> = memo(
+  function HealthStatusIcon({ health }) {
+    const classes = useStyles();
+    switch (health) {
+      case ApplicationLiveStateSnapshot.Status.UNKNOWN:
+        return <UnknownIcon className={classes.unknown} />;
+      case ApplicationLiveStateSnapshot.Status.HEALTHY:
+        return <FavoriteIcon className={classes.healthy} />;
+      case ApplicationLiveStateSnapshot.Status.OTHER:
+        return <OtherIcon className={classes.other} />;
+    }
+  }
+);

--- a/pkg/app/web/src/components/insight-header/index.stories.tsx
+++ b/pkg/app/web/src/components/insight-header/index.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { Story } from "@storybook/react";
 import { createDecoratorRedux } from "../../../.storybook/redux-decorator";
 import { InsightHeader } from "./";
 
@@ -8,4 +8,6 @@ export default {
   decorators: [createDecoratorRedux({})],
 };
 
-export const overview: React.FC = () => <InsightHeader />;
+const Template: Story = (args) => <InsightHeader {...args} />;
+export const Overview = Template.bind({});
+Overview.args = {};

--- a/pkg/app/web/src/components/kubernetes-resource-detail/index.stories.tsx
+++ b/pkg/app/web/src/components/kubernetes-resource-detail/index.stories.tsx
@@ -1,21 +1,26 @@
-import { action } from "@storybook/addon-actions";
-import * as React from "react";
-import { KubernetesResourceDetail } from "./";
+import { Story } from "@storybook/react";
+import { KubernetesResourceDetail, KubernetesResourceDetailProps } from "./";
 
 export default {
   title: "KubernetesResourceDetail",
   component: KubernetesResourceDetail,
+  argTypes: {
+    onClose: {
+      action: "onClose",
+    },
+  },
 };
 
-export const overview: React.FC = () => (
-  <KubernetesResourceDetail
-    resource={{
-      name: "demo-application-9504e8601a",
-      namespace: "default",
-      apiVersion: "apps/v1",
-      healthDescription: "Unimplemented or unknown resource",
-      kind: "Pod",
-    }}
-    onClose={action("onClose")}
-  />
+const Template: Story<KubernetesResourceDetailProps> = (args) => (
+  <KubernetesResourceDetail {...args} />
 );
+export const Overview = Template.bind({});
+Overview.args = {
+  resource: {
+    name: "demo-application-9504e8601a",
+    namespace: "default",
+    apiVersion: "apps/v1",
+    healthDescription: "Unimplemented or unknown resource",
+    kind: "Pod",
+  },
+};

--- a/pkg/app/web/src/components/kubernetes-resource/index.stories.tsx
+++ b/pkg/app/web/src/components/kubernetes-resource/index.stories.tsx
@@ -1,28 +1,33 @@
-import * as React from "react";
-import { KubernetesResource } from "./";
+import { KubernetesResource, KubernetesResourceProps } from "./";
 import { HealthStatus } from "../../modules/applications-live-state";
-import { action } from "@storybook/addon-actions";
+import { Story } from "@storybook/react";
 
 export default {
   title: "APPLICATION/KubernetesResource",
   component: KubernetesResource,
+  argTypes: {
+    onClick: {
+      action: "onClick",
+    },
+  },
 };
 
-export const overview: React.FC = () => (
-  <KubernetesResource
-    resource={{
-      apiVersion: "v1",
-      createdAt: 0,
-      healthStatus: HealthStatus.HEALTHY,
-      healthDescription: "",
-      id: "1",
-      kind: "Pod",
-      name: "resource-1",
-      namespace: "default",
-      ownerIdsList: [],
-      parentIdsList: [],
-      updatedAt: 0,
-    }}
-    onClick={action("onClick")}
-  />
+const Template: Story<KubernetesResourceProps> = (args) => (
+  <KubernetesResource {...args} />
 );
+export const Overview = Template.bind({});
+Overview.args = {
+  resource: {
+    apiVersion: "v1",
+    createdAt: 0,
+    healthStatus: HealthStatus.HEALTHY,
+    healthDescription: "",
+    id: "1",
+    kind: "Pod",
+    name: "resource-1",
+    namespace: "default",
+    ownerIdsList: [],
+    parentIdsList: [],
+    updatedAt: 0,
+  },
+};

--- a/pkg/app/web/src/components/kubernetes-state-view/index.stories.tsx
+++ b/pkg/app/web/src/components/kubernetes-state-view/index.stories.tsx
@@ -1,12 +1,14 @@
-import * as React from "react";
+import { Story } from "@storybook/react";
 import { resourcesList } from "../../__fixtures__/dummy-application-live-state";
-import { KubernetesStateView } from "./";
+import { KubernetesStateView, KubernetesStateViewProps } from "./";
 
 export default {
   title: "APPLICATION/KubernetesStateView",
   component: KubernetesStateView,
 };
 
-export const overview: React.FC = () => (
-  <KubernetesStateView resources={resourcesList} />
+const Template: Story<KubernetesStateViewProps> = (args) => (
+  <KubernetesStateView {...args} />
 );
+export const Overview = Template.bind({});
+Overview.args = { resources: resourcesList };

--- a/pkg/app/web/src/components/log-viewer/index.stories.tsx
+++ b/pkg/app/web/src/components/log-viewer/index.stories.tsx
@@ -1,9 +1,9 @@
-import * as React from "react";
 import { LogViewer } from "./";
 import { createDecoratorRedux } from "../../../.storybook/redux-decorator";
 import { LogSeverity, createActiveStageKey } from "../../modules/stage-logs";
 import { dummyDeployment } from "../../__fixtures__/dummy-deployment";
 import { dummyPipelineStage } from "../../__fixtures__/dummy-pipeline";
+import { Story } from "@storybook/react";
 
 export default {
   title: "DEPLOYMENT/LogViewer",
@@ -55,8 +55,10 @@ export default {
   ],
 };
 
-export const overview: React.FC = () => (
+const Template: Story = (args) => (
   <div style={{ position: "relative", height: "100vh" }}>
-    <LogViewer />
+    <LogViewer {...args} />
   </div>
 );
+export const Overview = Template.bind({});
+Overview.args = {};

--- a/pkg/app/web/src/components/log/index.stories.tsx
+++ b/pkg/app/web/src/components/log/index.stories.tsx
@@ -1,131 +1,127 @@
-import * as React from "react";
-import { Log } from "./";
+import { Log, LogProps } from "./";
 import { LogSeverity } from "../../modules/stage-logs";
+import { Story } from "@storybook/react";
 
 export default {
   title: "DEPLOYMENT/Log",
   component: Log,
 };
 
-export const overview: React.FC = () => (
-  <Log
-    logs={[
-      "Hello, World",
-      "Hello, World",
-      "Hello, World",
+const Template: Story<LogProps> = (args) => <Log {...args} />;
+
+export const Overview = Template.bind({});
+Overview.args = {
+  logs: [
+    "Hello, World",
+    "Hello, World",
+    "Hello, World",
+    "Hello, World!Hello, World!Hello, World!Hello, World!Hello, World!" +
       "Hello, World!Hello, World!Hello, World!Hello, World!Hello, World!" +
-        "Hello, World!Hello, World!Hello, World!Hello, World!Hello, World!" +
-        "Hello, World!Hello, World!Hello, World!Hello, World!Hello, World!" +
-        "Hello, World!Hello, World!Hello, World!Hello, World!Hello, World!" +
-        "Hello, World!Hello, World!Hello, World!Hello, World!Hello, World!Hello, World!Hello, World!",
-      "Hello, World",
-    ].map((v, i) => ({
-      log: v,
-      index: i,
-      severity: LogSeverity.INFO,
-      createdAt: 0,
-    }))}
-    loading={false}
-  />
-);
-
-export const severity: React.FC = () => (
-  <Log
-    logs={["Hello, World", "Hello, World", "Hello, World"].map((v, i) => ({
-      log: v,
-      index: i,
-      severity: i,
-      createdAt: 0,
-    }))}
-    loading={false}
-  />
-);
-
-export const loading: React.FC = () => (
-  <Log
-    logs={["Hello, World", "Hello, World", "Hello, World", "Hello, World"].map(
-      (v, i) => ({
-        log: v,
-        index: i,
-        severity: LogSeverity.INFO,
-        createdAt: 0,
-      })
-    )}
-    loading
-  />
-);
-
-export const wordWrap: React.FC = () => (
-  <Log
-    logs={[
-      "Hello, World",
-      "Hello, World",
-      "Hello, World",
       "Hello, World!Hello, World!Hello, World!Hello, World!Hello, World!" +
-        "Hello, World!Hello, World!Hello, World!Hello, World!Hello, World!" +
-        "Hello, World!Hello, World!Hello, World!Hello, World!Hello, World!" +
-        "Hello, World!Hello, World!Hello, World!Hello, World!Hello, World!" +
-        "Hello, World!Hello, World!Hello, World!Hello, World!Hello, World!Hello, World!Hello, World!",
-      "Hello, World",
-    ].map((v, i) => ({
-      log: v,
-      index: i,
-      severity: LogSeverity.INFO,
-      createdAt: 0,
-    }))}
-    loading={false}
-  />
-);
+      "Hello, World!Hello, World!Hello, World!Hello, World!Hello, World!" +
+      "Hello, World!Hello, World!Hello, World!Hello, World!Hello, World!Hello, World!Hello, World!",
+    "Hello, World",
+  ].map((v, i) => ({
+    log: v,
+    index: i,
+    severity: LogSeverity.INFO,
+    createdAt: 0,
+  })),
+  loading: false,
+};
 
-export const ansiCodes: React.FC = () => (
-  <Log
-    logs={[
-      "\u001b[30m A \u001b[31m B \u001b[32m C \u001b[33m D \u001b[0m",
-      "\u001b[34m E \u001b[35m F \u001b[36m G \u001b[37m H \u001b[0m",
-      "\u001b[40m A \u001b[41m B \u001b[42m C \u001b[43m D \u001b[0m",
-      "\u001b[44m A \u001b[45m B \u001b[46m C \u001b[47m D \u001b[0m",
-      "\u001b[1m BOLD \u001b[0m\u001b[4m Underline \u001b[0m\u001b[7m Reversed \u001b[0m",
-      "\u001b[1m\u001b[4m\u001b[7m BOLD Underline Reversed \u001b[0m",
-      "\u001b[1m\u001b[31m Red Bold \u001b[0m",
-      "\u001b[4m\u001b[44m Blue Background Underline \u001b[0m",
-    ].map((v, i) => ({
-      log: v,
-      index: i,
-      severity: LogSeverity.INFO,
-      createdAt: 0,
-    }))}
-    loading={false}
-  />
-);
+export const Severity = Template.bind({});
+Severity.args = {
+  logs: ["Hello, World", "Hello, World", "Hello, World"].map((v, i) => ({
+    log: v,
+    index: i,
+    severity: i,
+    createdAt: 0,
+  })),
+  loading: false,
+};
 
-export const allColors: React.FC = () => (
-  <Log
-    logs={[
-      "                 40m     41m     42m     43m     44m     45m     46m     47m",
-      "     m \u001b[m  gYw   \u001b[m\u001b[40m  gYw  \u001b[0m \u001b[m\u001b[41m  gYw  \u001b[0m \u001b[m\u001b[42m  gYw  \u001b[0m \u001b[m\u001b[43m  gYw  \u001b[0m \u001b[m\u001b[44m  gYw  \u001b[0m \u001b[m\u001b[45m  gYw  \u001b[0m \u001b[m\u001b[46m  gYw  \u001b[0m \u001b[m\u001b[47m  gYw  \u001b[0m",
-      "    1m \u001b[1m  gYw   \u001b[1m\u001b[40m  gYw  \u001b[0m \u001b[1m\u001b[41m  gYw  \u001b[0m \u001b[1m\u001b[42m  gYw  \u001b[0m \u001b[1m\u001b[43m  gYw  \u001b[0m \u001b[1m\u001b[44m  gYw  \u001b[0m \u001b[1m\u001b[45m  gYw  \u001b[0m \u001b[1m\u001b[46m  gYw  \u001b[0m \u001b[1m\u001b[47m  gYw  \u001b[0m",
-      "   30m \u001b[30m  gYw   \u001b[30m\u001b[40m  gYw  \u001b[0m \u001b[30m\u001b[41m  gYw  \u001b[0m \u001b[30m\u001b[42m  gYw  \u001b[0m \u001b[30m\u001b[43m  gYw  \u001b[0m \u001b[30m\u001b[44m  gYw  \u001b[0m \u001b[30m\u001b[45m  gYw  \u001b[0m \u001b[30m\u001b[46m  gYw  \u001b[0m \u001b[30m\u001b[47m  gYw  \u001b[0m",
-      " 1;30m \u001b[1;30m  gYw   \u001b[1;30m\u001b[40m  gYw  \u001b[0m \u001b[1;30m\u001b[41m  gYw  \u001b[0m \u001b[1;30m\u001b[42m  gYw  \u001b[0m \u001b[1;30m\u001b[43m  gYw  \u001b[0m \u001b[1;30m\u001b[44m  gYw  \u001b[0m \u001b[1;30m\u001b[45m  gYw  \u001b[0m \u001b[1;30m\u001b[46m  gYw  \u001b[0m \u001b[1;30m\u001b[47m  gYw  \u001b[0m",
-      "   31m \u001b[31m  gYw   \u001b[31m\u001b[40m  gYw  \u001b[0m \u001b[31m\u001b[41m  gYw  \u001b[0m \u001b[31m\u001b[42m  gYw  \u001b[0m \u001b[31m\u001b[43m  gYw  \u001b[0m \u001b[31m\u001b[44m  gYw  \u001b[0m \u001b[31m\u001b[45m  gYw  \u001b[0m \u001b[31m\u001b[46m  gYw  \u001b[0m \u001b[31m\u001b[47m  gYw  \u001b[0m",
-      " 1;31m \u001b[1;31m  gYw   \u001b[1;31m\u001b[40m  gYw  \u001b[0m \u001b[1;31m\u001b[41m  gYw  \u001b[0m \u001b[1;31m\u001b[42m  gYw  \u001b[0m \u001b[1;31m\u001b[43m  gYw  \u001b[0m \u001b[1;31m\u001b[44m  gYw  \u001b[0m \u001b[1;31m\u001b[45m  gYw  \u001b[0m \u001b[1;31m\u001b[46m  gYw  \u001b[0m \u001b[1;31m\u001b[47m  gYw  \u001b[0m",
-      "   32m \u001b[32m  gYw   \u001b[32m\u001b[40m  gYw  \u001b[0m \u001b[32m\u001b[41m  gYw  \u001b[0m \u001b[32m\u001b[42m  gYw  \u001b[0m \u001b[32m\u001b[43m  gYw  \u001b[0m \u001b[32m\u001b[44m  gYw  \u001b[0m \u001b[32m\u001b[45m  gYw  \u001b[0m \u001b[32m\u001b[46m  gYw  \u001b[0m \u001b[32m\u001b[47m  gYw  \u001b[0m",
-      " 1;32m \u001b[1;32m  gYw   \u001b[1;32m\u001b[40m  gYw  \u001b[0m \u001b[1;32m\u001b[41m  gYw  \u001b[0m \u001b[1;32m\u001b[42m  gYw  \u001b[0m \u001b[1;32m\u001b[43m  gYw  \u001b[0m \u001b[1;32m\u001b[44m  gYw  \u001b[0m \u001b[1;32m\u001b[45m  gYw  \u001b[0m \u001b[1;32m\u001b[46m  gYw  \u001b[0m \u001b[1;32m\u001b[47m  gYw  \u001b[0m",
-      "   33m \u001b[33m  gYw   \u001b[33m\u001b[40m  gYw  \u001b[0m \u001b[33m\u001b[41m  gYw  \u001b[0m \u001b[33m\u001b[42m  gYw  \u001b[0m \u001b[33m\u001b[43m  gYw  \u001b[0m \u001b[33m\u001b[44m  gYw  \u001b[0m \u001b[33m\u001b[45m  gYw  \u001b[0m \u001b[33m\u001b[46m  gYw  \u001b[0m \u001b[33m\u001b[47m  gYw  \u001b[0m",
-      " 1;33m \u001b[1;33m  gYw   \u001b[1;33m\u001b[40m  gYw  \u001b[0m \u001b[1;33m\u001b[41m  gYw  \u001b[0m \u001b[1;33m\u001b[42m  gYw  \u001b[0m \u001b[1;33m\u001b[43m  gYw  \u001b[0m \u001b[1;33m\u001b[44m  gYw  \u001b[0m \u001b[1;33m\u001b[45m  gYw  \u001b[0m \u001b[1;33m\u001b[46m  gYw  \u001b[0m \u001b[1;33m\u001b[47m  gYw  \u001b[0m",
-      "   34m \u001b[34m  gYw   \u001b[34m\u001b[40m  gYw  \u001b[0m \u001b[34m\u001b[41m  gYw  \u001b[0m \u001b[34m\u001b[42m  gYw  \u001b[0m \u001b[34m\u001b[43m  gYw  \u001b[0m \u001b[34m\u001b[44m  gYw  \u001b[0m \u001b[34m\u001b[45m  gYw  \u001b[0m \u001b[34m\u001b[46m  gYw  \u001b[0m \u001b[34m\u001b[47m  gYw  \u001b[0m",
-      " 1;34m \u001b[1;34m  gYw   \u001b[1;34m\u001b[40m  gYw  \u001b[0m \u001b[1;34m\u001b[41m  gYw  \u001b[0m \u001b[1;34m\u001b[42m  gYw  \u001b[0m \u001b[1;34m\u001b[43m  gYw  \u001b[0m \u001b[1;34m\u001b[44m  gYw  \u001b[0m \u001b[1;34m\u001b[45m  gYw  \u001b[0m \u001b[1;34m\u001b[46m  gYw  \u001b[0m \u001b[1;34m\u001b[47m  gYw  \u001b[0m",
-      "   35m \u001b[35m  gYw   \u001b[35m\u001b[40m  gYw  \u001b[0m \u001b[35m\u001b[41m  gYw  \u001b[0m \u001b[35m\u001b[42m  gYw  \u001b[0m \u001b[35m\u001b[43m  gYw  \u001b[0m \u001b[35m\u001b[44m  gYw  \u001b[0m \u001b[35m\u001b[45m  gYw  \u001b[0m \u001b[35m\u001b[46m  gYw  \u001b[0m \u001b[35m\u001b[47m  gYw  \u001b[0m",
-      " 1;35m \u001b[1;35m  gYw   \u001b[1;35m\u001b[40m  gYw  \u001b[0m \u001b[1;35m\u001b[41m  gYw  \u001b[0m \u001b[1;35m\u001b[42m  gYw  \u001b[0m \u001b[1;35m\u001b[43m  gYw  \u001b[0m \u001b[1;35m\u001b[44m  gYw  \u001b[0m \u001b[1;35m\u001b[45m  gYw  \u001b[0m \u001b[1;35m\u001b[46m  gYw  \u001b[0m \u001b[1;35m\u001b[47m  gYw  \u001b[0m",
-      "   36m \u001b[36m  gYw   \u001b[36m\u001b[40m  gYw  \u001b[0m \u001b[36m\u001b[41m  gYw  \u001b[0m \u001b[36m\u001b[42m  gYw  \u001b[0m \u001b[36m\u001b[43m  gYw  \u001b[0m \u001b[36m\u001b[44m  gYw  \u001b[0m \u001b[36m\u001b[45m  gYw  \u001b[0m \u001b[36m\u001b[46m  gYw  \u001b[0m \u001b[36m\u001b[47m  gYw  \u001b[0m",
-      " 1;36m \u001b[1;36m  gYw   \u001b[1;36m\u001b[40m  gYw  \u001b[0m \u001b[1;36m\u001b[41m  gYw  \u001b[0m \u001b[1;36m\u001b[42m  gYw  \u001b[0m \u001b[1;36m\u001b[43m  gYw  \u001b[0m \u001b[1;36m\u001b[44m  gYw  \u001b[0m \u001b[1;36m\u001b[45m  gYw  \u001b[0m \u001b[1;36m\u001b[46m  gYw  \u001b[0m \u001b[1;36m\u001b[47m  gYw  \u001b[0m",
-      "   37m \u001b[37m  gYw   \u001b[37m\u001b[40m  gYw  \u001b[0m \u001b[37m\u001b[41m  gYw  \u001b[0m \u001b[37m\u001b[42m  gYw  \u001b[0m \u001b[37m\u001b[43m  gYw  \u001b[0m \u001b[37m\u001b[44m  gYw  \u001b[0m \u001b[37m\u001b[45m  gYw  \u001b[0m \u001b[37m\u001b[46m  gYw  \u001b[0m \u001b[37m\u001b[47m  gYw  \u001b[0m",
-      " 1;37m \u001b[1;37m  gYw   \u001b[1;37m\u001b[40m  gYw  \u001b[0m \u001b[1;37m\u001b[41m  gYw  \u001b[0m \u001b[1;37m\u001b[42m  gYw  \u001b[0m \u001b[1;37m\u001b[43m  gYw  \u001b[0m \u001b[1;37m\u001b[44m  gYw  \u001b[0m \u001b[1;37m\u001b[45m  gYw  \u001b[0m \u001b[1;37m\u001b[46m  gYw  \u001b[0m \u001b[1;37m\u001b[47m  gYw  \u001b[0m",
-    ].map((v, i) => ({
+export const Loading = Template.bind({});
+Loading.args = {
+  logs: ["Hello, World", "Hello, World", "Hello, World", "Hello, World"].map(
+    (v, i) => ({
       log: v,
       index: i,
       severity: LogSeverity.INFO,
       createdAt: 0,
-    }))}
-    loading={false}
-  />
-);
+    })
+  ),
+  loading: true,
+};
+
+export const WordWrap = Template.bind({});
+WordWrap.args = {
+  logs: [
+    "Hello, World",
+    "Hello, World",
+    "Hello, World",
+    "Hello, World!Hello, World!Hello, World!Hello, World!Hello, World!" +
+      "Hello, World!Hello, World!Hello, World!Hello, World!Hello, World!" +
+      "Hello, World!Hello, World!Hello, World!Hello, World!Hello, World!" +
+      "Hello, World!Hello, World!Hello, World!Hello, World!Hello, World!" +
+      "Hello, World!Hello, World!Hello, World!Hello, World!Hello, World!Hello, World!Hello, World!",
+    "Hello, World",
+  ].map((v, i) => ({
+    log: v,
+    index: i,
+    severity: LogSeverity.INFO,
+    createdAt: 0,
+  })),
+  loading: false,
+};
+
+export const AnsiCodes = Template.bind({});
+AnsiCodes.args = {
+  logs: [
+    "\u001b[30m A \u001b[31m B \u001b[32m C \u001b[33m D \u001b[0m",
+    "\u001b[34m E \u001b[35m F \u001b[36m G \u001b[37m H \u001b[0m",
+    "\u001b[40m A \u001b[41m B \u001b[42m C \u001b[43m D \u001b[0m",
+    "\u001b[44m A \u001b[45m B \u001b[46m C \u001b[47m D \u001b[0m",
+    "\u001b[1m BOLD \u001b[0m\u001b[4m Underline \u001b[0m\u001b[7m Reversed \u001b[0m",
+    "\u001b[1m\u001b[4m\u001b[7m BOLD Underline Reversed \u001b[0m",
+    "\u001b[1m\u001b[31m Red Bold \u001b[0m",
+    "\u001b[4m\u001b[44m Blue Background Underline \u001b[0m",
+  ].map((v, i) => ({
+    log: v,
+    index: i,
+    severity: LogSeverity.INFO,
+    createdAt: 0,
+  })),
+  loading: false,
+};
+
+export const AllColors = Template.bind({});
+AllColors.args = {
+  logs: [
+    "                 40m     41m     42m     43m     44m     45m     46m     47m",
+    "     m \u001b[m  gYw   \u001b[m\u001b[40m  gYw  \u001b[0m \u001b[m\u001b[41m  gYw  \u001b[0m \u001b[m\u001b[42m  gYw  \u001b[0m \u001b[m\u001b[43m  gYw  \u001b[0m \u001b[m\u001b[44m  gYw  \u001b[0m \u001b[m\u001b[45m  gYw  \u001b[0m \u001b[m\u001b[46m  gYw  \u001b[0m \u001b[m\u001b[47m  gYw  \u001b[0m",
+    "    1m \u001b[1m  gYw   \u001b[1m\u001b[40m  gYw  \u001b[0m \u001b[1m\u001b[41m  gYw  \u001b[0m \u001b[1m\u001b[42m  gYw  \u001b[0m \u001b[1m\u001b[43m  gYw  \u001b[0m \u001b[1m\u001b[44m  gYw  \u001b[0m \u001b[1m\u001b[45m  gYw  \u001b[0m \u001b[1m\u001b[46m  gYw  \u001b[0m \u001b[1m\u001b[47m  gYw  \u001b[0m",
+    "   30m \u001b[30m  gYw   \u001b[30m\u001b[40m  gYw  \u001b[0m \u001b[30m\u001b[41m  gYw  \u001b[0m \u001b[30m\u001b[42m  gYw  \u001b[0m \u001b[30m\u001b[43m  gYw  \u001b[0m \u001b[30m\u001b[44m  gYw  \u001b[0m \u001b[30m\u001b[45m  gYw  \u001b[0m \u001b[30m\u001b[46m  gYw  \u001b[0m \u001b[30m\u001b[47m  gYw  \u001b[0m",
+    " 1;30m \u001b[1;30m  gYw   \u001b[1;30m\u001b[40m  gYw  \u001b[0m \u001b[1;30m\u001b[41m  gYw  \u001b[0m \u001b[1;30m\u001b[42m  gYw  \u001b[0m \u001b[1;30m\u001b[43m  gYw  \u001b[0m \u001b[1;30m\u001b[44m  gYw  \u001b[0m \u001b[1;30m\u001b[45m  gYw  \u001b[0m \u001b[1;30m\u001b[46m  gYw  \u001b[0m \u001b[1;30m\u001b[47m  gYw  \u001b[0m",
+    "   31m \u001b[31m  gYw   \u001b[31m\u001b[40m  gYw  \u001b[0m \u001b[31m\u001b[41m  gYw  \u001b[0m \u001b[31m\u001b[42m  gYw  \u001b[0m \u001b[31m\u001b[43m  gYw  \u001b[0m \u001b[31m\u001b[44m  gYw  \u001b[0m \u001b[31m\u001b[45m  gYw  \u001b[0m \u001b[31m\u001b[46m  gYw  \u001b[0m \u001b[31m\u001b[47m  gYw  \u001b[0m",
+    " 1;31m \u001b[1;31m  gYw   \u001b[1;31m\u001b[40m  gYw  \u001b[0m \u001b[1;31m\u001b[41m  gYw  \u001b[0m \u001b[1;31m\u001b[42m  gYw  \u001b[0m \u001b[1;31m\u001b[43m  gYw  \u001b[0m \u001b[1;31m\u001b[44m  gYw  \u001b[0m \u001b[1;31m\u001b[45m  gYw  \u001b[0m \u001b[1;31m\u001b[46m  gYw  \u001b[0m \u001b[1;31m\u001b[47m  gYw  \u001b[0m",
+    "   32m \u001b[32m  gYw   \u001b[32m\u001b[40m  gYw  \u001b[0m \u001b[32m\u001b[41m  gYw  \u001b[0m \u001b[32m\u001b[42m  gYw  \u001b[0m \u001b[32m\u001b[43m  gYw  \u001b[0m \u001b[32m\u001b[44m  gYw  \u001b[0m \u001b[32m\u001b[45m  gYw  \u001b[0m \u001b[32m\u001b[46m  gYw  \u001b[0m \u001b[32m\u001b[47m  gYw  \u001b[0m",
+    " 1;32m \u001b[1;32m  gYw   \u001b[1;32m\u001b[40m  gYw  \u001b[0m \u001b[1;32m\u001b[41m  gYw  \u001b[0m \u001b[1;32m\u001b[42m  gYw  \u001b[0m \u001b[1;32m\u001b[43m  gYw  \u001b[0m \u001b[1;32m\u001b[44m  gYw  \u001b[0m \u001b[1;32m\u001b[45m  gYw  \u001b[0m \u001b[1;32m\u001b[46m  gYw  \u001b[0m \u001b[1;32m\u001b[47m  gYw  \u001b[0m",
+    "   33m \u001b[33m  gYw   \u001b[33m\u001b[40m  gYw  \u001b[0m \u001b[33m\u001b[41m  gYw  \u001b[0m \u001b[33m\u001b[42m  gYw  \u001b[0m \u001b[33m\u001b[43m  gYw  \u001b[0m \u001b[33m\u001b[44m  gYw  \u001b[0m \u001b[33m\u001b[45m  gYw  \u001b[0m \u001b[33m\u001b[46m  gYw  \u001b[0m \u001b[33m\u001b[47m  gYw  \u001b[0m",
+    " 1;33m \u001b[1;33m  gYw   \u001b[1;33m\u001b[40m  gYw  \u001b[0m \u001b[1;33m\u001b[41m  gYw  \u001b[0m \u001b[1;33m\u001b[42m  gYw  \u001b[0m \u001b[1;33m\u001b[43m  gYw  \u001b[0m \u001b[1;33m\u001b[44m  gYw  \u001b[0m \u001b[1;33m\u001b[45m  gYw  \u001b[0m \u001b[1;33m\u001b[46m  gYw  \u001b[0m \u001b[1;33m\u001b[47m  gYw  \u001b[0m",
+    "   34m \u001b[34m  gYw   \u001b[34m\u001b[40m  gYw  \u001b[0m \u001b[34m\u001b[41m  gYw  \u001b[0m \u001b[34m\u001b[42m  gYw  \u001b[0m \u001b[34m\u001b[43m  gYw  \u001b[0m \u001b[34m\u001b[44m  gYw  \u001b[0m \u001b[34m\u001b[45m  gYw  \u001b[0m \u001b[34m\u001b[46m  gYw  \u001b[0m \u001b[34m\u001b[47m  gYw  \u001b[0m",
+    " 1;34m \u001b[1;34m  gYw   \u001b[1;34m\u001b[40m  gYw  \u001b[0m \u001b[1;34m\u001b[41m  gYw  \u001b[0m \u001b[1;34m\u001b[42m  gYw  \u001b[0m \u001b[1;34m\u001b[43m  gYw  \u001b[0m \u001b[1;34m\u001b[44m  gYw  \u001b[0m \u001b[1;34m\u001b[45m  gYw  \u001b[0m \u001b[1;34m\u001b[46m  gYw  \u001b[0m \u001b[1;34m\u001b[47m  gYw  \u001b[0m",
+    "   35m \u001b[35m  gYw   \u001b[35m\u001b[40m  gYw  \u001b[0m \u001b[35m\u001b[41m  gYw  \u001b[0m \u001b[35m\u001b[42m  gYw  \u001b[0m \u001b[35m\u001b[43m  gYw  \u001b[0m \u001b[35m\u001b[44m  gYw  \u001b[0m \u001b[35m\u001b[45m  gYw  \u001b[0m \u001b[35m\u001b[46m  gYw  \u001b[0m \u001b[35m\u001b[47m  gYw  \u001b[0m",
+    " 1;35m \u001b[1;35m  gYw   \u001b[1;35m\u001b[40m  gYw  \u001b[0m \u001b[1;35m\u001b[41m  gYw  \u001b[0m \u001b[1;35m\u001b[42m  gYw  \u001b[0m \u001b[1;35m\u001b[43m  gYw  \u001b[0m \u001b[1;35m\u001b[44m  gYw  \u001b[0m \u001b[1;35m\u001b[45m  gYw  \u001b[0m \u001b[1;35m\u001b[46m  gYw  \u001b[0m \u001b[1;35m\u001b[47m  gYw  \u001b[0m",
+    "   36m \u001b[36m  gYw   \u001b[36m\u001b[40m  gYw  \u001b[0m \u001b[36m\u001b[41m  gYw  \u001b[0m \u001b[36m\u001b[42m  gYw  \u001b[0m \u001b[36m\u001b[43m  gYw  \u001b[0m \u001b[36m\u001b[44m  gYw  \u001b[0m \u001b[36m\u001b[45m  gYw  \u001b[0m \u001b[36m\u001b[46m  gYw  \u001b[0m \u001b[36m\u001b[47m  gYw  \u001b[0m",
+    " 1;36m \u001b[1;36m  gYw   \u001b[1;36m\u001b[40m  gYw  \u001b[0m \u001b[1;36m\u001b[41m  gYw  \u001b[0m \u001b[1;36m\u001b[42m  gYw  \u001b[0m \u001b[1;36m\u001b[43m  gYw  \u001b[0m \u001b[1;36m\u001b[44m  gYw  \u001b[0m \u001b[1;36m\u001b[45m  gYw  \u001b[0m \u001b[1;36m\u001b[46m  gYw  \u001b[0m \u001b[1;36m\u001b[47m  gYw  \u001b[0m",
+    "   37m \u001b[37m  gYw   \u001b[37m\u001b[40m  gYw  \u001b[0m \u001b[37m\u001b[41m  gYw  \u001b[0m \u001b[37m\u001b[42m  gYw  \u001b[0m \u001b[37m\u001b[43m  gYw  \u001b[0m \u001b[37m\u001b[44m  gYw  \u001b[0m \u001b[37m\u001b[45m  gYw  \u001b[0m \u001b[37m\u001b[46m  gYw  \u001b[0m \u001b[37m\u001b[47m  gYw  \u001b[0m",
+    " 1;37m \u001b[1;37m  gYw   \u001b[1;37m\u001b[40m  gYw  \u001b[0m \u001b[1;37m\u001b[41m  gYw  \u001b[0m \u001b[1;37m\u001b[42m  gYw  \u001b[0m \u001b[1;37m\u001b[43m  gYw  \u001b[0m \u001b[1;37m\u001b[44m  gYw  \u001b[0m \u001b[1;37m\u001b[45m  gYw  \u001b[0m \u001b[1;37m\u001b[46m  gYw  \u001b[0m \u001b[1;37m\u001b[47m  gYw  \u001b[0m",
+  ].map((v, i) => ({
+    log: v,
+    index: i,
+    severity: LogSeverity.INFO,
+    createdAt: 0,
+  })),
+  loading: false,
+};

--- a/pkg/app/web/src/components/login-form/index.stories.tsx
+++ b/pkg/app/web/src/components/login-form/index.stories.tsx
@@ -1,6 +1,6 @@
-import * as React from "react";
-import { LoginForm } from "./";
+import { LoginForm, LoginFormProps } from "./";
 import { createDecoratorRedux } from "../../../.storybook/redux-decorator";
+import { Story } from "@storybook/react";
 
 export default {
   title: "LOGIN/LoginForm",
@@ -8,4 +8,8 @@ export default {
   decorators: [createDecoratorRedux({})],
 };
 
-export const overview: React.FC = () => <LoginForm projectName="pipecd" />;
+const Template: Story<LoginFormProps> = (args) => <LoginForm {...args} />;
+export const Overview = Template.bind({});
+Overview.args = {
+  projectName: "PipeCD",
+};

--- a/pkg/app/web/src/components/login-form/index.tsx
+++ b/pkg/app/web/src/components/login-form/index.tsx
@@ -58,11 +58,13 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-interface Props {
+export interface LoginFormProps {
   projectName: string;
 }
 
-export const LoginForm: FC<Props> = memo(function LoginForm({ projectName }) {
+export const LoginForm: FC<LoginFormProps> = memo(function LoginForm({
+  projectName,
+}) {
   const classes = useStyles();
 
   return (

--- a/pkg/app/web/src/components/piped-filter/index.stories.tsx
+++ b/pkg/app/web/src/components/piped-filter/index.stories.tsx
@@ -1,12 +1,20 @@
-import { action } from "@storybook/addon-actions";
-import * as React from "react";
-import { PipedFilter } from "./";
+import { Story } from "@storybook/react";
+import { PipedFilter, PipedFilterProps } from "./";
 
 export default {
-  title: "SETTINGS/Piped/PipedFilter",
+  title: "Setting/Piped/PipedFilter",
   component: PipedFilter,
+  argTypes: {
+    onChange: {
+      action: "onChange",
+    },
+  },
 };
 
-export const overview: React.FC = () => (
-  <PipedFilter values={{ enabled: false }} onChange={action("onChange")} />
-);
+const Template: Story<PipedFilterProps> = (args) => <PipedFilter {...args} />;
+export const Overview = Template.bind({});
+Overview.args = {
+  values: {
+    enabled: false,
+  },
+};

--- a/pkg/app/web/src/components/pipeline-stage/index.stories.tsx
+++ b/pkg/app/web/src/components/pipeline-stage/index.stories.tsx
@@ -1,4 +1,4 @@
-import { Story } from "@storybook/react/types-6-0";
+import { Story } from "@storybook/react";
 import { StageStatus } from "pipe/pkg/app/web/model/deployment_pb";
 import { PipelineStage, PipelineStageProps } from "./";
 

--- a/pkg/app/web/src/components/pipeline/index.stories.tsx
+++ b/pkg/app/web/src/components/pipeline/index.stories.tsx
@@ -1,10 +1,10 @@
-import * as React from "react";
 import { createDecoratorRedux } from "../../../.storybook/redux-decorator";
-import { Pipeline } from "./";
+import { Pipeline, PipelineProps } from "./";
 import { Deployment } from "../../modules/deployments";
 import { createPipelineStage } from "../../__fixtures__/dummy-pipeline";
 import { METADATA_APPROVED_BY } from "../../constants/metadata-keys";
 import { SyncStrategy } from "pipe/pkg/app/web/model/deployment_pb";
+import { Story } from "@storybook/react";
 
 const DEPLOYMENT_ID = "debug-deployment-id-01";
 const fakeDeployment: Deployment.AsObject = {
@@ -134,6 +134,6 @@ export default {
   ],
 };
 
-export const overview: React.FC = () => (
-  <Pipeline deploymentId={DEPLOYMENT_ID} />
-);
+const Template: Story<PipelineProps> = (args) => <Pipeline {...args} />;
+export const Overview = Template.bind({});
+Overview.args = { deploymentId: DEPLOYMENT_ID };

--- a/pkg/app/web/src/components/project-setting-labeled-text/index.stories.tsx
+++ b/pkg/app/web/src/components/project-setting-labeled-text/index.stories.tsx
@@ -1,11 +1,13 @@
-import * as React from "react";
-import { ProjectSettingLabeledText } from "./";
+import { Story } from "@storybook/react";
+import { ProjectSettingLabeledText, ProjectSettingLabeledTextProps } from "./";
 
 export default {
   title: "ProjectSettingLabeledText",
   component: ProjectSettingLabeledText,
 };
 
-export const overview: React.FC = () => (
-  <ProjectSettingLabeledText label="Label" value="value" />
+const Template: Story<ProjectSettingLabeledTextProps> = (args) => (
+  <ProjectSettingLabeledText {...args} />
 );
+export const Overview = Template.bind({});
+Overview.args = { label: "label", value: "value" };

--- a/pkg/app/web/src/components/rbac-form/index.stories.tsx
+++ b/pkg/app/web/src/components/rbac-form/index.stories.tsx
@@ -1,14 +1,14 @@
-import * as React from "react";
 import { RBACForm } from "./";
 import { Provider } from "react-redux";
 import { createStore } from "../../../test-utils";
+import { Story } from "@storybook/react";
 
 export default {
   title: "RBACForm",
   component: RBACForm,
 };
 
-export const overview: React.FC = () => (
+export const Overview: Story = () => (
   <Provider
     store={createStore({
       project: {
@@ -20,7 +20,7 @@ export const overview: React.FC = () => (
   </Provider>
 );
 
-export const notConfigured: React.FC = () => (
+export const NotConfigured: Story = () => (
   <Provider
     store={createStore({
       project: {

--- a/pkg/app/web/src/components/resource-filter-popover/index.stories.tsx
+++ b/pkg/app/web/src/components/resource-filter-popover/index.stories.tsx
@@ -1,15 +1,18 @@
-import { action } from "@storybook/addon-actions";
-import * as React from "react";
-import { ResourceFilterPopover } from "./";
+import { Story } from "@storybook/react";
+import { ResourceFilterPopover, ResourceFilterPopoverProps } from "./";
 
 export default {
   title: "ResourceFilterPopover",
   component: ResourceFilterPopover,
+  argTypes: {
+    onChange: {
+      action: "onChange",
+    },
+  },
 };
 
-export const overview: React.FC = () => (
-  <ResourceFilterPopover
-    enables={{ Pod: true, ReplicaSet: false }}
-    onChange={action("onChange")}
-  />
+const Template: Story<ResourceFilterPopoverProps> = (args) => (
+  <ResourceFilterPopover {...args} />
 );
+export const Overview = Template.bind({});
+Overview.args = { enables: { Pod: true, ReplicaSet: false } };

--- a/pkg/app/web/src/components/sealed-secret-dialog/index.stories.tsx
+++ b/pkg/app/web/src/components/sealed-secret-dialog/index.stories.tsx
@@ -1,53 +1,51 @@
 import { action } from "@storybook/addon-actions";
-import * as React from "react";
 import { dummyApplication } from "../../__fixtures__/dummy-application";
 import { SealedSecretDialog } from "./";
 import { Provider } from "react-redux";
 import { createStore } from "../../../test-utils";
+import { Story } from "@storybook/react";
 
 export default {
   title: "APPLICATION/SealedSecretDialog",
   component: SealedSecretDialog,
 };
 
-export const overview: React.FC = () => {
-  const store = createStore({
-    applications: {
-      entities: { [dummyApplication.id]: dummyApplication },
-      ids: [dummyApplication.id],
-    },
-  });
-  return (
-    <Provider store={store}>
-      <SealedSecretDialog
-        open
-        applicationId={dummyApplication.id}
-        onClose={action("onClose")}
-      />
-    </Provider>
-  );
-};
+export const Overview: Story = () => (
+  <Provider
+    store={createStore({
+      applications: {
+        entities: { [dummyApplication.id]: dummyApplication },
+        ids: [dummyApplication.id],
+      },
+    })}
+  >
+    <SealedSecretDialog
+      open
+      applicationId={dummyApplication.id}
+      onClose={action("onClose")}
+    />
+  </Provider>
+);
 
-export const encrypted: React.FC = () => {
-  const store = createStore({
-    applications: {
-      entities: { [dummyApplication.id]: dummyApplication },
-      ids: [dummyApplication.id],
-    },
-    sealedSecret: {
-      isLoading: false,
-      // dummy data
-      data:
-        "AgEAk+XZY0+8hJSv5GG8rDTZGV56xe3xCROxGtVwNVY3kSg3MAvq1BcbhkIToT1q7JVYnE/MQ/nuks5MXPrFpu5/bHCehlzsFc8tnffQeYtVO3XuCi771zd4KNsAmCMvN0Fo57eqzuhU/uEYt+1thRJh3FA/tJilZ0j1JiSvrn01Zfb1Xw0QGMCO4/C75YRUa6g2JC75yLKZ06Yzequ1wSglLzF7rzUdl1+kxCBWJM1HnFkBpLGtCcH7xqBbkQMEz1jOjgpluPDUD7nCwMmZzY9sw83jOXfsCdNvmy/uStIsTDBZDPE1uWxN8MAWEieLoOvLLUFWGXmMDEJAa6nv1iI/jv8OLXzUEOeklc/OKZ7jLOnylmqQ4U7YCFsfHqAMzAFadpORxHCHt09zHzm9nKoyhOCFo9gDVyX6HiD9h3V/j1gBmr9lgonfiVC0HbsghOLJMjf+9njNiEqD7IOhBVv6TEwGpGI+1SYoBu6m8+Jlex2j5VcspMybx6p5aKmuwQpLqrEFMZBYJwAXMrAxkMiiE5QnB9/K7YAcYr3a33qGPu+JmQKgg9QRN0X5jvl/FNaYDoXzNp1FBuFEQUtu0hw8QKtf/DWVAUj/zgyviPQ2j8fy5Yg7qwxuL12EQMeAtC0pwyFNE7SlyvGoGoKc+yp0/EfpFzyH3n807+UD8ueN+bbvKn0gXkePO2Af1a61LU/lPOe68A==",
-    },
-  });
-  return (
-    <Provider store={store}>
-      <SealedSecretDialog
-        open
-        applicationId={dummyApplication.id}
-        onClose={action("onClose")}
-      />
-    </Provider>
-  );
-};
+export const Encrypted: Story = () => (
+  <Provider
+    store={createStore({
+      applications: {
+        entities: { [dummyApplication.id]: dummyApplication },
+        ids: [dummyApplication.id],
+      },
+      sealedSecret: {
+        isLoading: false,
+        // dummy data
+        data:
+          "AgEAk+XZY0+8hJSv5GG8rDTZGV56xe3xCROxGtVwNVY3kSg3MAvq1BcbhkIToT1q7JVYnE/MQ/nuks5MXPrFpu5/bHCehlzsFc8tnffQeYtVO3XuCi771zd4KNsAmCMvN0Fo57eqzuhU/uEYt+1thRJh3FA/tJilZ0j1JiSvrn01Zfb1Xw0QGMCO4/C75YRUa6g2JC75yLKZ06Yzequ1wSglLzF7rzUdl1+kxCBWJM1HnFkBpLGtCcH7xqBbkQMEz1jOjgpluPDUD7nCwMmZzY9sw83jOXfsCdNvmy/uStIsTDBZDPE1uWxN8MAWEieLoOvLLUFWGXmMDEJAa6nv1iI/jv8OLXzUEOeklc/OKZ7jLOnylmqQ4U7YCFsfHqAMzAFadpORxHCHt09zHzm9nKoyhOCFo9gDVyX6HiD9h3V/j1gBmr9lgonfiVC0HbsghOLJMjf+9njNiEqD7IOhBVv6TEwGpGI+1SYoBu6m8+Jlex2j5VcspMybx6p5aKmuwQpLqrEFMZBYJwAXMrAxkMiiE5QnB9/K7YAcYr3a33qGPu+JmQKgg9QRN0X5jvl/FNaYDoXzNp1FBuFEQUtu0hw8QKtf/DWVAUj/zgyviPQ2j8fy5Yg7qwxuL12EQMeAtC0pwyFNE7SlyvGoGoKc+yp0/EfpFzyH3n807+UD8ueN+bbvKn0gXkePO2Af1a61LU/lPOe68A==",
+      },
+    })}
+  >
+    <SealedSecretDialog
+      open
+      applicationId={dummyApplication.id}
+      onClose={action("onClose")}
+    />
+  </Provider>
+);

--- a/pkg/app/web/src/components/split-button/index.stories.tsx
+++ b/pkg/app/web/src/components/split-button/index.stories.tsx
@@ -1,31 +1,30 @@
-import * as React from "react";
-import { SplitButton } from "./";
+import { SplitButton, SplitButtonProps } from "./";
 import CancelIcon from "@material-ui/icons/Cancel";
-import { action } from "@storybook/addon-actions";
+import { Story } from "@storybook/react";
 
 export default {
   title: "COMMON/SplitButton",
   component: SplitButton,
+  argTypes: {
+    onClick: { action: "onClick" },
+  },
 };
 
-export const overview: React.FC = () => (
-  <SplitButton
-    label="select option"
-    startIcon={<CancelIcon />}
-    options={["Cancel", "Cancel Without Rollback"]}
-    onClick={action("onClick")}
-    disabled={false}
-    loading={false}
-  />
-);
+const Template: Story<SplitButtonProps> = (args) => <SplitButton {...args} />;
+export const Overview = Template.bind({});
+Overview.args = {
+  label: "select option",
+  startIcon: <CancelIcon />,
+  options: ["Cancel", "Cancel Without Rollback"],
+  disabled: false,
+  loading: false,
+};
 
-export const loading: React.FC = () => (
-  <SplitButton
-    label="select option"
-    startIcon={<CancelIcon />}
-    options={["Cancel", "Cancel Without Rollback"]}
-    onClick={action("onClick")}
-    loading
-    disabled
-  />
-);
+export const Loading = Template.bind({});
+Loading.args = {
+  label: "select option",
+  startIcon: <CancelIcon />,
+  options: ["Cancel", "Cancel Without Rollback"],
+  disabled: true,
+  loading: true,
+};

--- a/pkg/app/web/src/components/stage-status-icon/index.stories.tsx
+++ b/pkg/app/web/src/components/stage-status-icon/index.stories.tsx
@@ -1,18 +1,27 @@
-import * as React from "react";
-import { StageStatusIcon } from "./";
+import { StageStatusIcon, StageStatusIconProps } from "./";
 import { StageStatus } from "pipe/pkg/app/web/model/deployment_pb";
+import { Story } from "@storybook/react";
 
 export default {
   title: "DEPLOYMENT/StageStatusIcon",
   component: StageStatusIcon,
 };
 
-export const overview: React.FC = () => (
-  <>
-    <StageStatusIcon status={StageStatus.STAGE_CANCELLED} />
-    <StageStatusIcon status={StageStatus.STAGE_FAILURE} />
-    <StageStatusIcon status={StageStatus.STAGE_NOT_STARTED_YET} />
-    <StageStatusIcon status={StageStatus.STAGE_RUNNING} />
-    <StageStatusIcon status={StageStatus.STAGE_SUCCESS} />
-  </>
+const Template: Story<StageStatusIconProps> = (args) => (
+  <StageStatusIcon {...args} />
 );
+
+export const Cancelled = Template.bind({});
+Cancelled.args = { status: StageStatus.STAGE_CANCELLED };
+
+export const Failure = Template.bind({});
+Failure.args = { status: StageStatus.STAGE_FAILURE };
+
+export const NotStartedYet = Template.bind({});
+NotStartedYet.args = { status: StageStatus.STAGE_NOT_STARTED_YET };
+
+export const Running = Template.bind({});
+Running.args = { status: StageStatus.STAGE_RUNNING };
+
+export const Success = Template.bind({});
+Success.args = { status: StageStatus.STAGE_SUCCESS };

--- a/pkg/app/web/src/components/static-admin-form/index.stories.tsx
+++ b/pkg/app/web/src/components/static-admin-form/index.stories.tsx
@@ -1,9 +1,9 @@
-import * as React from "react";
+import { Story } from "@storybook/react";
 import { createDecoratorRedux } from "../../../.storybook/redux-decorator";
 import { StaticAdminForm } from "./";
 
 export default {
-  title: "SETTINGS/StaticAdminForm",
+  title: "Setting/StaticAdminForm",
   component: StaticAdminForm,
   decorators: [
     createDecoratorRedux({
@@ -15,4 +15,6 @@ export default {
   ],
 };
 
-export const overview: React.FC = () => <StaticAdminForm />;
+const Template: Story = (args) => <StaticAdminForm {...args} />;
+export const Overview = Template.bind({});
+Overview.args = {};

--- a/pkg/app/web/src/components/sync-state-reason/index.stories.tsx
+++ b/pkg/app/web/src/components/sync-state-reason/index.stories.tsx
@@ -1,23 +1,25 @@
-import * as React from "react";
-import { SyncStateReason } from "./";
+import { Story } from "@storybook/react";
+import { SyncStateReason, SyncStateReasonProps } from "./";
 
 export default {
   title: "APPLICATION/SyncStateReason",
   component: SyncStateReason,
 };
 
-export const overview: React.FC = () => (
-  <SyncStateReason
-    summary="There are 1 missing manifests and 2 redundant manifests."
-    detail={`The following 1 manifests are defined in Git, but NOT appearing in the cluster:
-    - apiVersion=v1, kind=Service, namespace=default, name=wait-approvalThe following 2 manifests are NOT defined in Git, but appearing in the cluster:
-    - apiVersion=apps/v1, kind=Deployment, namespace=default, name=wait-approval-canary- apiVersion=v1, kind=Service, namespace=default, name=wait-approval`}
-  />
+const Template: Story<SyncStateReasonProps> = (args) => (
+  <SyncStateReason {...args} />
 );
 
-export const diff: React.FC = () => (
-  <SyncStateReason
-    summary="Summary message"
-    detail={`message\n\n+ added-line\n- deleted-line`}
-  />
-);
+export const Overview = Template.bind({});
+Overview.args = {
+  summary: "There are 1 missing manifests and 2 redundant manifests.",
+  detail: `The following 1 manifests are defined in Git, but NOT appearing in the cluster:
+  - apiVersion=v1, kind=Service, namespace=default, name=wait-approvalThe following 2 manifests are NOT defined in Git, but appearing in the cluster:
+  - apiVersion=apps/v1, kind=Deployment, namespace=default, name=wait-approval-canary- apiVersion=v1, kind=Service, namespace=default, name=wait-approval`,
+};
+
+export const Diff = Template.bind({});
+Diff.args = {
+  summary: "Summary message",
+  detail: `message\n\n+ added-line\n- deleted-line`,
+};

--- a/pkg/app/web/src/components/sync-status-icon/index.stories.tsx
+++ b/pkg/app/web/src/components/sync-status-icon/index.stories.tsx
@@ -1,17 +1,32 @@
-import * as React from "react";
-import { SyncStatusIcon } from "./";
+import { SyncStatusIcon, SyncStatusIconProps } from "./";
 import { ApplicationSyncStatus } from "pipe/pkg/app/web/model/application_pb";
+import { Story } from "@storybook/react";
 
 export default {
   title: "APPLICATION/SyncStatusIcon",
   component: SyncStatusIcon,
 };
 
-export const overview: React.FC = () => (
-  <>
-    <SyncStatusIcon status={ApplicationSyncStatus.UNKNOWN} />
-    <SyncStatusIcon status={ApplicationSyncStatus.SYNCED} />
-    <SyncStatusIcon status={ApplicationSyncStatus.DEPLOYING} />
-    <SyncStatusIcon status={ApplicationSyncStatus.OUT_OF_SYNC} />
-  </>
+const Template: Story<SyncStatusIconProps> = (args) => (
+  <SyncStatusIcon {...args} />
 );
+
+export const Unknown = Template.bind({});
+Unknown.args = {
+  status: ApplicationSyncStatus.UNKNOWN,
+};
+
+export const Synced = Template.bind({});
+Synced.args = {
+  status: ApplicationSyncStatus.SYNCED,
+};
+
+export const Deploying = Template.bind({});
+Deploying.args = {
+  status: ApplicationSyncStatus.DEPLOYING,
+};
+
+export const OutOfSync = Template.bind({});
+OutOfSync.args = {
+  status: ApplicationSyncStatus.OUT_OF_SYNC,
+};

--- a/pkg/app/web/src/components/text-with-copy-button/index.stories.tsx
+++ b/pkg/app/web/src/components/text-with-copy-button/index.stories.tsx
@@ -1,4 +1,4 @@
-import { Story } from "@storybook/react/types-6-0";
+import { Story } from "@storybook/react";
 import { createDecoratorRedux } from "../../../.storybook/redux-decorator";
 import { TextWithCopyButton, TextWithCopyButtonProps } from "./";
 

--- a/pkg/app/web/src/components/toasts/index.stories.tsx
+++ b/pkg/app/web/src/components/toasts/index.stories.tsx
@@ -1,14 +1,14 @@
-import * as React from "react";
 import { Toasts } from "./";
 import { Provider } from "react-redux";
 import { createStore } from "../../../test-utils";
+import { Story } from "@storybook/react";
 
 export default {
   title: "COMMON/Toasts",
   component: Toasts,
 };
 
-export const overview: React.FC = () => (
+export const Overview: Story = () => (
   <Provider
     store={createStore({
       toasts: {
@@ -27,7 +27,7 @@ export const overview: React.FC = () => (
   </Provider>
 );
 
-export const url: React.FC = () => (
+export const Url: Story = () => (
   <Provider
     store={createStore({
       toasts: {

--- a/pkg/app/web/src/components/week-picker/index.stories.tsx
+++ b/pkg/app/web/src/components/week-picker/index.stories.tsx
@@ -1,16 +1,17 @@
-import { action } from "@storybook/addon-actions";
-import * as React from "react";
-import { WeekPicker } from "./";
+import { Story } from "@storybook/react";
+import { WeekPicker, WeekPickerProps } from "./";
 
 export default {
   title: "COMMON/WeekPicker",
   component: WeekPicker,
+  argTypes: {
+    onChange: { action: "onChange" },
+  },
 };
 
-export const overview: React.FC = () => (
-  <WeekPicker
-    value={new Date()}
-    label="Week Picker"
-    onChange={action("onChange")}
-  />
-);
+const Template: Story<WeekPickerProps> = (args) => <WeekPicker {...args} />;
+export const Overview = Template.bind({});
+Overview.args = {
+  value: new Date(),
+  label: "Week Picker",
+};


### PR DESCRIPTION
**What this PR does / why we need it**:

- Use `Story` type for story components.
- Use PascalCase for components name.
- Create a `Template` component then use it for each stories.
  - https://github.com/pipe-cd/pipe/blob/fix-stories/pkg/app/web/.scaffdog/component.md#-inputsname-indexstoriestsx

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
