### PR TITLE
Revert "Enable to track request response size statistics (#2160)"

### DIFF
--- a/manifests/pipecd/templates/envoy-configmap.yaml
+++ b/manifests/pipecd/templates/envoy-configmap.yaml
@@ -102,8 +102,6 @@ data:
                   socket_address:
                     address: {{ include "pipecd.fullname" . }}-server
                     port_value: 9080
-        track_cluster_stats:
-          request_response_sizes: true
       - name: server-web-api
         http2_protocol_options: {}
         connect_timeout: 0.25s
@@ -118,8 +116,6 @@ data:
                   socket_address:
                     address: {{ include "pipecd.fullname" . }}-server
                     port_value: 9081
-        track_cluster_stats:
-          request_response_sizes: true
       - name: server-api
         http2_protocol_options: {}
         connect_timeout: 0.25s
@@ -134,8 +130,6 @@ data:
                   socket_address:
                     address: {{ include "pipecd.fullname" . }}-server
                     port_value: 9083
-        track_cluster_stats:
-          request_response_sizes: true
       - name: server-http
         #http2_protocol_options: {}
         connect_timeout: 0.25s
@@ -150,5 +144,3 @@ data:
                   socket_address:
                     address: {{ include "pipecd.fullname" . }}-server
                     port_value: 9082
-        track_cluster_stats:
-          request_response_sizes: true


### PR DESCRIPTION
This reverts commit cf502d51f7dc2227d8b189577257a0afa6acdbf1.

**What this PR does / why we need it**:
Seems like the config field `track_cluster_stats` is supported only for [V3](https://www.envoyproxy.io/docs/envoy/latest/api-v3/api) API [introduced from v1.13](https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.13.0). On the other hand our current version of Envoy is 1.10 which supports only v2 API.

Currently, the latest version of `pipecd-gateway` is unavailable due to unable to parse the config so this PR reverts for now. But either way, we'd better bump Envoy to after v1.13 (current latest is v1.19)  as soon as possible because [V2 API is no longer supported](https://www.envoyproxy.io/docs/envoy/latest/api/api_supported_versions).

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
