### PR TITLE
Enable to track request response size statistics

### DIFF
--- a/manifests/pipecd/templates/envoy-configmap.yaml
+++ b/manifests/pipecd/templates/envoy-configmap.yaml
@@ -102,6 +102,8 @@ data:
                   socket_address:
                     address: {{ include "pipecd.fullname" . }}-server
                     port_value: 9080
+        track_cluster_stats:
+          request_response_sizes: true
       - name: server-web-api
         http2_protocol_options: {}
         connect_timeout: 0.25s
@@ -116,6 +118,8 @@ data:
                   socket_address:
                     address: {{ include "pipecd.fullname" . }}-server
                     port_value: 9081
+        track_cluster_stats:
+          request_response_sizes: true
       - name: server-api
         http2_protocol_options: {}
         connect_timeout: 0.25s
@@ -130,6 +134,8 @@ data:
                   socket_address:
                     address: {{ include "pipecd.fullname" . }}-server
                     port_value: 9083
+        track_cluster_stats:
+          request_response_sizes: true
       - name: server-http
         #http2_protocol_options: {}
         connect_timeout: 0.25s
@@ -144,3 +150,5 @@ data:
                   socket_address:
                     address: {{ include "pipecd.fullname" . }}-server
                     port_value: 9082
+        track_cluster_stats:
+          request_response_sizes: true


### PR DESCRIPTION
**What this PR does / why we need it**:
To track request/response body size, this PR adds a new config field.

See more: https://www.envoyproxy.io/docs/envoy/latest/configuration/upstream/cluster_manager/cluster_stats#request-response-size-statistics

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
