### PR TITLE
Ensure ECS deployment allow JSON file config

### DIFF
--- a/pkg/app/piped/cloudprovider/ecs/BUILD.bazel
+++ b/pkg/app/piped/cloudprovider/ecs/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -25,5 +25,20 @@ go_library(
         "@io_k8s_sigs_yaml//:go_default_library",
         "@org_golang_x_sync//singleflight:go_default_library",
         "@org_uber_go_zap//:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    size="small",
+    srcs = [
+        "servce_test.go",
+        "task_test.go",
+    ],
+    embed = [":go_default_library"],
+    deps = [
+        "@com_github_aws_aws_sdk_go_v2//aws:go_default_library",
+        "@com_github_aws_aws_sdk_go_v2_service_ecs//types:go_default_library",
+        "@com_github_stretchr_testify//assert:go_default_library",
     ],
 )

--- a/pkg/app/piped/cloudprovider/ecs/servce_test.go
+++ b/pkg/app/piped/cloudprovider/ecs/servce_test.go
@@ -1,0 +1,165 @@
+// Copyright 2021 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ecs
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseServiceDefinition(t *testing.T) {
+	testcases := []struct {
+		name        string
+		input       string
+		expected    types.Service
+		expectedErr bool
+	}{
+		{
+			name: "yaml format input",
+			input: `
+cluster: arn:aws:ecs:ap-northeast-1:XXXX:cluster/YYYY
+serviceName: nginx-external-canary
+desiredCount: 2
+role: arn:aws:iam::XXXXX:role/ecsTaskExecutionRole
+deploymentConfiguration:
+  maximumPercent: 200
+  minimumHealthyPercent: 0
+schedulingStrategy: REPLICA
+deploymentController:
+  type: EXTERNAL
+`,
+			expected: types.Service{
+				ClusterArn:   aws.String("arn:aws:ecs:ap-northeast-1:XXXX:cluster/YYYY"),
+				ServiceName:  aws.String("nginx-external-canary"),
+				DesiredCount: 2,
+				RoleArn:      aws.String("arn:aws:iam::XXXXX:role/ecsTaskExecutionRole"),
+				DeploymentConfiguration: &types.DeploymentConfiguration{
+					MaximumPercent:        aws.Int32(200),
+					MinimumHealthyPercent: aws.Int32(0),
+				},
+				SchedulingStrategy: types.SchedulingStrategyReplica,
+				DeploymentController: &types.DeploymentController{
+					Type: types.DeploymentControllerTypeExternal,
+				},
+			},
+		},
+		{
+			name: "yaml format input with roleArn field name",
+			input: `
+cluster: arn:aws:ecs:ap-northeast-1:XXXX:cluster/YYYY
+serviceName: nginx-external-canary
+desiredCount: 2
+roleArn: arn:aws:iam::XXXXX:role/ecsTaskExecutionRole
+deploymentConfiguration:
+  maximumPercent: 200
+  minimumHealthyPercent: 0
+schedulingStrategy: REPLICA
+deploymentController:
+  type: EXTERNAL
+`,
+			expected: types.Service{
+				ClusterArn:   aws.String("arn:aws:ecs:ap-northeast-1:XXXX:cluster/YYYY"),
+				ServiceName:  aws.String("nginx-external-canary"),
+				DesiredCount: 2,
+				RoleArn:      aws.String("arn:aws:iam::XXXXX:role/ecsTaskExecutionRole"),
+				DeploymentConfiguration: &types.DeploymentConfiguration{
+					MaximumPercent:        aws.Int32(200),
+					MinimumHealthyPercent: aws.Int32(0),
+				},
+				SchedulingStrategy: types.SchedulingStrategyReplica,
+				DeploymentController: &types.DeploymentController{
+					Type: types.DeploymentControllerTypeExternal,
+				},
+			},
+		},
+		{
+			name: "json format input",
+			input: `
+{
+  "cluster": "arn:aws:ecs:ap-northeast-1:XXXX:cluster/YYYY",
+  "serviceName": "nginx-external-canary",
+  "desiredCount": 2,
+  "role": "arn:aws:iam::XXXXX:role/ecsTaskExecutionRole",
+  "deploymentConfiguration": {
+    "maximumPercent": 200,
+    "minimumHealthyPercent": 0
+  },
+  "schedulingStrategy": "REPLICA",
+  "deploymentController": {
+    "type": "EXTERNAL"
+  }
+}
+`,
+			expected: types.Service{
+				ClusterArn:   aws.String("arn:aws:ecs:ap-northeast-1:XXXX:cluster/YYYY"),
+				ServiceName:  aws.String("nginx-external-canary"),
+				DesiredCount: 2,
+				RoleArn:      aws.String("arn:aws:iam::XXXXX:role/ecsTaskExecutionRole"),
+				DeploymentConfiguration: &types.DeploymentConfiguration{
+					MaximumPercent:        aws.Int32(200),
+					MinimumHealthyPercent: aws.Int32(0),
+				},
+				SchedulingStrategy: types.SchedulingStrategyReplica,
+				DeploymentController: &types.DeploymentController{
+					Type: types.DeploymentControllerTypeExternal,
+				},
+			},
+		},
+		{
+			name: "json format input with clusterArn field name",
+			input: `
+{
+  "clusterArn": "arn:aws:ecs:ap-northeast-1:XXXX:cluster/YYYY",
+  "serviceName": "nginx-external-canary",
+  "desiredCount": 2,
+  "role": "arn:aws:iam::XXXXX:role/ecsTaskExecutionRole",
+  "deploymentConfiguration": {
+    "maximumPercent": 200,
+    "minimumHealthyPercent": 0
+  },
+  "schedulingStrategy": "REPLICA",
+  "deploymentController": {
+    "type": "EXTERNAL"
+  }
+}
+`,
+			expected: types.Service{
+				ClusterArn:   aws.String("arn:aws:ecs:ap-northeast-1:XXXX:cluster/YYYY"),
+				ServiceName:  aws.String("nginx-external-canary"),
+				DesiredCount: 2,
+				RoleArn:      aws.String("arn:aws:iam::XXXXX:role/ecsTaskExecutionRole"),
+				DeploymentConfiguration: &types.DeploymentConfiguration{
+					MaximumPercent:        aws.Int32(200),
+					MinimumHealthyPercent: aws.Int32(0),
+				},
+				SchedulingStrategy: types.SchedulingStrategyReplica,
+				DeploymentController: &types.DeploymentController{
+					Type: types.DeploymentControllerTypeExternal,
+				},
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseServiceDefinition([]byte(tc.input))
+			assert.Equal(t, tc.expectedErr, err != nil)
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+}

--- a/pkg/app/piped/cloudprovider/ecs/task.go
+++ b/pkg/app/piped/cloudprovider/ecs/task.go
@@ -34,7 +34,6 @@ func loadTaskDefinition(path string) (types.TaskDefinition, error) {
 
 func parseTaskDefinition(data []byte) (types.TaskDefinition, error) {
 	var obj types.TaskDefinition
-	// TODO: Support loading TaskDefinition file with JSON format
 	if err := yaml.Unmarshal(data, &obj); err != nil {
 		return types.TaskDefinition{}, err
 	}

--- a/pkg/app/piped/cloudprovider/ecs/task_test.go
+++ b/pkg/app/piped/cloudprovider/ecs/task_test.go
@@ -1,0 +1,80 @@
+// Copyright 2021 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ecs
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseTaskDefinition(t *testing.T) {
+	testcases := []struct {
+		name        string
+		input       string
+		expected    types.TaskDefinition
+		expectedErr bool
+	}{
+		{
+			name: "yaml format input",
+			input: `
+family: nginx-canary-fam-1
+compatibilities:
+  - FARGATE
+networkMode: awsvpc
+memory: 512
+cpu: 256
+`,
+			expected: types.TaskDefinition{
+				Family:          aws.String("nginx-canary-fam-1"),
+				Compatibilities: []types.Compatibility{types.CompatibilityFargate},
+				NetworkMode:     types.NetworkModeAwsvpc,
+				Memory:          aws.String("512"),
+				Cpu:             aws.String("256"),
+			},
+		},
+		{
+			name: "json format input",
+			input: `
+{
+  "family": "nginx-canary-fam-1",
+  "compatibilities": [
+    "FARGATE"
+  ],
+  "networkMode": "awsvpc",
+  "memory": 512,
+  "cpu": 256
+}
+`,
+			expected: types.TaskDefinition{
+				Family:          aws.String("nginx-canary-fam-1"),
+				Compatibilities: []types.Compatibility{types.CompatibilityFargate},
+				NetworkMode:     types.NetworkModeAwsvpc,
+				Memory:          aws.String("512"),
+				Cpu:             aws.String("256"),
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseTaskDefinition([]byte(tc.input))
+			assert.Equal(t, tc.expectedErr, err != nil)
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Add test to ensure the current ECS deployment allows configuration in JSON format.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
