### PR TITLE
Fix the bug that canary workloads were not using canary config resources

### DIFF
--- a/pkg/app/piped/executor/kubernetes/canary.go
+++ b/pkg/app/piped/executor/kubernetes/canary.go
@@ -144,13 +144,13 @@ func (e *deployExecutor) generateCanaryManifests(manifests []provider.Manifest, 
 
 	// Find config map manifests and duplicate them for CANARY variant.
 	configMaps := findConfigMapManifests(manifests)
-	configMaps = duplicateManifests(configMaps, suffix)
-	canaryManifests = append(canaryManifests, configMaps...)
+	canaryConfigMaps := duplicateManifests(configMaps, suffix)
+	canaryManifests = append(canaryManifests, canaryConfigMaps...)
 
 	// Find secret manifests and duplicate them for CANARY variant.
 	secrets := findSecretManifests(manifests)
-	secrets = duplicateManifests(secrets, suffix)
-	canaryManifests = append(canaryManifests, secrets...)
+	canarySecrets := duplicateManifests(secrets, suffix)
+	canaryManifests = append(canaryManifests, canarySecrets...)
 
 	// Generate new workload manifests for CANARY variant.
 	// The generated ones will mount to the new ConfigMaps and Secrets.

--- a/pkg/app/piped/executor/kubernetes/kubernetes_test.go
+++ b/pkg/app/piped/executor/kubernetes/kubernetes_test.go
@@ -71,7 +71,7 @@ func TestGenerateServiceManifests(t *testing.T) {
 	}
 }
 
-func TestGenerateWorkloadManifests(t *testing.T) {
+func TestGenerateVariantWorkloadManifests(t *testing.T) {
 	testcases := []struct {
 		name           string
 		manifestsFile  string

--- a/pkg/app/piped/executor/kubernetes/testdata/deployments.yaml
+++ b/pkg/app/piped/executor/kubernetes/testdata/deployments.yaml
@@ -21,6 +21,18 @@ spec:
         ports:
         - containerPort: 9085
           protocol: TCP
+        # TODO: Update the references in ENV list.
+        # env:
+        # - name: CONFIG_ENV
+        #   valueFrom:
+        #     configMapKeyRef:
+        #       key: key
+        #       name: configmap-name-2
+        # - name: SECRET_ENV
+        #   valueFrom:
+        #     secretKeyRef:
+        #       key: key
+        #       name: secret-name-1
       volumes:
       - name: secret-1
         secret:


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
