### PR TITLE
Fix: gnu sed support

### DIFF
--- a/hack/render-manifests.sh
+++ b/hack/render-manifests.sh
@@ -39,14 +39,14 @@ echo "Copying manifests to ${OUT}..."
 cp -rf manifests ${OUT}
 
 echo "Updating version to ${VERSION}..."
-sed -i '' -e 's/{{ .VERSION }}/'"${VERSION}"'/g' ${OUT}/pipecd/Chart.yaml
-sed -i '' -e 's/{{ .VERSION }}/'"${VERSION}"'/g' ${OUT}/piped/Chart.yaml
+sed -i'' -e 's/{{ .VERSION }}/'"${VERSION}"'/g' ${OUT}/pipecd/Chart.yaml
+sed -i'' -e 's/{{ .VERSION }}/'"${VERSION}"'/g' ${OUT}/piped/Chart.yaml
 
 if [ ! -z "${REGISTRY}" ]
 then
   echo "Updating image registry to ${REGISTRY}..."
-  sed -i '' -e 's/gcr.io\/pipecd/'"${REGISTRY}"'/g' ${OUT}/pipecd/values.yaml
-  sed -i '' -e 's/gcr.io\/pipecd/'"${REGISTRY}"'/g' ${OUT}/piped/values.yaml
+  sed -i'' -e 's/gcr.io\/pipecd/'"${REGISTRY}"'/g' ${OUT}/pipecd/values.yaml
+  sed -i'' -e 's/gcr.io\/pipecd/'"${REGISTRY}"'/g' ${OUT}/piped/values.yaml
 fi
 
 echo "Updating dependencies..."


### PR DESCRIPTION
**What this PR does / why we need it**:
GNU sed does not support backup flag with space between name of the extension.
This change updates the command to be compatible with GNU sed as well as the osx version

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
