### PR TITLE
Allow specifying additional labels to Piped's service manifest

### DIFF
--- a/manifests/piped/templates/service.yaml
+++ b/manifests/piped/templates/service.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "piped.fullname" . }}
   labels:
     {{- include "piped.labels" . | nindent 4 }}
+    {{- if .Values.service.additionalLabels }}
+    {{ toYaml .Values.service.additionalLabels | nindent 4 }}
+    {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/manifests/piped/values.yaml
+++ b/manifests/piped/values.yaml
@@ -15,6 +15,8 @@ service:
   enabled: true
   type: ClusterIP
   port: 9085
+  # Optional additional labels to add to the Service
+  # additionalLabels: {}
 
 config:
   # Specifies whether a ConfigMap for piped configuration should be created.


### PR DESCRIPTION
**What this PR does / why we need it**:
Change to be able to add optional labels to the pipe service.
Labels are useful because they may be used for purposes other than those used by Piped.
If necessary, add it to pipecd, site, but how about it?

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
