### PR TITLE
Disable EnvIds column

### DIFF
--- a/pkg/datastore/mysql/ensurer/indexes.sql
+++ b/pkg/datastore/mysql/ensurer/indexes.sql
@@ -88,6 +88,6 @@ CREATE INDEX event_key_name_project_id_created_at_desc ON Event (EventKey, Name,
 --
 
 -- index on `ProjectId` ASC and `EnvIds` ASC
-ALTER TABLE Piped ADD COLUMN EnvIds JSON GENERATED ALWAYS AS (IFNULL(data ->> "$.env_ids", '[]')) VIRTUAL NOT NULL;
+-- ALTER TABLE Piped ADD COLUMN EnvIds JSON GENERATED ALWAYS AS (IFNULL(data ->> "$.env_ids", '[]')) VIRTUAL NOT NULL;
 -- TODO: Create index on ProjectId and EnvIds
 -- CREATE INDEX piped_project_id_env_ids_asc ON Piped (ProjectId, (CAST(EnvIds->'$' AS BINARY(16) ARRAY)));


### PR DESCRIPTION
**What this PR does / why we need it**:
In order to maintain consistency, commented out the newly added column where type is likely to be varied in the near future. After fixing the type, it will be reverted.

If you try to delete an environment where datastore is MySQL, it gets something like:

![image](https://user-images.githubusercontent.com/19730728/121148135-733fe800-c87c-11eb-8eee-a4f2be111ea0.png)

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
