### PR TITLE
Change the default ECS configuration files format to `JSON`

### DIFF
--- a/docs/content/en/docs/user-guide/configuration-reference.md
+++ b/docs/content/en/docs/user-guide/configuration-reference.md
@@ -93,6 +93,7 @@ spec:
 ``` yaml
 apiVersion: pipecd.dev/v1beta1
 kind: ECSApp
+input:
 spec:
   pipeline:
   ...
@@ -100,6 +101,7 @@ spec:
 
 | Field | Type | Description | Required |
 |-|-|-|-|
+| input | [ECSDeploymentInput](#ecsdeploymentinput) | Input for ECS deployment such as TaskDefinition, Service... | Yes |
 | quickSync | [ECSQuickSync](/docs/user-guide/configuration-reference/#ecsquicksync) | Configuration for quick sync. | No |
 | pipeline | [Pipeline](/docs/user-guide/configuration-reference/#pipeline) | Pipeline for deploying progressively. | No |
 | triggerPaths | []string | List of directories or files where their changes will trigger the deployment. Regular expression can be used. | No |
@@ -294,6 +296,23 @@ spec:
 
 | Field | Type | Description | Required |
 |-|-|-|-|
+
+## ECSDeploymentInput
+
+| Field | Type | Description | Required |
+|-|-|-|-|
+| serviceDefinitionFile | string | The path ECS Service configuration file. Allow file in both `yaml` and `json` format. The default value is `servicedef.json`. | No |
+| taskDefinitionFile | string | The path to ECS TaskDefinition configuration file. Allow file in both `yaml` and `json` format. The default value is `taskdef.json`. | No |
+| targetGroups | [ECSTargetGroupInput](#ecstargetgroupinput) | The target groups configuration, will be used to routing traffic to created task sets. | Yes |
+
+### ECSTargetGroupInput
+
+| Field | Type | Description | Required |
+|-|-|-|-|
+| primary | ECSTargetGroupObject | The PRIMARY target group, will be used to register the PRIMARY ECS task set. | Yes |
+| canary | ECSTargetGroupObject | The CANARY target group, will be used to register the CANARY ECS task set if exist. It's required to enable PipeCD to perform the multi-stage deployment. | No |
+
+Note: You can get examples for those object from [here](/docs/examples/#ecs-applications).
 
 ## ECSQuickSync
 

--- a/docs/content/en/docs/user-guide/configuration-reference.md
+++ b/docs/content/en/docs/user-guide/configuration-reference.md
@@ -93,8 +93,8 @@ spec:
 ``` yaml
 apiVersion: pipecd.dev/v1beta1
 kind: ECSApp
-input:
 spec:
