### PR TITLE
Make Popover render only when needed

### DIFF
--- a/pkg/app/web/src/components/application-list-item/index.tsx
+++ b/pkg/app/web/src/components/application-list-item/index.tsx
@@ -152,7 +152,6 @@ export const ApplicationListItem: FC<ApplicationListItemProps> = memo(
         <Menu
           id="application-menu"
           anchorEl={anchorEl}
-          keepMounted
           open={Boolean(anchorEl)}
           onClose={() => setAnchorEl(null)}
           PaperProps={{

--- a/pkg/app/web/src/components/header/index.tsx
+++ b/pkg/app/web/src/components/header/index.tsx
@@ -160,7 +160,6 @@ export const Header: FC = memo(function Header() {
       <Menu
         id="user-menu"
         anchorEl={anchorEl}
-        keepMounted
         open={Boolean(anchorEl)}
         onClose={handleClose}
       >

--- a/pkg/app/web/src/pages/settings/piped/piped-table-row.tsx
+++ b/pkg/app/web/src/pages/settings/piped/piped-table-row.tsx
@@ -175,7 +175,6 @@ export const PipedTableRow: FC<Props> = memo(function PipedTableRow({
       <Menu
         id="piped-menu"
         anchorEl={anchorEl}
-        keepMounted
         open={Boolean(anchorEl)}
         onClose={handleMenuClose}
         PaperProps={menuStyle}


### PR DESCRIPTION
**What this PR does / why we need it**:

I set the KeepMounted option to false.
This will mount the DOM only when the menu is opened.
https://material-ui.com/api/modal/#props

**Before**

<image width="300" src="https://user-images.githubusercontent.com/6136383/122552546-63d94f80-d071-11eb-89ca-05d90c1685ce.png" />


**After**

<image width="300" src="https://user-images.githubusercontent.com/6136383/122552490-56bc6080-d071-11eb-9a17-6db29f81e1cb.png" />


**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
