### PR TITLE
Add relabel config for kube-state-metrics

### DIFF
--- a/manifests/pipecd/values.yaml
+++ b/manifests/pipecd/values.yaml
@@ -304,6 +304,11 @@ prometheus:
             - source_labels: [__meta_kubernetes_pod_node_name]
               action: replace
               target_label: kubernetes_node
+          metric_relabel_configs:
+            - source_labels: [pod]
+              target_label: service
+              regex: (.+)-[0-9a-zA-Z]+(-[0-9a-zA-Z]+)$
+              replacement: $1
 
         # Scrape config for pods that has "prometheus.io/scrape: true"
         - job_name: kubernetes-pods


### PR DESCRIPTION
**What this PR does / why we need it**:
To track the number of Pods restarts, it has to be relabeled before ingesting samples from kube-state-metrics.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