+  input:
   pipeline:
   ...
 ```

--- a/docs/content/en/docs/user-guide/configuration-reference.md
+++ b/docs/content/en/docs/user-guide/configuration-reference.md
@@ -301,7 +301,7 @@ spec:
 
 | Field | Type | Description | Required |
 |-|-|-|-|
-| serviceDefinitionFile | string | The path ECS Service configuration file. Allow file in both `yaml` and `json` format. The default value is `servicedef.json`. | No |
+| serviceDefinitionFile | string | The path ECS Service configuration file. Allow file in both `yaml` and `json` format. The default value is `service.json`. | No |
 | taskDefinitionFile | string | The path to ECS TaskDefinition configuration file. Allow file in both `yaml` and `json` format. The default value is `taskdef.json`. | No |
 | targetGroups | [ECSTargetGroupInput](#ecstargetgroupinput) | The target groups configuration, will be used to routing traffic to created task sets. | Yes |
 

--- a/docs/content/en/docs/user-guide/configuring-deployment/ecs.md
+++ b/docs/content/en/docs/user-guide/configuring-deployment/ecs.md
@@ -6,7 +6,7 @@ description: >
   Specific guide for configuring Amazon ECS deployment.
 ---
 
-Deploying an Amazon ECS application requires `taskdef.yaml` and `servicedef.yaml` file placing inside the application directory. Those files contain all configuration for [ECS TaskDefinition](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definitions.html) object and [ECS Service](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs_services.html) object, and will be used by Piped agent while deploy your application/service to ECS cluster.
+Deploying an Amazon ECS application requires `TaskDefinition` and `Service` configuration files placing inside the application directory. Those files contain all configuration for [ECS TaskDefinition](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definitions.html) object and [ECS Service](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs_services.html) object, and will be used by Piped agent while deploy your application/service to ECS cluster.
 
 If you're not familiar with ECS, you can get examples for those files from [here](/docs/examples/#ecs-applications).
 
@@ -44,6 +44,22 @@ Here is an example that rolls out the new version gradually:
 apiVersion: pipecd.dev/v1beta1
 kind: ECSApp
 spec:
+  input:
+    # Path to Service configuration file in Yaml/JSON format.
+    # Default is `servicedef.json`
+    serviceDefinitionFile: servicedef.yaml
+    # Path to TaskDefinition configuration file in Yaml/JSON format.
+    # Default is `taskdef.json`
+    taskDefinitionFile: taskdef.yaml
+    targetGroups:
+      primary:
+        targetGroupArn: arn:aws:elasticloadbalancing:ap-northeast-1:XXXX:targetgroup/ecs-canary-blue/YYYY
+        containerName: web
+        containerPort: 80
+      canary:
+        targetGroupArn: arn:aws:elasticloadbalancing:ap-northeast-1:XXXX:targetgroup/ecs-canary-green/YYYY
+        containerName: web
+        containerPort: 80
   pipeline:
     stages:
       # Deploy the workloads of CANARY variant, the number of workload

--- a/docs/content/en/docs/user-guide/configuring-deployment/ecs.md
+++ b/docs/content/en/docs/user-guide/configuring-deployment/ecs.md
@@ -46,7 +46,7 @@ kind: ECSApp
 spec:
   input:
     # Path to Service configuration file in Yaml/JSON format.
-    # Default is `servicedef.json`
+    # Default is `service.json`
     serviceDefinitionFile: servicedef.yaml
     # Path to TaskDefinition configuration file in Yaml/JSON format.
     # Default is `taskdef.json`

--- a/pkg/config/deployment_ecs.go
+++ b/pkg/config/deployment_ecs.go
@@ -35,8 +35,8 @@ func (s *ECSDeploymentSpec) Validate() error {
 
 type ECSDeploymentInput struct {
 	// The name of service definition file placing in application directory.
-	// Default is servicedef.json
-	ServiceDefinitionFile string `json:"serviceDefinitionFile" default:"servicedef.json"`
+	// Default is service.json
+	ServiceDefinitionFile string `json:"serviceDefinitionFile" default:"service.json"`
 	// The name of task definition file placing in application directory.
 	// Default is taskdef.json
 	TaskDefinitionFile string `json:"taskDefinitionFile" default:"taskdef.json"`

--- a/pkg/config/deployment_ecs.go
+++ b/pkg/config/deployment_ecs.go
@@ -35,11 +35,11 @@ func (s *ECSDeploymentSpec) Validate() error {
 
 type ECSDeploymentInput struct {
 	// The name of service definition file placing in application directory.
-	// Default is servicedef.yaml
-	ServiceDefinitionFile string `json:"serviceDefinitionFile" default:"servicedef.yaml"`
+	// Default is servicedef.json
+	ServiceDefinitionFile string `json:"serviceDefinitionFile" default:"servicedef.json"`
 	// The name of task definition file placing in application directory.
-	// Default is taskdef.yaml
-	TaskDefinitionFile string `json:"taskDefinitionFile" default:"taskdef.yaml"`
+	// Default is taskdef.json
+	TaskDefinitionFile string `json:"taskDefinitionFile" default:"taskdef.json"`
 	// ECSTargetGroups
 	TargetGroups ECSTargetGroups `json:"targetGroups"`
 	// Automatically reverts all changes from all stages when one of them failed.


### PR DESCRIPTION
**What this PR does / why we need it**:

- Change the default value for ECS configuration's files (TaskDef and Service) to `*.json`
- Update ECS docs.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
