### PR TITLE
Make get operation of env-store to be cancelable and single-flight

### DIFF
--- a/pkg/app/piped/apistore/environmentstore/BUILD.bazel
+++ b/pkg/app/piped/apistore/environmentstore/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "//pkg/cache:go_default_library",
         "//pkg/model:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
+        "@org_golang_x_sync//singleflight:go_default_library",
         "@org_uber_go_zap//:go_default_library",
     ],
 )

--- a/pkg/app/piped/trigger/deployment.go
+++ b/pkg/app/piped/trigger/deployment.go
@@ -44,15 +44,15 @@ func (t *Trigger) triggerDeployment(
 		if err != nil {
 			return
 		}
-		var envName string
-		if env, ok := t.environmentLister.Get(deployment.EnvId); ok {
-			envName = env.Name
+		env, err := t.environmentLister.Get(ctx, deployment.EnvId)
+		if err != nil {
+			return
 		}
 		t.notifier.Notify(model.NotificationEvent{
 			Type: model.NotificationEventType_EVENT_DEPLOYMENT_TRIGGERED,
 			Metadata: &model.NotificationEventDeploymentTriggered{
 				Deployment: deployment,
-				EnvName:    envName,
+				EnvName:    env.Name,
 			},
 		})
 	}()

--- a/pkg/app/piped/trigger/trigger.go
+++ b/pkg/app/piped/trigger/trigger.go
@@ -64,7 +64,7 @@ type commandLister interface {
 }
 
 type environmentLister interface {
-	Get(id string) (*model.Environment, bool)
+	Get(ctx context.Context, id string) (*model.Environment, error)
 }
 
 type notifier interface {


### PR DESCRIPTION
**What this PR does / why we need it**:

- Add ctx to `Get` function to allow canceling the request
- Ensure that only one API call is executed for a given environment at a time

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
