### PR TITLE
Add ability to use both SecretManagement and SealedSecretManagement

### DIFF
--- a/pkg/app/api/grpcapi/piped_api.go
+++ b/pkg/app/api/grpcapi/piped_api.go
@@ -99,7 +99,7 @@ func (a *PipedAPI) ReportPipedMeta(ctx context.Context, req *pipedservice.Report
 	now := time.Now().Unix()
 	connStatus := model.Piped_ONLINE
 
-	if err = a.pipedStore.UpdatePiped(ctx, pipedID, datastore.PipedMetadataUpdater(req.CloudProviders, req.Repositories, connStatus, req.SealedSecretEncryption, req.Version, now)); err != nil {
+	if err = a.pipedStore.UpdatePiped(ctx, pipedID, datastore.PipedMetadataUpdater(req.CloudProviders, req.Repositories, connStatus, req.SecretEncryption, req.Version, now)); err != nil {
 		switch err {
 		case datastore.ErrNotFound:
 			return nil, status.Error(codes.InvalidArgument, "piped is not found")

--- a/pkg/app/api/grpcapi/web_api.go
+++ b/pkg/app/api/grpcapi/web_api.go
@@ -924,10 +924,7 @@ func (a *WebAPI) GenerateApplicationSealedSecret(ctx context.Context, req *webse
 		return nil, err
 	}
 
-	se := piped.SecretEncryption
-	if se == nil {
-		se = piped.SealedSecretEncryption
-	}
+	se := model.GetSecretEncryptionInPiped(piped)
 	if se == nil {
 		return nil, status.Error(codes.FailedPrecondition, "The piped does not contain the encryption configuration")
 	}

--- a/pkg/app/api/service/pipedservice/service.proto
+++ b/pkg/app/api/service/pipedservice/service.proto
@@ -160,7 +160,7 @@ message ReportPipedMetaRequest {
     string version = 1;
     repeated pipe.model.Piped.CloudProvider cloud_providers = 2;
     repeated pipe.model.ApplicationGitRepository repositories = 3;
-    pipe.model.Piped.SealedSecretEncryption sealed_secret_encryption = 4;
+    pipe.model.Piped.SecretEncryption secret_encryption = 4;
 }
 
 message ReportPipedMetaResponse {

--- a/pkg/app/piped/cmd/piped/piped.go
+++ b/pkg/app/piped/cmd/piped/piped.go
@@ -437,11 +437,7 @@ func (p *piped) loadConfig() (*config.PipedSpec, error) {
 }
 
 func (p *piped) initializeSecretDecrypter(cfg *config.PipedSpec) (crypto.Decrypter, error) {
-	// Load from SecretManagement field first, if it was not specified use the legacy one.
-	sm := cfg.SecretManagement
-	if sm == nil {
-		sm = cfg.SealedSecretManagement
-	}
+	sm := cfg.GetSecretManagement()
 	if sm == nil {
 		return nil, nil
 	}
@@ -502,11 +498,7 @@ func (p *piped) sendPipedMeta(ctx context.Context, client pipedservice.Client, c
 	}
 
 	// Configure secret management.
-	sm := cfg.SecretManagement
-	if sm == nil {
-		sm = cfg.SealedSecretManagement
-	}
-	if sm != nil {
+	if sm := cfg.GetSecretManagement(); sm != nil {
 		switch sm.Type {
 		case model.SecretManagementTypeSealingKey:
 			fallthrough

--- a/pkg/app/piped/cmd/piped/piped.go
+++ b/pkg/app/piped/cmd/piped/piped.go
@@ -291,9 +291,9 @@ func (p *piped) run(ctx context.Context, t cli.Telemetry) (runErr error) {
 		})
 	}
 
-	decrypter, err := p.initializeSealedSecretDecrypter(cfg)
+	decrypter, err := p.initializeSecretDecrypter(cfg)
 	if err != nil {
-		t.Logger.Error("failed to initialize sealed secret decrypter", zap.Error(err))
+		t.Logger.Error("failed to initialize secret decrypter", zap.Error(err))
 		return err
 	}
 
@@ -436,33 +436,40 @@ func (p *piped) loadConfig() (*config.PipedSpec, error) {
 	return cfg.PipedSpec, nil
 }
 
-func (p *piped) initializeSealedSecretDecrypter(cfg *config.PipedSpec) (crypto.Decrypter, error) {
-	ssm := cfg.SealedSecretManagement
-	if ssm == nil {
+func (p *piped) initializeSecretDecrypter(cfg *config.PipedSpec) (crypto.Decrypter, error) {
+	// Load from SecretManagement field first, if it was not specified use the legacy one.
+	sm := cfg.SecretManagement
+	if sm == nil {
+		sm = cfg.SealedSecretManagement
+	}
+	if sm == nil {
 		return nil, nil
 	}
 
-	switch ssm.Type {
-	case model.SealedSecretManagementNone:
+	switch sm.Type {
+	case model.SecretManagementTypeNone:
 		return nil, nil
 
-	case model.SealedSecretManagementSealingKey:
-		if ssm.SealingKeyConfig.PrivateKeyFile == "" {
-			return nil, fmt.Errorf("sealedSecretManagement.privateKeyFile must be set")
+	case model.SecretManagementTypeSealingKey:
+		fallthrough
+	case model.SecretManagementTypeKeyPair:
+		if sm.KeyPair.PrivateKeyFile == "" {
+			return nil, fmt.Errorf("secretManagement.privateKeyFile must be set")
 		}
-		decrypter, err := crypto.NewHybridDecrypter(ssm.SealingKeyConfig.PrivateKeyFile)
+		decrypter, err := crypto.NewHybridDecrypter(sm.KeyPair.PrivateKeyFile)
 		if err != nil {
 			return nil, fmt.Errorf("failed to initialize decrypter (%w)", err)
 		}
 		return decrypter, nil
-	case model.SealedSecretManagementGCPKMS:
-		return nil, fmt.Errorf("type %q is not implemented yet", ssm.Type.String())
 
-	case model.SealedSecretManagementAWSKMS:
-		return nil, fmt.Errorf("type %q is not implemented yet", ssm.Type.String())
+	case model.SecretManagementTypeGCPKMS:
+		return nil, fmt.Errorf("type %q is not implemented yet", sm.Type.String())
+
+	case model.SecretManagementTypeAWSKMS:
+		return nil, fmt.Errorf("type %q is not implemented yet", sm.Type.String())
 
 	default:
-		return nil, fmt.Errorf("unsupported sealed secret management type: %s", ssm.Type.String())
+		return nil, fmt.Errorf("unsupported secret management type: %s", sm.Type.String())
 	}
 }
 
@@ -494,23 +501,29 @@ func (p *piped) sendPipedMeta(ctx context.Context, client pipedservice.Client, c
 		})
 	}
 
-	// Configure sealed secret management.
-	if sm := cfg.SealedSecretManagement; sm != nil {
+	// Configure secret management.
+	sm := cfg.SecretManagement
+	if sm == nil {
+		sm = cfg.SealedSecretManagement
+	}
+	if sm != nil {
 		switch sm.Type {
-		case model.SealedSecretManagementSealingKey:
-			publicKey, err := ioutil.ReadFile(sm.SealingKeyConfig.PublicKeyFile)
+		case model.SecretManagementTypeSealingKey:
+			fallthrough
+		case model.SecretManagementTypeKeyPair:
+			publicKey, err := ioutil.ReadFile(sm.KeyPair.PublicKeyFile)
 			if err != nil {
-				return fmt.Errorf("failed to read public key for sealed secret management (%w)", err)
+				return fmt.Errorf("failed to read public key for secret management (%w)", err)
 			}
-			req.SealedSecretEncryption = &model.Piped_SealedSecretEncryption{
+			req.SecretEncryption = &model.Piped_SecretEncryption{
 				Type:      sm.Type.String(),
 				PublicKey: string(publicKey),
 			}
 		}
 	}
-	if req.SealedSecretEncryption == nil {
-		req.SealedSecretEncryption = &model.Piped_SealedSecretEncryption{
-			Type: model.SealedSecretManagementNone.String(),
+	if req.SecretEncryption == nil {
+		req.SecretEncryption = &model.Piped_SecretEncryption{
+			Type: model.SecretManagementTypeNone.String(),
 		}
 	}
 

--- a/pkg/app/piped/controller/planner.go
+++ b/pkg/app/piped/controller/planner.go
@@ -48,7 +48,7 @@ type planner struct {
 	apiClient                apiClient
 	gitClient                gitClient
 	notifier                 notifier
-	sealedSecretDecrypter    sealedSecretDecrypter
+	secretDecrypter          secretDecrypter
 	plannerRegistry          registry.Registry
 	pipedConfig              *config.PipedSpec
 	appManifestsCache        cache.Cache
@@ -71,7 +71,7 @@ func newPlanner(
 	apiClient apiClient,
 	gitClient gitClient,
 	notifier notifier,
-	ssd sealedSecretDecrypter,
+	sd secretDecrypter,
 	pipedConfig *config.PipedSpec,
 	appManifestsCache cache.Cache,
 	logger *zap.Logger,
@@ -94,7 +94,7 @@ func newPlanner(
 		apiClient:                apiClient,
 		gitClient:                gitClient,
 		notifier:                 notifier,
-		sealedSecretDecrypter:    ssd,
+		secretDecrypter:          sd,
 		pipedConfig:              pipedConfig,
 		plannerRegistry:          registry.DefaultRegistry(),
 		appManifestsCache:        appManifestsCache,
@@ -177,7 +177,7 @@ func (p *planner) Run(ctx context.Context) error {
 		p.deployment.Trigger.Commit.Hash,
 		p.gitClient,
 		p.deployment.GitPath,
-		p.sealedSecretDecrypter,
+		p.secretDecrypter,
 	)
 
 	if p.lastSuccessfulCommitHash != "" {
@@ -188,7 +188,7 @@ func (p *planner) Run(ctx context.Context) error {
 			p.lastSuccessfulCommitHash,
 			p.gitClient,
 			p.deployment.GitPath,
-			p.sealedSecretDecrypter,
+			p.secretDecrypter,
 		)
 	}
 

--- a/pkg/app/piped/deploysource/deploysource_test.go
+++ b/pkg/app/piped/deploysource/deploysource_test.go
@@ -26,16 +26,16 @@ import (
 	"github.com/pipe-cd/pipe/pkg/config"
 )
 
-type testSealedSecretDecrypter struct {
+type testSecretDecrypter struct {
 	prefix string
 }
 
-func (d testSealedSecretDecrypter) Decrypt(text string) (string, error) {
+func (d testSecretDecrypter) Decrypt(text string) (string, error) {
 	return d.prefix + text, nil
 }
 
-func TestDecryptSealedSecrets(t *testing.T) {
-	dir, err := ioutil.TempDir("", "test-decrypting-sealed-secrets")
+func TestDecryptSecrets(t *testing.T) {
+	dir, err := ioutil.TempDir("", "test-decrypting-secrets")
 	require.NoError(t, err)
 
 	defer os.RemoveAll(dir)
@@ -85,12 +85,12 @@ spec:
 			OutDir: ".credentials",
 		},
 	}
-	dcr := testSealedSecretDecrypter{
+	dcr := testSecretDecrypter{
 		prefix: "decrypted-",
 	}
 
 	for _, s := range secrets {
-		err = decryptSealedSecret(dir, s, dcr)
+		err = decryptSecret(dir, s, dcr)
 		require.NoError(t, err)
 	}
 

--- a/pkg/app/piped/driftdetector/detector.go
+++ b/pkg/app/piped/driftdetector/detector.go
@@ -52,7 +52,7 @@ type apiClient interface {
 	ReportApplicationSyncState(ctx context.Context, req *pipedservice.ReportApplicationSyncStateRequest, opts ...grpc.CallOption) (*pipedservice.ReportApplicationSyncStateResponse, error)
 }
 
-type sealedSecretDecrypter interface {
+type secretDecrypter interface {
 	Decrypt(string) (string, error)
 }
 
@@ -80,7 +80,7 @@ func NewDetector(
 	apiClient apiClient,
 	appManifestsCache cache.Cache,
 	cfg *config.PipedSpec,
-	ssd sealedSecretDecrypter,
+	sd secretDecrypter,
 	logger *zap.Logger,
 ) *detector {
 
@@ -107,7 +107,7 @@ func NewDetector(
 				d,
 				appManifestsCache,
 				cfg,
-				ssd,
+				sd,
 				logger,
 			))
 

--- a/pkg/app/piped/driftdetector/kubernetes/detector_test.go
+++ b/pkg/app/piped/driftdetector/kubernetes/detector_test.go
@@ -121,16 +121,16 @@ func TestGroupManifests(t *testing.T) {
 	}
 }
 
-type testSealedSecretDecrypter struct {
+type testSecretDecrypter struct {
 	prefix string
 }
 
-func (d testSealedSecretDecrypter) Decrypt(text string) (string, error) {
+func (d testSecretDecrypter) Decrypt(text string) (string, error) {
 	return d.prefix + text, nil
 }
 
-func TestDecryptSealedSecrets(t *testing.T) {
-	dir, err := ioutil.TempDir("", "test-decrypting-sealed-secrets")
+func TestDecryptSecrets(t *testing.T) {
+	dir, err := ioutil.TempDir("", "test-decrypting-secrets")
 	require.NoError(t, err)
 
 	defer os.RemoveAll(dir)
@@ -180,11 +180,11 @@ spec:
 			OutDir: ".credentials",
 		},
 	}
-	dcr := testSealedSecretDecrypter{
+	dcr := testSecretDecrypter{
 		prefix: "decrypted-",
 	}
 
-	err = decryptSealedSecrets(dir, secrets, dcr)
+	err = decryptSecrets(dir, secrets, dcr)
 	require.NoError(t, err)
 
 	data, err := ioutil.ReadFile(filepath.Join(dir, "replacing.yaml"))

--- a/pkg/config/piped.go
+++ b/pkg/config/piped.go
@@ -182,6 +182,13 @@ func (s *PipedSpec) IsInsecureChartRepository(name string) bool {
 	return false
 }
 
+func (s *PipedSpec) GetSecretManagement() *SecretManagement {
+	if s.SealedSecretManagement != nil {
+		return s.SealedSecretManagement
+	}
+	return s.SecretManagement
+}
+
 type PipedGit struct {
 	// The username that will be configured for `git` user.
 	// Default is "piped".

--- a/pkg/config/piped.go
+++ b/pkg/config/piped.go
@@ -519,14 +519,14 @@ type SecretManagement struct {
 	GCPKMS  *SecretManagementGCPKMS
 }
 
-func (m *SecretManagement) Validate() error {
-	switch m.Type {
+func (s *SecretManagement) Validate() error {
+	switch s.Type {
 	case model.SecretManagementTypeKeyPair:
-		return m.KeyPair.Validate()
+		return s.KeyPair.Validate()
 	case model.SecretManagementTypeGCPKMS:
-		return m.GCPKMS.Validate()
+		return s.GCPKMS.Validate()
 	default:
-		return fmt.Errorf("unsupported sealed secret management type: %s", m.Type)
+		return fmt.Errorf("unsupported sealed secret management type: %s", s.Type)
 	}
 }
 
@@ -538,11 +538,11 @@ type SecretManagementKeyPair struct {
 	PublicKeyFile string `json:"publicKeyFile"`
 }
 
-func (m *SecretManagementKeyPair) Validate() error {
-	if m.PrivateKeyFile == "" {
+func (s *SecretManagementKeyPair) Validate() error {
+	if s.PrivateKeyFile == "" {
 		return fmt.Errorf("privateKeyFile must be set")
 	}
-	if m.PublicKeyFile == "" {
+	if s.PublicKeyFile == "" {
 		return fmt.Errorf("publicKeyFile must be set")
 	}
 	return nil
@@ -558,14 +558,14 @@ type SecretManagementGCPKMS struct {
 	EncryptServiceAccountFile string `json:"encryptServiceAccountFile"`
 }
 
-func (m *SecretManagementGCPKMS) Validate() error {
-	if m.KeyName == "" {
+func (s *SecretManagementGCPKMS) Validate() error {
+	if s.KeyName == "" {
 		return fmt.Errorf("keyName must be set")
 	}
-	if m.DecryptServiceAccountFile == "" {
+	if s.DecryptServiceAccountFile == "" {
 		return fmt.Errorf("decryptServiceAccountFile must be set")
 	}
-	if m.EncryptServiceAccountFile == "" {
+	if s.EncryptServiceAccountFile == "" {
 		return fmt.Errorf("encryptServiceAccountFile must be set")
 	}
 	return nil
@@ -576,7 +576,7 @@ type genericSecretManagement struct {
 	Config json.RawMessage            `json:"config"`
 }
 
-func (p *SecretManagement) UnmarshalJSON(data []byte) error {
+func (s *SecretManagement) UnmarshalJSON(data []byte) error {
 	var err error
 	g := genericSecretManagement{}
 	if err = json.Unmarshal(data, &g); err != nil {
@@ -587,19 +587,19 @@ func (p *SecretManagement) UnmarshalJSON(data []byte) error {
 	case model.SecretManagementTypeSealingKey:
 		fallthrough
 	case model.SecretManagementTypeKeyPair:
-		p.Type = model.SecretManagementTypeKeyPair
-		p.KeyPair = &SecretManagementKeyPair{}
+		s.Type = model.SecretManagementTypeKeyPair
+		s.KeyPair = &SecretManagementKeyPair{}
 		if len(g.Config) > 0 {
-			err = json.Unmarshal(g.Config, p.KeyPair)
+			err = json.Unmarshal(g.Config, s.KeyPair)
 		}
 	case model.SecretManagementTypeGCPKMS:
-		p.Type = model.SecretManagementTypeGCPKMS
-		p.GCPKMS = &SecretManagementGCPKMS{}
+		s.Type = model.SecretManagementTypeGCPKMS
+		s.GCPKMS = &SecretManagementGCPKMS{}
 		if len(g.Config) > 0 {
-			err = json.Unmarshal(g.Config, p.GCPKMS)
+			err = json.Unmarshal(g.Config, s.GCPKMS)
 		}
 	default:
-		err = fmt.Errorf("unsupported secret management type: %s", g.Type)
+		err = fmt.Errorf("unsupported secret management type: %s", s.Type)
 	}
 	return err
 }

--- a/pkg/config/piped_test.go
+++ b/pkg/config/piped_test.go
@@ -188,11 +188,18 @@ func TestPipedConfig(t *testing.T) {
 						},
 					},
 				},
-				SealedSecretManagement: &SealedSecretManagement{
-					Type: model.SealedSecretManagementSealingKey,
-					SealingKeyConfig: &SealedSecretManagementSealingKey{
+				SealedSecretManagement: &SecretManagement{
+					Type: model.SecretManagementTypeKeyPair,
+					KeyPair: &SecretManagementKeyPair{
 						PrivateKeyFile: "/etc/piped-secret/sealing-private-key",
 						PublicKeyFile:  "/etc/piped-secret/sealing-public-key",
+					},
+				},
+				SecretManagement: &SecretManagement{
+					Type: model.SecretManagementTypeKeyPair,
+					KeyPair: &SecretManagementKeyPair{
+						PrivateKeyFile: "/etc/piped-secret/pair-private-key",
+						PublicKeyFile:  "/etc/piped-secret/pair-public-key",
 					},
 				},
 				EventWatcher: PipedEventWatcher{

--- a/pkg/config/testdata/piped/piped-config.yaml
+++ b/pkg/config/testdata/piped/piped-config.yaml
@@ -114,6 +114,11 @@ spec:
     #   keyName: key-name
     #   decryptServiceAccountFile: /etc/piped-secret/decrypt-service-account.json 
     #   encryptServiceAccountFile: /etc/piped-secret/encrypt-service-account.json
+  secretManagement:
+    type: KEY_PAIR
+    config:
+      privateKeyFile: /etc/piped-secret/pair-private-key
+      publicKeyFile: /etc/piped-secret/pair-public-key
 
   eventWatcher:
     checkInterval: 10m

--- a/pkg/datastore/pipedstore.go
+++ b/pkg/datastore/pipedstore.go
@@ -31,7 +31,7 @@ var (
 		cloudProviders []*model.Piped_CloudProvider,
 		repos []*model.ApplicationGitRepository,
 		status model.Piped_ConnectionStatus,
-		sse *model.Piped_SealedSecretEncryption,
+		se *model.Piped_SecretEncryption,
 		version string,
 		startedAt int64,
 	) func(piped *model.Piped) error {
@@ -40,9 +40,11 @@ var (
 			piped.CloudProviders = cloudProviders
 			piped.Repositories = repos
 			piped.Status = status
-			if sse != nil {
-				piped.SealedSecretEncryption = sse
-			}
+
+			piped.SecretEncryption = se
+			// Remove the legacy data.
+			piped.SealedSecretEncryption = nil
+
 			piped.Version = version
 			piped.StartedAt = startedAt
 			return nil

--- a/pkg/model/piped.go
+++ b/pkg/model/piped.go
@@ -32,11 +32,11 @@ type SecretManagementType string
 
 const (
 	SecretManagementTypeNone SecretManagementType = "NONE"
-	// This type is equal to SEALING_KEY.
+	// SecretManagementTypeKeyPair is equal to SecretManagementTypeSealingKey.
 	// We added this new type because of removing "sealed" prefix.
 	SecretManagementTypeKeyPair SecretManagementType = "KEY_PAIR"
+	// SecretManagementTypeSealingKey is deprecated for a while before being removed completely.
 	// Deprecated
-	// SEALING_KEY is deprecated for a while before being removed completely.
 	SecretManagementTypeSealingKey SecretManagementType = "SEALING_KEY"
 	SecretManagementTypeGCPKMS     SecretManagementType = "GCP_KMS"
 	SecretManagementTypeAWSKMS     SecretManagementType = "AWS_KMS"

--- a/pkg/model/piped.go
+++ b/pkg/model/piped.go
@@ -46,6 +46,13 @@ func (t SecretManagementType) String() string {
 	return string(t)
 }
 
+func GetSecretEncryptionInPiped(p *Piped) *Piped_SecretEncryption {
+	if p.SealedSecretEncryption != nil {
+		return p.SealedSecretEncryption
+	}
+	return p.SecretEncryption
+}
+
 // GeneratePipedKey generates a new key for piped.
 // This returns raw key value for used by piped and
 // a hash value of the key for storing in datastore.

--- a/pkg/model/piped.go
+++ b/pkg/model/piped.go
@@ -28,16 +28,21 @@ const (
 	redactedMessage = "redacted"
 )
 
-type SealedSecretManagementType string
+type SecretManagementType string
 
 const (
-	SealedSecretManagementNone       SealedSecretManagementType = "NONE"
-	SealedSecretManagementSealingKey SealedSecretManagementType = "SEALING_KEY"
-	SealedSecretManagementGCPKMS     SealedSecretManagementType = "GCP_KMS"
-	SealedSecretManagementAWSKMS     SealedSecretManagementType = "AWS_KMS"
+	SecretManagementTypeNone SecretManagementType = "NONE"
+	// This type is equal to SEALING_KEY.
+	// We added this new type because of removing "sealed" prefix.
+	SecretManagementTypeKeyPair SecretManagementType = "KEY_PAIR"
+	// Deprecated
+	// SEALING_KEY is deprecated for a while before being removed completely.
+	SecretManagementTypeSealingKey SecretManagementType = "SEALING_KEY"
+	SecretManagementTypeGCPKMS     SecretManagementType = "GCP_KMS"
+	SecretManagementTypeAWSKMS     SecretManagementType = "AWS_KMS"
 )
 
-func (t SealedSecretManagementType) String() string {
+func (t SecretManagementType) String() string {
 	return string(t)
 }
 

--- a/pkg/model/piped.proto
+++ b/pkg/model/piped.proto
@@ -26,8 +26,8 @@ message Piped {
         string type = 2 [(validate.rules).string.min_len = 1];
     }
 
-    message SealedSecretEncryption {
-        string type = 1 [(validate.rules).string = {in: ["SEALING_KEY", "GCP_KMS", "AWS_KMS", "NONE"]}];
+    message SecretEncryption {
+        string type = 1 [(validate.rules).string = {in: ["KEY_PAIR", "SEALING_KEY", "GCP_KMS", "AWS_KMS", "NONE"]}];
         string public_key = 2;
         string encrypt_service_account = 3;
     }
@@ -62,7 +62,10 @@ message Piped {
     // The latest connection status of piped.
     ConnectionStatus status = 11 [(validate.rules).enum.defined_only = true];
     // The public key/service account for encrypting the secret data.
-    SealedSecretEncryption sealed_secret_encryption = 12;
+    // Deprecated.
+    // TODO: Remove sealed_secret_encryption field in the future.
+    SecretEncryption sealed_secret_encryption = 12;
+    SecretEncryption secret_encryption = 21;
 
     // The list keys can be used to authenticate.
     repeated PipedKey keys = 20;

--- a/pkg/model/piped.proto
+++ b/pkg/model/piped.proto
@@ -64,7 +64,7 @@ message Piped {
     // The public key/service account for encrypting the secret data.
     // Deprecated.
     // TODO: Remove sealed_secret_encryption field in the future.
-    SecretEncryption sealed_secret_encryption = 12;
+    SecretEncryption sealed_secret_encryption = 12 [deprecated = true];
     SecretEncryption secret_encryption = 21;
 
     // The list keys can be used to authenticate.


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds a new `SecretManagement` field next to the existing `SealedSecretManagement` in `Piped` configuration. The new one is more general so it can be used widely, from the current feature as `SealedSecret` to the future ones as  `Secret Templating`, `Remote Config`.
To ensure backward compatibility the`SealedSecretManagement` field is marked with the "Deprecated" label and will be kept for a while. It will be removed completely in the future.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
