### PR TITLE
Prevent  STAGE_NOT_STARTED_YET stage from becoming active

### DIFF
--- a/pkg/app/web/src/components/applications-page/add-application-drawer/index.test.tsx
+++ b/pkg/app/web/src/components/applications-page/add-application-drawer/index.test.tsx
@@ -8,6 +8,8 @@ import { dummyPiped } from "~/__fixtures__/dummy-piped";
 import { createStore, render, screen, waitFor } from "~~/test-utils";
 import { AddApplicationDrawer } from ".";
 
+jest.setTimeout(20_000);
+
 beforeAll(() => {
   server.listen();
 });


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR ensures that the correct stage is selected when the deployment is opened.

#### Before 
![image](https://user-images.githubusercontent.com/6136383/123767145-3bb7df00-d902-11eb-8f7b-ece79aa9178e.png)

#### After
![image](https://user-images.githubusercontent.com/6136383/123767176-3fe3fc80-d902-11eb-95b3-cc109bcdc0bf.png)


**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Fix wrong focus on STAGE_NOT_STARTED_YET stage in deployment detail page
```
