### PR TITLE
Add Prometheus relabeling config to manipulate metrics from cAdvisor

### DIFF
--- a/manifests/pipecd/values.yaml
+++ b/manifests/pipecd/values.yaml
@@ -266,6 +266,11 @@ prometheus:
               regex: (.+)
               target_label: __metrics_path__
               replacement: /api/v1/nodes/$1/proxy/metrics/cadvisor
+          metric_relabel_configs:
+            - source_labels: [pod]
+              target_label: service
+              regex: (.+)-[0-9a-zA-Z]+(-[0-9a-zA-Z]+)$
+              replacement: $1
 
         # Scrape config for services that has "prometheus.io/scrape: true"
         - job_name: kubernetes-service-endpoints


### PR DESCRIPTION
**What this PR does / why we need it**:
To group the resource dashboard by service, this PR adds a new label for services.

**Which issue(s) this PR fixes**:

Ref https://github.com/pipe-cd/pipe/issues/1867

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
