### PR TITLE
Implement ECS new stage design

### DIFF
--- a/pkg/app/piped/cloudprovider/ecs/client.go
+++ b/pkg/app/piped/cloudprovider/ecs/client.go
@@ -149,7 +149,7 @@ func (c *client) RegisterTaskDefinition(ctx context.Context, taskDefinition type
 	return output.TaskDefinition, nil
 }
 
-func (c *client) CreateTaskSet(ctx context.Context, service types.Service, taskDefinition types.TaskDefinition, targetGroup types.LoadBalancer) (*types.TaskSet, error) {
+func (c *client) CreateTaskSet(ctx context.Context, service types.Service, taskDefinition types.TaskDefinition, targetGroup types.LoadBalancer, scale int) (*types.TaskSet, error) {
 	if taskDefinition.TaskDefinitionArn == nil {
 		return nil, fmt.Errorf("failed to create task set of task family %s: no task definition provided", *taskDefinition.Family)
 	}
@@ -157,8 +157,7 @@ func (c *client) CreateTaskSet(ctx context.Context, service types.Service, taskD
 		Cluster:        service.ClusterArn,
 		Service:        service.ServiceArn,
 		TaskDefinition: taskDefinition.TaskDefinitionArn,
-		// Always create a new taskSet which has as many tasks as desiredCount number set by service.
-		Scale: &types.Scale{Unit: types.ScaleUnitPercent, Value: float64(100)},
+		Scale:          &types.Scale{Unit: types.ScaleUnitPercent, Value: float64(scale)},
 		// If you specify the awsvpc network mode, the task is allocated an elastic network interface,
 		// and you must specify a NetworkConfiguration when run a task with the task definition.
 		NetworkConfiguration: service.NetworkConfiguration,

--- a/pkg/app/piped/cloudprovider/ecs/ecs.go
+++ b/pkg/app/piped/cloudprovider/ecs/ecs.go
@@ -38,7 +38,7 @@ type ECS interface {
 	UpdateService(ctx context.Context, service types.Service) (*types.Service, error)
 	RegisterTaskDefinition(ctx context.Context, taskDefinition types.TaskDefinition) (*types.TaskDefinition, error)
 	GetPrimaryTaskSet(ctx context.Context, service types.Service) (*types.TaskSet, error)
-	CreateTaskSet(ctx context.Context, service types.Service, taskDefinition types.TaskDefinition, targetGroup types.LoadBalancer) (*types.TaskSet, error)
+	CreateTaskSet(ctx context.Context, service types.Service, taskDefinition types.TaskDefinition, targetGroup types.LoadBalancer, scale int) (*types.TaskSet, error)
 	DeleteTaskSet(ctx context.Context, service types.Service, taskSetArn string) error
 	UpdateServicePrimaryTaskSet(ctx context.Context, service types.Service, taskSet types.TaskSet) (*types.TaskSet, error)
 }

--- a/pkg/app/piped/executor/ecs/rollback.go
+++ b/pkg/app/piped/executor/ecs/rollback.go
@@ -126,7 +126,8 @@ func rollback(ctx context.Context, in *executor.Input, cloudProviderName string,
 		return false
 	}
 
-	taskSet, err := client.CreateTaskSet(ctx, *service, *td, targetGroup)
+	// On rolling back, the scale of desired tasks will be set to 100 (same as the original state).
+	taskSet, err := client.CreateTaskSet(ctx, *service, *td, targetGroup, 100)
 	if err != nil {
 		in.LogPersister.Errorf("Failed to create ECS task set %s: %v", *serviceDefinition.ServiceName, err)
 		return false

--- a/pkg/config/deployment.go
+++ b/pkg/config/deployment.go
@@ -128,6 +128,7 @@ type PipelineStage struct {
 	ECSCanaryRolloutStageOptions  *ECSCanaryRolloutStageOptions
 	ECSPrimaryRolloutStageOptions *ECSPrimaryRolloutStageOptions
 	ECSCanaryCleanStageOptions    *ECSCanaryCleanStageOptions
+	ECSTrafficRoutingStageOptions *ECSTrafficRoutingStageOptions
 }
 
 type genericPipelineStage struct {
@@ -266,6 +267,11 @@ func (s *PipelineStage) UnmarshalJSON(data []byte) error {
 		s.ECSCanaryCleanStageOptions = &ECSCanaryCleanStageOptions{}
 		if len(gs.With) > 0 {
 			err = json.Unmarshal(gs.With, s.ECSCanaryCleanStageOptions)
+		}
+	case model.StageECSTrafficRouting:
+		s.ECSTrafficRoutingStageOptions = &ECSTrafficRoutingStageOptions{}
+		if len(gs.With) > 0 {
+			err = json.Unmarshal(gs.With, s.ECSTrafficRoutingStageOptions)
 		}
 
 	default:

--- a/pkg/config/deployment_ecs.go
+++ b/pkg/config/deployment_ecs.go
@@ -58,8 +58,9 @@ type ECSSyncStageOptions struct {
 
 // ECSCanaryRolloutStageOptions contains all configurable values for a ECS_CANARY_ROLLOUT stage.
 type ECSCanaryRolloutStageOptions struct {
-	// Traffic represents the amount of traffic that the rolled out CANARY variant will serve.
-	Traffic int `json:"traffic"`
+	// TODO: Using other risk defined type instead of primitive int.
+	// Scale represents the amount of desired task that should be rolled out as CANARY variant workload.
+	Scale int `json:"scale"`
 }
 
 // ECSPrimaryRolloutStageOptions contains all configurable values for a ECS_PRIMARY_ROLLOUT stage.
@@ -68,4 +69,29 @@ type ECSPrimaryRolloutStageOptions struct {
 
 // ECSCanaryCleanStageOptions contains all configurable values for a ECS_CANARY_CLEAN stage.
 type ECSCanaryCleanStageOptions struct {
+}
+
+// ECSTrafficRoutingStageOptions contains all configurable values for ECS_TRAFFIC_ROUTING stage.
+type ECSTrafficRoutingStageOptions struct {
+	// Canary represents the amount of traffic that the rolled out CANARY variant will serve.
+	Canary int `json:"canary"`
+	// Primary represents the amount of traffic that the rolled out CANARY variant will serve.
+	Primary int `json:"primary"`
+}
+
+func (opts ECSTrafficRoutingStageOptions) Percentage() (primary, canary int) {
+	if opts.Primary > 0 && opts.Primary < 100 {
+		primary = opts.Primary
+		canary = 100 - primary
+		return
+	}
+	if opts.Canary > 0 && opts.Canary < 100 {
+		canary = opts.Canary
+		primary = 100 - canary
+		return
+	}
+	// As default, Primary variant will receive 100% of traffic.
+	primary = 100
+	canary = 0
+	return
 }

--- a/pkg/config/deployment_ecs.go
+++ b/pkg/config/deployment_ecs.go
@@ -80,12 +80,12 @@ type ECSTrafficRoutingStageOptions struct {
 }
 
 func (opts ECSTrafficRoutingStageOptions) Percentage() (primary, canary int) {
-	if opts.Primary > 0 && opts.Primary < 100 {
+	if opts.Primary > 0 && opts.Primary <= 100 {
 		primary = opts.Primary
 		canary = 100 - primary
 		return
 	}
-	if opts.Canary > 0 && opts.Canary < 100 {
+	if opts.Canary > 0 && opts.Canary <= 100 {
 		canary = opts.Canary
 		primary = 100 - canary
 		return

--- a/pkg/model/stage.go
+++ b/pkg/model/stage.go
@@ -85,6 +85,9 @@ const (
 	// the PRIMARY variant resource have been rolled out with the new version/configuration.
 	// The PRIMARY variant will serve 100% traffic after it's rolled out.
 	StageECSPrimaryRollout Stage = "ECS_PRIMARY_ROLLOUT"
+	// StageECSTrafficRouting represents the state where the traffic to application
+	// should be splitted as the specified percentage to PRIMARY/CANARY variants.
+	StageECSTrafficRouting Stage = "ECS_TRAFFIC_ROUTING"
 	// StageECSCanaryClean represents the stage where
 	// the CANARY variant resources has been cleaned.
 	StageECSCanaryClean Stage = "ECS_CANARY_CLEAN"


### PR DESCRIPTION
**What this PR does / why we need it**:

A typical ECS progressive flow would look like this
<img width="1429" alt="Screen Shot 2021-06-14 at 17 55 31" src="https://user-images.githubusercontent.com/32532742/121866372-d4aefd80-cd39-11eb-8ea8-15a5e4a1a2d9.png">
Configuration as below 👇 
```yaml
  pipeline:
    stages:
      # Deploy the workloads of CANARY variant, the number of workload
      # for CANARY variant is equal to 10% of PRIMARY's workload.
      # But this is still receiving no traffic.
      - name: ECS_CANARY_ROLLOUT
        with:
          scale: 10
      # Change the traffic routing state where
      # the CANARY workloads will receive the specified percentage of traffic.
      # This is known as multi-phase canary strategy.
      - name: ECS_TRAFFIC_ROUTING
        with:
          canary: 20
      # Optional: We can also add an ANALYSIS stage to verify the new version.
      # If this stage finds any not good metrics of the new version,
      # a rollback process to the previous version will be executed.
      - name: ANALYSIS
      # Update the workload of PRIMARY variant to the new version.
      - name: ECS_PRIMARY_ROLLOUT
      # Change the traffic routing state where
      # the PRIMARY workloads will receive 100% of the traffic.
      - name: ECS_TRAFFIC_ROUTING
        with:
          primary: 100
      # Destroy all workloads of CANARY variant.
      - name: ECS_CANARY_CLEAN
```

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Add ECS_TRAFFIC_ROUTING as ECS deployment stage
```
