### PR TITLE
Fix cut index on getting versioning information

### DIFF
--- a/.kapetanios/postsubmit.yaml
+++ b/.kapetanios/postsubmit.yaml
@@ -85,7 +85,7 @@ spec:
         - cd docs
         - npm install autoprefixer
         - npm install postcss-cli
-        - env HUGO_ENV="production" RELEASE="$(cut -c9- ../release/RELEASE)" hugo
+        - env HUGO_ENV="production" RELEASE="$(cut -c10- ../release/RELEASE)" hugo
 
     - name: docker-build
       description: Build docker image


### PR DESCRIPTION
**What this PR does / why we need it**:

Wrong index for cut command yields unexpected result
```
+ cut -c9- ../release/RELEASE
+ env 'HUGO_ENV=production' 'RELEASE= v0.10.2' hugo
```

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
