### PR TITLE
Fix wrong link to secret management in feature status page

### DIFF
--- a/docs/content/en/docs/feature-status/_index.md
+++ b/docs/content/en/docs/feature-status/_index.md
@@ -87,7 +87,7 @@ Please note that the phases (Incubating, Alpha, Beta, and Stable) are applied to
 | [Wait Manual Approval Stage](/docs/user-guide/adding-a-manual-approval/) | Beta |
 | [Notification](/docs/operator-manual/piped/configuring-notifications/) to Slack | Beta |
 | [Notification](/docs/operator-manual/piped/configuring-notifications/) to Webhook | Incubating |
-| [Secrets Management](/docs/user-guide/sealed-secrets/) | Beta |
+| [Secrets Management](/docs/user-guide/secret-management/) | Beta |
 | [Event Watcher](/docs/user-guide/event-watcher/) | Alpha |
 | [Command-line tool (pipectl) and API for external services](/docs/user-guide/command-line-tool/) | Beta |
 | Support executing custom stage | Incubating |


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
