### PR TITLE
Add --dependency-update flag to fetch dependencies before installing quickstart

### DIFF
--- a/docs/content/en/docs/quickstart/_index.md
+++ b/docs/content/en/docs/quickstart/_index.md
@@ -26,7 +26,7 @@ cd manifests
 ### 2. Installing control plane
 
 ``` console
-helm -n pipecd install pipecd ./manifests/pipecd --create-namespace \
+helm -n pipecd install pipecd ./manifests/pipecd --dependency-update --create-namespace \
   --values ./quickstart/control-plane-values.yaml
 ```
 


### PR DESCRIPTION

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
