### PR TITLE
Support pattern syntax to specify EventWatcher files to be included/excluded

### DIFF
--- a/docs/content/en/docs/operator-manual/piped/configuration-reference.md
+++ b/docs/content/en/docs/operator-manual/piped/configuration-reference.md
@@ -170,8 +170,8 @@ Must be one of the following structs:
 |-|-|-|-|
 | repoId | string | Id of the git repository. This must be unique within the repos' elements. | Yes |
 | commitMessage | string | The commit message used to push after replacing values. Default message is used if not given. | No |
-| includes | []string | The paths to EventWatcher files to be included. | No |
-| excludes | []string | The paths to EventWatcher files to be excluded. This is prioritized if both includes and this are given. | No |
+| includes | []string | The paths to EventWatcher files to be included. Patterns can be used like `foo/*.yaml`. | No |
+| excludes | []string | The paths to EventWatcher files to be excluded. Patterns can be used like `foo/*.yaml`. This is prioritized if both includes and this are given. | No |
 
 ## Notifications
 

--- a/pkg/config/BUILD.bazel
+++ b/pkg/config/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
     importpath = "github.com/pipe-cd/pipe/pkg/config",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/filematcher:go_default_library",
         "//pkg/model:go_default_library",
         "@com_github_creasty_defaults//:go_default_library",
         "@com_github_golang_protobuf//jsonpb:go_default_library_gen",

--- a/pkg/config/event_watcher.go
+++ b/pkg/config/event_watcher.go
@@ -116,7 +116,6 @@ func filterEventWatcherFiles(files, includePatterns, excludePatterns []string) (
 		for _, f := range files {
 			// TODO: Cache match results so that it doesn't have to compare include/exclude patterns each time.
 			for _, p := range includePatterns {
-				fmt.Println("pattern:", p, "file:", f) // FIXME: REMOVE
 				matched, err := path.Match(p, f)
 				if err != nil {
 					return nil, fmt.Errorf("failed to check if file name metches the given include pattern: %w", err)

--- a/pkg/config/event_watcher.go
+++ b/pkg/config/event_watcher.go
@@ -130,10 +130,6 @@ func filterEventWatcherFiles(files, includePatterns, excludePatterns []string) (
 	}
 
 	// Use exclude patterns
-	blackList := make(map[string]struct{}, len(excludePatterns))
-	for _, e := range excludePatterns {
-		blackList[e] = struct{}{}
-	}
 L:
 	for _, f := range files {
 		for _, p := range excludePatterns {

--- a/pkg/config/piped.go
+++ b/pkg/config/piped.go
@@ -641,9 +641,11 @@ type PipedEventWatcherGitRepo struct {
 	// The commit message used to push after replacing values.
 	// Default message is used if not given.
 	CommitMessage string `json:"commitMessage"`
-	// The paths to files to be included.
+	// The file path patterns to be included.
+	// Patterns can be used like "foo/*.yaml".
 	Includes []string `json:"includes"`
-	// The paths to files to be excluded.
+	// The file path patterns to be excluded.
+	// Patterns can be used like "foo/*.yaml".
 	// This is prioritized if both includes and this one are given.
 	Excludes []string `json:"excludes"`
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Pattern syntax will be available like:

```yaml
apiVersion: pipecd.dev/v1beta1
kind: Piped
spec:
  eventWatcher:
    gitRepos:
      - repoId: repo-1
        includes:
          - foo/*.yaml
          - bar/*.yaml
```

**Which issue(s) this PR fixes**:

Fixes https://github.com/pipe-cd/pipe/issues/2119

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Support pattern syntax to specify EventWatcher files to be included/excluded
```
