### PR TITLE
Fix indent in quickstart chart template

### DIFF
--- a/manifests/pipecd/templates/configmap.yaml
+++ b/manifests/pipecd/templates/configmap.yaml
@@ -10,7 +10,7 @@ data:
 {{ tpl .Values.config.data . | indent 4 }}
 {{- end }}
 
-{{- if .Values.monitoring.enabled -}}
+{{- if .Values.monitoring.enabled }}
 ---
 apiVersion: v1
 kind: ConfigMap


### PR DESCRIPTION
**What this PR does / why we need it**:
In case of enabling `monitoring` for quickstart chart, wrong indent root to invalid yaml generate as below
```yaml
---
# Source: pipecd/templates/configmap.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: pipecd
...
    --- # <- this line was wrong
apiVersion: v1
kind: ConfigMap
metadata:
  name: pipecd-grafana-dashboards
```
cause enable to apply pipecd's configmap and make pipecd-server, pipecd-ops (which requires pipecd configmap to start) failed to rolled out.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
