### PR TITLE
Avoid using the same pointer across goroutines

### DIFF
--- a/pkg/app/piped/eventwatcher/eventwatcher.go
+++ b/pkg/app/piped/eventwatcher/eventwatcher.go
@@ -93,7 +93,7 @@ func (w *watcher) Run(ctx context.Context) error {
 		defer os.RemoveAll(repo.GetPath())
 
 		w.wg.Add(1)
-		go w.run(ctx, repo, &repoCfg)
+		go w.run(ctx, repo, repoCfg)
 	}
 
 	w.wg.Wait()
@@ -102,7 +102,7 @@ func (w *watcher) Run(ctx context.Context) error {
 
 // run works against a single git repo. It periodically compares the value in the given
 // git repository and one in the control-plane. And then pushes those with differences.
-func (w *watcher) run(ctx context.Context, repo git.Repo, repoCfg *config.PipedRepository) {
+func (w *watcher) run(ctx context.Context, repo git.Repo, repoCfg config.PipedRepository) {
 	defer w.wg.Done()
 
 	var (


### PR DESCRIPTION
**What this PR does / why we need it**:
Tiny fix not to share the same pointer across goroutines.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
