### PR TITLE
Create a multi-valued composite index for ProjectId and EnvIds

### DIFF
--- a/pkg/datastore/mysql/ensurer/indexes.sql
+++ b/pkg/datastore/mysql/ensurer/indexes.sql
@@ -88,6 +88,5 @@ CREATE INDEX event_key_name_project_id_created_at_desc ON Event (EventKey, Name,
 --
 
 -- index on `ProjectId` ASC and `EnvIds` ASC
--- ALTER TABLE Piped ADD COLUMN EnvIds JSON GENERATED ALWAYS AS (IFNULL(data ->> "$.env_ids", '[]')) VIRTUAL NOT NULL;
--- TODO: Create index on ProjectId and EnvIds
--- CREATE INDEX piped_project_id_env_ids_asc ON Piped (ProjectId, (CAST(EnvIds->'$' AS BINARY(16) ARRAY)));
+ ALTER TABLE Piped ADD COLUMN EnvIds JSON GENERATED ALWAYS AS (IFNULL(data ->> "$.env_ids", '[]')) VIRTUAL NOT NULL;
+CREATE INDEX piped_project_id_env_ids_asc ON Piped (ProjectId, (CAST(EnvIds AS CHAR(36) ARRAY)));

--- a/pkg/datastore/mysql/ensurer/indexes.sql
+++ b/pkg/datastore/mysql/ensurer/indexes.sql
@@ -88,5 +88,5 @@ CREATE INDEX event_key_name_project_id_created_at_desc ON Event (EventKey, Name,
 --
 
 -- index on `ProjectId` ASC and `EnvIds` ASC
- ALTER TABLE Piped ADD COLUMN EnvIds JSON GENERATED ALWAYS AS (IFNULL(data ->> "$.env_ids", '[]')) VIRTUAL NOT NULL;
+ALTER TABLE Piped ADD COLUMN EnvIds JSON GENERATED ALWAYS AS (IFNULL(data ->> "$.env_ids", '[]')) VIRTUAL NOT NULL;
 CREATE INDEX piped_project_id_env_ids_asc ON Piped (ProjectId, (CAST(EnvIds AS CHAR(36) ARRAY)));


### PR DESCRIPTION
**What this PR does / why we need it**:
I've confirmed that MySQL uses the newly created index when deleting an environment.

We can check what query it uses as:
```bash
mysql> SET GLOBAL general_log = 'ON';
Query OK, 0 rows affected (0.00 sec)
mysql> exit

root@pipecd-mysql-55bc4f9495-x7q74:/ tail -f /var/lib/mysql/pipecd-mysql-55bc4f9495-x7q74.log
/usr/sbin/mysqld, Version: 8.0.23 (MySQL Community Server - GPL). started with:
Tcp port: 3306  Unix socket: /var/run/mysqld/mysqld.sock
Time                 Id Command    Argument
2021-06-08T09:13:32.856141Z	   24 Execute	SELECT Data FROM Piped WHERE ProjectId = 'quickstart' AND 'e5c214d6-e6cb-489c-884c-d2c8fdef3bba' MEMBER OF (EnvIds) AND Disabled = 0
2021-06-08T09:13:32.856782Z	   24 Close stmt
2021-06-08T09:13:35.210023Z	   21 Quit
```

It turns out that it executes `SELECT Data FROM Piped WHERE ProjectId = 'quickstart' AND 'e5c214d6-e6cb-489c-884c-d2c8fdef3bba' MEMBER OF (EnvIds) AND Disabled = 0`.

To check if it uses the index, we can use `EXPLAIN`.
```sql
mysql> EXPLAIN SELECT Data FROM Piped WHERE ProjectId = 'quickstart' AND 'e5c214d6-e6cb-489c-884c-d2c8fdef3bba' MEMBER OF (EnvIds) AND Disabled = 0;
+----+-------------+-------+------------+------+------------------------------+------------------------------+---------+-------+------+----------+-------------+
| id | select_type | table | partitions | type | possible_keys                | key                          | key_len | ref   | rows | filtered | Extra       |
+----+-------------+-------+------------+------+------------------------------+------------------------------+---------+-------+------+----------+-------------+
|  1 | SIMPLE      | Piped | NULL       | ref  | piped_project_id_env_ids_asc | piped_project_id_env_ids_asc | 202     | const |    2 |    50.00 | Using where |
+----+-------------+-------+------------+------+------------------------------+------------------------------+---------+-------+------+----------+-------------+
1 row in set, 1 warning (0.00 sec)
```

Look at the type column. We can see `ref` is set; it seems to use the newly added composite index.

Note that it doesn't support `VARCHAR(36) ARRAY` as a multi-valued index. Our EnvId is fixed length and not required to have any space, that's why I thought using CHAR is enought.

**Which issue(s) this PR fixes**:

Fixes https://github.com/pipe-cd/pipe/issues/2047

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
