### PR TITLE
Use absolute path for test utils importing

### DIFF
--- a/pkg/app/web/.storybook/redux-decorator.tsx
+++ b/pkg/app/web/.storybook/redux-decorator.tsx
@@ -1,7 +1,7 @@
 import { DeepPartial } from "@reduxjs/toolkit";
 import { Provider } from "react-redux";
 import type { AppState } from "../src/store";
-import { createStore } from "../test-utils";
+import { createStore } from "test-utils";
 
 export const createDecoratorRedux = (initialState: DeepPartial<AppState>) => (
   storyFn: any

--- a/pkg/app/web/BUILD.bazel
+++ b/pkg/app/web/BUILD.bazel
@@ -116,7 +116,7 @@ jest_test(
         ":file-transformer.js",
         ":jest.after-env.ts",
         ":jest.setup.js",
-        ":test-utils.tsx",
+        ":test-utils",
         ":tsconfig.json",
         "@npm//:node_modules",
     ],

--- a/pkg/app/web/jest.config.js
+++ b/pkg/app/web/jest.config.js
@@ -7,6 +7,7 @@ module.exports = {
   },
   moduleNameMapper: {
     "^pipe/(.*)$": "<rootDir>/../../../$1",
+    "^test-utils$": "<rootDir>/test-utils",
   },
   moduleDirectories: ["node_modules", "__fixtures__"],
   coveragePathIgnorePatterns: [

--- a/pkg/app/web/jest.config.local.js
+++ b/pkg/app/web/jest.config.local.js
@@ -7,6 +7,7 @@ module.exports = {
   },
   moduleNameMapper: {
     "^pipe/(.*)$": "<rootDir>/../../../bazel-bin/$1",
+    "^test-utils$": "<rootDir>/test-utils",
   },
   moduleDirectories: ["<rootDir>/node_modules", "__fixtures__"],
   coveragePathIgnorePatterns: [

--- a/pkg/app/web/src/components/add-application-drawer/index.test.tsx
+++ b/pkg/app/web/src/components/add-application-drawer/index.test.tsx
@@ -1,5 +1,5 @@
 import { AddApplicationDrawer } from "./";
-import { createStore, render, screen, waitFor } from "../../../test-utils";
+import { createStore, render, screen, waitFor } from "test-utils";
 import { UI_TEXT_CANCEL, UI_TEXT_SAVE } from "../../constants/ui-text";
 import { dummyEnv } from "../../__fixtures__/dummy-environment";
 import { APPLICATION_KIND_TEXT } from "../../constants/application-kind";

--- a/pkg/app/web/src/components/app-live-state/index.stories.tsx
+++ b/pkg/app/web/src/components/app-live-state/index.stories.tsx
@@ -1,6 +1,6 @@
 import { Story } from "@storybook/react";
 import { Provider } from "react-redux";
-import { createStore } from "../../../test-utils";
+import { createStore } from "test-utils";
 import { dummyApplication } from "../../__fixtures__/dummy-application";
 import { dummyApplicationLiveState } from "../../__fixtures__/dummy-application-live-state";
 import { AppLiveState } from "./";

--- a/pkg/app/web/src/components/application-counts/index.test.tsx
+++ b/pkg/app/web/src/components/application-counts/index.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "../../../test-utils";
+import { render, screen } from "test-utils";
 import { ApplicationCounts } from "./index";
 
 test("displaying application counts", () => {

--- a/pkg/app/web/src/components/application-detail/index.stories.tsx
+++ b/pkg/app/web/src/components/application-detail/index.stories.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { ApplicationSyncStatus } from "pipe/pkg/app/web/model/application_pb";
-import { createStore } from "../../../test-utils";
+import { createStore } from "test-utils";
 import { dummyApplication } from "../../__fixtures__/dummy-application";
 import { dummyApplicationLiveState } from "../../__fixtures__/dummy-application-live-state";
 import { dummyEnv } from "../../__fixtures__/dummy-environment";

--- a/pkg/app/web/src/components/application-detail/index.test.tsx
+++ b/pkg/app/web/src/components/application-detail/index.test.tsx
@@ -6,7 +6,7 @@ import {
   render,
   screen,
   waitFor,
-} from "../../../test-utils";
+} from "test-utils";
 import { server } from "../../mocks/server";
 import {
   Application,

--- a/pkg/app/web/src/components/application-filter/index.test.tsx
+++ b/pkg/app/web/src/components/application-filter/index.test.tsx
@@ -1,5 +1,5 @@
 import userEvent from "@testing-library/user-event";
-import { render, screen } from "../../../test-utils";
+import { render, screen } from "test-utils";
 import { UI_TEXT_CLEAR } from "../../constants/ui-text";
 import {
   ApplicationKind,

--- a/pkg/app/web/src/components/application-list-item/index.test.tsx
+++ b/pkg/app/web/src/components/application-list-item/index.test.tsx
@@ -1,6 +1,6 @@
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
-import { createStore, render, screen } from "../../../test-utils";
+import { createStore, render, screen } from "test-utils";
 import { dummyApplication } from "../../__fixtures__/dummy-application";
 import { ApplicationListItem } from "./";
 

--- a/pkg/app/web/src/components/application-list/index.test.tsx
+++ b/pkg/app/web/src/components/application-list/index.test.tsx
@@ -1,6 +1,6 @@
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
-import { createStore, render, screen, waitFor } from "../../../test-utils";
+import { createStore, render, screen, waitFor } from "test-utils";
 import { server } from "../../mocks/server";
 import {
   disableApplication,

--- a/pkg/app/web/src/components/application-state-view/index.test.tsx
+++ b/pkg/app/web/src/components/application-state-view/index.test.tsx
@@ -1,4 +1,4 @@
-import { createStore, render, screen } from "../../../test-utils";
+import { createStore, render, screen } from "test-utils";
 import { ApplicationStateView } from "./";
 import { dummyApplicationLiveState } from "../../__fixtures__/dummy-application-live-state";
 import { fetchApplicationStateById } from "../../modules/applications-live-state";

--- a/pkg/app/web/src/components/approval-stage/index.test.tsx
+++ b/pkg/app/web/src/components/approval-stage/index.test.tsx
@@ -1,5 +1,5 @@
 import { ApprovalStage } from "./";
-import { render, screen } from "../../../test-utils";
+import { render, screen } from "test-utils";
 import userEvent from "@testing-library/user-event";
 
 it("shows stage name", () => {

--- a/pkg/app/web/src/components/copy-icon-button/index.test.tsx
+++ b/pkg/app/web/src/components/copy-icon-button/index.test.tsx
@@ -1,6 +1,6 @@
 import { waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { render, screen, createStore } from "../../../test-utils";
+import { render, screen, createStore } from "test-utils";
 import { addToast } from "../../modules/toasts";
 import { CopyIconButton } from "./";
 

--- a/pkg/app/web/src/components/deployment-config-form/index.stories.tsx
+++ b/pkg/app/web/src/components/deployment-config-form/index.stories.tsx
@@ -1,6 +1,6 @@
 import { DeploymentConfigForm } from "./";
 import { action } from "@storybook/addon-actions";
-import { createStore } from "../../../test-utils";
+import { createStore } from "test-utils";
 import { Provider } from "react-redux";
 import { dummyDeploymentConfigTemplates } from "../../__fixtures__/dummy-deployment-config";
 import { Story } from "@storybook/react";

--- a/pkg/app/web/src/components/deployment-config-form/index.test.tsx
+++ b/pkg/app/web/src/components/deployment-config-form/index.test.tsx
@@ -1,6 +1,6 @@
 import userEvent from "@testing-library/user-event";
 import { setupServer } from "msw/node";
-import { createReduxStore, render, screen, waitFor } from "../../../test-utils";
+import { createReduxStore, render, screen, waitFor } from "test-utils";
 import { listDeploymentConfigTemplatesHandler } from "../../mocks/services/deployment-config";
 import { dummyApplication } from "../../__fixtures__/dummy-application";
 import { DeploymentConfigForm } from "./";

--- a/pkg/app/web/src/components/deployment-detail/index.test.tsx
+++ b/pkg/app/web/src/components/deployment-detail/index.test.tsx
@@ -1,4 +1,4 @@
-import { createStore, render, screen } from "../../../test-utils";
+import { createStore, render, screen } from "test-utils";
 import { DeploymentDetail } from "./";
 import { dummyDeployment } from "../../__fixtures__/dummy-deployment";
 import { dummyEnv } from "../../__fixtures__/dummy-environment";

--- a/pkg/app/web/src/components/deployment-filter/index.test.tsx
+++ b/pkg/app/web/src/components/deployment-filter/index.test.tsx
@@ -1,5 +1,5 @@
 import userEvent from "@testing-library/user-event";
-import { render, screen } from "../../../test-utils";
+import { render, screen } from "test-utils";
 import { UI_TEXT_CLEAR } from "../../constants/ui-text";
 import { ApplicationKind } from "../../modules/applications";
 import { DeploymentStatus } from "../../modules/deployments";

--- a/pkg/app/web/src/components/deployment-item/index.stories.tsx
+++ b/pkg/app/web/src/components/deployment-item/index.stories.tsx
@@ -3,7 +3,7 @@ import { dummyDeployment } from "../../__fixtures__/dummy-deployment";
 import { dummyApplication } from "../../__fixtures__/dummy-application";
 import { dummyEnv } from "../../__fixtures__/dummy-environment";
 import { Provider } from "react-redux";
-import { createStore } from "../../../test-utils";
+import { createStore } from "test-utils";
 import { Story } from "@storybook/react";
 
 export default {

--- a/pkg/app/web/src/components/deployment-status-icon/index.test.tsx
+++ b/pkg/app/web/src/components/deployment-status-icon/index.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "../../../test-utils";
+import { render, screen } from "test-utils";
 import { DeploymentStatus } from "../../modules/deployments";
 import { DeploymentStatusIcon } from "./";
 

--- a/pkg/app/web/src/components/diff-view/index.test.tsx
+++ b/pkg/app/web/src/components/diff-view/index.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "../../../test-utils";
+import { render, screen } from "test-utils";
 import { DiffView } from "./";
 
 it("should render normal text", () => {

--- a/pkg/app/web/src/components/edit-application-drawer/index.test.tsx
+++ b/pkg/app/web/src/components/edit-application-drawer/index.test.tsx
@@ -1,7 +1,7 @@
 import { waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { setupServer } from "msw/node";
-import { createReduxStore, render, screen } from "../../../test-utils";
+import { createReduxStore, render, screen } from "test-utils";
 import { UI_TEXT_SAVE } from "../../constants/ui-text";
 import {
   updateApplicationHandler,

--- a/pkg/app/web/src/components/header/index.stories.tsx
+++ b/pkg/app/web/src/components/header/index.stories.tsx
@@ -1,5 +1,5 @@
 import { Header } from "./";
-import { createStore } from "../../../test-utils";
+import { createStore } from "test-utils";
 import { Provider } from "react-redux";
 import { Role } from "../../../../../../bazel-bin/pkg/app/web/model/role_pb";
 import { Story } from "@storybook/react";

--- a/pkg/app/web/src/components/header/index.test.tsx
+++ b/pkg/app/web/src/components/header/index.test.tsx
@@ -1,6 +1,6 @@
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
-import { render, screen } from "../../../test-utils";
+import { render, screen } from "test-utils";
 import { Role } from "../../modules/me";
 import { Header } from "./";
 

--- a/pkg/app/web/src/components/kubernetes-state-view/index.test.tsx
+++ b/pkg/app/web/src/components/kubernetes-state-view/index.test.tsx
@@ -1,5 +1,5 @@
 import userEvent from "@testing-library/user-event";
-import { render, screen } from "../../../test-utils";
+import { render, screen } from "test-utils";
 import { UI_TEXT_FILTER } from "../../constants/ui-text";
 import { resourcesList } from "../../__fixtures__/dummy-application-live-state";
 import { KubernetesStateView } from "./";

--- a/pkg/app/web/src/components/log-viewer/index.test.tsx
+++ b/pkg/app/web/src/components/log-viewer/index.test.tsx
@@ -1,5 +1,5 @@
 import userEvent from "@testing-library/user-event";
-import { createStore, render, screen } from "../../../test-utils";
+import { createStore, render, screen } from "test-utils";
 import { clearActiveStage } from "../../modules/active-stage";
 import { createActiveStageKey, LogSeverity } from "../../modules/stage-logs";
 import { dummyDeployment } from "../../__fixtures__/dummy-deployment";

--- a/pkg/app/web/src/components/pipeline/index.test.tsx
+++ b/pkg/app/web/src/components/pipeline/index.test.tsx
@@ -1,4 +1,4 @@
-import { createStore, render } from "../../../test-utils";
+import { createStore, render } from "test-utils";
 import { updateActiveStage } from "../../modules/active-stage";
 import { dummyDeployment } from "../../__fixtures__/dummy-deployment";
 

--- a/pkg/app/web/src/components/rbac-form/index.stories.tsx
+++ b/pkg/app/web/src/components/rbac-form/index.stories.tsx
@@ -1,6 +1,6 @@
 import { RBACForm } from "./";
 import { Provider } from "react-redux";
-import { createStore } from "../../../test-utils";
+import { createStore } from "test-utils";
 import { Story } from "@storybook/react";
 
 export default {

--- a/pkg/app/web/src/components/sealed-secret-dialog/index.stories.tsx
+++ b/pkg/app/web/src/components/sealed-secret-dialog/index.stories.tsx
@@ -2,7 +2,7 @@ import { action } from "@storybook/addon-actions";
 import { dummyApplication } from "../../__fixtures__/dummy-application";
 import { SealedSecretDialog } from "./";
 import { Provider } from "react-redux";
-import { createStore } from "../../../test-utils";
+import { createStore } from "test-utils";
 import { Story } from "@storybook/react";
 
 export default {

--- a/pkg/app/web/src/components/sealed-secret-dialog/index.test.tsx
+++ b/pkg/app/web/src/components/sealed-secret-dialog/index.test.tsx
@@ -1,7 +1,7 @@
 import { waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { setupServer } from "msw/node";
-import { createReduxStore, render, screen } from "../../../test-utils";
+import { createReduxStore, render, screen } from "test-utils";
 import { generateApplicationSealedSecretHandler } from "../../mocks/services/piped";
 import { dummyApplication } from "../../__fixtures__/dummy-application";
 import { SealedSecretDialog } from "./";

--- a/pkg/app/web/src/components/split-button/index.test.tsx
+++ b/pkg/app/web/src/components/split-button/index.test.tsx
@@ -1,5 +1,5 @@
 import userEvent from "@testing-library/user-event";
-import { render, screen } from "../../../test-utils";
+import { render, screen } from "test-utils";
 import { SplitButton } from "./";
 
 it("calls onClick handler with option's index if clicked", async () => {

--- a/pkg/app/web/src/components/static-admin-form/index.test.tsx
+++ b/pkg/app/web/src/components/static-admin-form/index.test.tsx
@@ -6,7 +6,7 @@ import {
   act,
   waitForElementToBeRemoved,
   waitFor,
-} from "../../../test-utils";
+} from "test-utils";
 import { server } from "../../mocks/server";
 import { updateStaticAdmin } from "../../modules/project";
 import { StaticAdminForm } from "./";

--- a/pkg/app/web/src/components/toasts/index.stories.tsx
+++ b/pkg/app/web/src/components/toasts/index.stories.tsx
@@ -1,6 +1,6 @@
 import { Toasts } from "./";
 import { Provider } from "react-redux";
-import { createStore } from "../../../test-utils";
+import { createStore } from "test-utils";
 import { Story } from "@storybook/react";
 
 export default {

--- a/pkg/app/web/src/components/toasts/index.test.tsx
+++ b/pkg/app/web/src/components/toasts/index.test.tsx
@@ -1,5 +1,5 @@
 import userEvent from "@testing-library/user-event";
-import { render, screen, createStore } from "../../../test-utils";
+import { render, screen, createStore } from "test-utils";
 import { IToast, removeToast } from "../../modules/toasts";
 import { Toasts } from "./";
 

--- a/pkg/app/web/src/modules/application-counts/index.test.ts
+++ b/pkg/app/web/src/modules/application-counts/index.test.ts
@@ -1,5 +1,5 @@
 import { setupServer } from "msw/node";
-import { createReduxStore, createStore } from "../../../test-utils";
+import { createReduxStore, createStore } from "test-utils";
 import {
   getInsightApplicationCountHandler,
   getInsightApplicationCountNotFound,

--- a/pkg/app/web/src/modules/applications/index.test.ts
+++ b/pkg/app/web/src/modules/applications/index.test.ts
@@ -1,5 +1,5 @@
 import { setupServer } from "msw/node";
-import { createStore } from "../../../test-utils";
+import { createStore } from "test-utils";
 import { listApplicationsHandler } from "../../mocks/services/application";
 import {
   dummyApplication,

--- a/pkg/app/web/src/modules/commands/index.test.ts
+++ b/pkg/app/web/src/modules/commands/index.test.ts
@@ -1,4 +1,4 @@
-import { createStore } from "../../../test-utils";
+import { createStore } from "test-utils";
 import { server } from "../../mocks/server";
 import {
   dummyCommand,

--- a/pkg/app/web/src/modules/environments/index.test.ts
+++ b/pkg/app/web/src/modules/environments/index.test.ts
@@ -1,4 +1,4 @@
-import { createReduxStore, createStore } from "../../../test-utils";
+import { createReduxStore, createStore } from "test-utils";
 import { server } from "../../mocks/server";
 import {
   addEnvironmentHandler,

--- a/pkg/app/web/src/modules/me/index.test.ts
+++ b/pkg/app/web/src/modules/me/index.test.ts
@@ -1,5 +1,5 @@
 import { setupServer } from "msw/node";
-import { createStore } from "../../../test-utils";
+import { createStore } from "test-utils";
 import { getMeHandler } from "../../mocks/services/me";
 import { dummyMe } from "../../__fixtures__/dummy-me";
 import { fetchMe, meSlice, Role, selectProjectName } from "./";

--- a/pkg/app/web/src/modules/stage-logs/index.test.ts
+++ b/pkg/app/web/src/modules/stage-logs/index.test.ts
@@ -6,7 +6,7 @@ import {
   LogSeverity,
 } from "./";
 import { setupServer } from "msw/node";
-import { createReduxStore } from "../../../test-utils";
+import { createReduxStore } from "test-utils";
 import { dummyDeployment } from "../../__fixtures__/dummy-deployment";
 import {
   getStageLogHandler,

--- a/pkg/app/web/src/pages/applications/detail.test.tsx
+++ b/pkg/app/web/src/pages/applications/detail.test.tsx
@@ -1,5 +1,5 @@
 import { MemoryRouter, Route } from "react-router-dom";
-import { createStore, render } from "../../../test-utils";
+import { createStore, render } from "test-utils";
 import { PAGE_PATH_APPLICATIONS } from "../../constants/path";
 import { fetchApplication } from "../../modules/applications";
 import { fetchApplicationStateById } from "../../modules/applications-live-state";

--- a/pkg/app/web/src/pages/deployments/detail.test.tsx
+++ b/pkg/app/web/src/pages/deployments/detail.test.tsx
@@ -1,5 +1,5 @@
 import { MemoryRouter, Route } from "react-router-dom";
-import { createReduxStore, render, waitFor } from "../../../test-utils";
+import { createReduxStore, render, waitFor } from "test-utils";
 import { server } from "../../mocks/server";
 import { dummyDeployment } from "../../__fixtures__/dummy-deployment";
 import { dummyEnv } from "../../__fixtures__/dummy-environment";

--- a/pkg/app/web/src/pages/index.test.tsx
+++ b/pkg/app/web/src/pages/index.test.tsx
@@ -1,5 +1,5 @@
 import { MemoryRouter } from "react-router-dom";
-import { render, screen } from "../../test-utils";
+import { render, screen } from "test-utils";
 import { Pages } from "./index";
 import { setupServer } from "msw/node";
 import { GetMeResponse } from "pipe/pkg/app/web/api_client/service_pb";

--- a/pkg/app/web/src/pages/settings/environment/index.test.tsx
+++ b/pkg/app/web/src/pages/settings/environment/index.test.tsx
@@ -1,5 +1,5 @@
 import userEvent from "@testing-library/user-event";
-import { render, screen, createReduxStore } from "../../../../test-utils";
+import { render, screen, createReduxStore } from "test-utils";
 import { SettingsEnvironmentPage } from "./index";
 import { setupServer } from "msw/node";
 import {

--- a/pkg/app/web/test-utils/index.tsx
+++ b/pkg/app/web/test-utils/index.tsx
@@ -11,10 +11,10 @@ import {
 import { render, RenderOptions, RenderResult } from "@testing-library/react";
 import { Provider } from "react-redux";
 import configureMockStore from "redux-mock-store";
-import { reducers } from "./src/modules";
-import type { AppState } from "./src/store";
-import { theme } from "./src/theme";
-import { thunkErrorHandler } from "./src/middlewares/thunk-error-handler";
+import { reducers } from "../src/modules";
+import type { AppState } from "../src/store";
+import { theme } from "../src/theme";
+import { thunkErrorHandler } from "../src/middlewares/thunk-error-handler";
 
 const middlewares = getDefaultMiddleware({
   immutableCheck: false,

--- a/pkg/app/web/tsconfig.json
+++ b/pkg/app/web/tsconfig.json
@@ -1,6 +1,9 @@
 {
   "compilerOptions": {
     "paths": {
+      "test-utils": [
+        "./test-utils"
+      ],
       "pipe/*": [
         "../../../bazel-out/darwin-fastbuild/bin/*",
         "../../../bazel-out/k8-fastbuild/bin/*",


### PR DESCRIPTION
**What this PR does / why we need it**:

**Before**
```ts
import { screen } from '../test-utils';
import { screen } from '../../test-utils';
import { screen } from '../../../test-utils';
```

**After**
```ts
import { screen } from 'test-utils';
```

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
