### PR TITLE
Fix: obsolete terraform flags

### DIFF
--- a/pkg/app/piped/cloudprovider/terraform/terraform.go
+++ b/pkg/app/piped/cloudprovider/terraform/terraform.go
@@ -64,7 +64,6 @@ func (t *Terraform) Init(ctx context.Context, w io.Writer) error {
 	for _, f := range t.varFiles {
 		args = append(args, fmt.Sprintf("-var-file=%s", f))
 	}
-	args = append(args, "-lock=false", ".")
 
 	cmd := exec.CommandContext(ctx, t.execPath, args...)
 	cmd.Dir = t.dir
@@ -80,7 +79,6 @@ func (t *Terraform) SelectWorkspace(ctx context.Context, workspace string) error
 		"workspace",
 		"select",
 		workspace,
-		".",
 	}
 	cmd := exec.CommandContext(ctx, t.execPath, args...)
 	cmd.Dir = t.dir
@@ -115,7 +113,6 @@ func (t *Terraform) Plan(ctx context.Context, w io.Writer) (PlanResult, error) {
 	for _, f := range t.varFiles {
 		args = append(args, fmt.Sprintf("-var-file=%s", f))
 	}
-	args = append(args, "-lock=false", ".")
 
 	var buf bytes.Buffer
 	stdout := io.MultiWriter(w, &buf)
@@ -185,7 +182,6 @@ func (t *Terraform) Apply(ctx context.Context, w io.Writer) error {
 	for _, f := range t.varFiles {
 		args = append(args, fmt.Sprintf("-var-file=%s", f))
 	}
-	args = append(args, ".")
 
 	cmd := exec.CommandContext(ctx, t.execPath, args...)
 	cmd.Dir = t.dir


### PR DESCRIPTION
**What this PR does / why we need it**:

Terraform cloudprovider failed to execute with the latest terraform stable version 1.0.0. This PR addresses the issues caused by changes to command line flags, and 

The directory parameter '.' has been changed to `-chdir` and is optional. This PR removes the flag from the command
The `-lock=false` is no longer valid parameter for `init` command. This PR removes the flag from the command. 
I've tested the changed parameters with following terraform versions:
- 1.0.0
- 0.15.5
- 0.14.11
- 0.13.7

Parsing plan with no changes failed in latest terraform version. This is most likely due to subtle changes to the text output. 

![image](https://user-images.githubusercontent.com/12850042/123560326-6cc8d000-d799-11eb-828d-8dfbb80cebc4.png)


This PR proposes change to detect explicit exit status to parse only plans with changes. This method should be less error prone when the string output of terraform changes. 

**Which issue(s) this PR fixes**:


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
