### PR TITLE
Fix a wrong indent in piped Helm chart

### DIFF
--- a/manifests/piped/templates/deployment.yaml
+++ b/manifests/piped/templates/deployment.yaml
@@ -19,7 +19,7 @@ spec:
         sidecar.istio.io/inject: "false"
         rollme: {{ randAlphaNum 5 | quote }}
     spec:
-      {{- if .Values.serviceAccount.create -}}
+      {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ include "piped.serviceAccountName" . }}
       {{- end }}
       containers:


### PR DESCRIPTION
**What this PR does / why we need it**:

The current chart renders a wrong indent as below:

``` yaml
spec:serviceAccountName: RELEASE-NAME-piped
  containers:
    - name: piped
 ```

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Fix a wrong indent in piped Helm chart
```
