### PR TITLE
Fix to register multiple events during a single fetch interval

### DIFF
--- a/pkg/app/piped/eventwatcher/eventwatcher.go
+++ b/pkg/app/piped/eventwatcher/eventwatcher.go
@@ -86,7 +86,7 @@ func (w *watcher) Run(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		defer os.RemoveAll(repo.GetPath())
+		defer repo.Clean()
 
 		w.wg.Add(1)
 		go w.run(ctx, repo, repoCfg)
@@ -134,7 +134,7 @@ func (w *watcher) run(ctx context.Context, repo git.Repo, repoCfg config.PipedRe
 					zap.String("branch", repo.GetClonedBranch()),
 					zap.Error(err),
 				)
-				if err := os.RemoveAll(repo.GetPath()); err != nil {
+				if err := repo.Clean(); err != nil {
 					w.logger.Error("failed to remove repo directory",
 						zap.String("path", repo.GetPath()),
 						zap.Error(err),

--- a/pkg/app/piped/eventwatcher/eventwatcher.go
+++ b/pkg/app/piped/eventwatcher/eventwatcher.go
@@ -178,7 +178,11 @@ func (w *watcher) run(ctx context.Context, repo git.Repo, repoCfg config.PipedRe
 
 // cloneRepo clones the git repository under the working directory.
 func (w *watcher) cloneRepo(ctx context.Context, repoCfg config.PipedRepository) (git.Repo, error) {
-	repo, err := w.gitClient.Clone(ctx, repoCfg.RepoID, repoCfg.Remote, repoCfg.Branch, filepath.Join(w.workingDir, repoCfg.RepoID))
+	dst, err := ioutil.TempDir(w.workingDir, repoCfg.RepoID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create a new temporary directory: %w", err)
+	}
+	repo, err := w.gitClient.Clone(ctx, repoCfg.RepoID, repoCfg.Remote, repoCfg.Branch, dst)
 	if err != nil {
 		w.logger.Error("failed to clone repository",
 			zap.String("repo-id", repoCfg.RepoID),


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes two EventWatcher issues that:
- can't register multiple events during a single fetch interval
- we have to restart Piped when the repository was force pushed

**Which issue(s) this PR fixes**:

Fixes https://github.com/pipe-cd/pipe/issues/1934

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Fix a bug that can't register multiple events during a single fetch interval
```
