### PR TITLE
Update planpreview's builder to detect which apps should be triggered

### DIFF
--- a/pkg/app/piped/planpreview/BUILD.bazel
+++ b/pkg/app/piped/planpreview/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     importpath = "github.com/pipe-cd/pipe/pkg/app/piped/planpreview",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/app/piped/trigger:go_default_library",
         "//pkg/config:go_default_library",
         "//pkg/git:go_default_library",
         "//pkg/model:go_default_library",

--- a/pkg/app/piped/planpreview/builder.go
+++ b/pkg/app/piped/planpreview/builder.go
@@ -63,7 +63,7 @@ func (b *builder) Build(ctx context.Context, id string, cmd model.Command_BuildP
 		return nil, fmt.Errorf("repository %s was not found in Piped config", cmd.RepositoryId)
 	}
 	if repoCfg.Branch != cmd.BaseBranch {
-		return nil, fmt.Errorf("base branch repository %s was not match, requested %s, expected %s", cmd.RepositoryId, cmd.BaseBranch, repoCfg.Branch)
+		return nil, fmt.Errorf("base branch repository %s was not matched, requested %s, expected %s", cmd.RepositoryId, cmd.BaseBranch, repoCfg.Branch)
 	}
 
 	// List all applications that belong to this Piped
@@ -97,9 +97,12 @@ func (b *builder) Build(ctx context.Context, id string, cmd model.Command_BuildP
 		if err != nil {
 			// We only need the environment name
 			// so the returned error can be ignorable.
-			env, _ := b.environmentGetter.Get(ctx, app.EnvId)
+			var envName string
+			if env, err := b.environmentGetter.Get(ctx, app.EnvId); err == nil {
+				envName = env.Name
+			}
 
-			r := model.MakeApplicationPlanPreviewResult(*app, env)
+			r := model.MakeApplicationPlanPreviewResult(*app, envName)
 			r.Error = fmt.Sprintf("Failed while determining the application should be triggered or not, %v", err)
 			results = append(results, r)
 			continue
@@ -114,9 +117,12 @@ func (b *builder) Build(ctx context.Context, id string, cmd model.Command_BuildP
 	for _, app := range triggerApps {
 		// We only need the environment name
 		// so the returned error can be ignorable.
-		env, _ := b.environmentGetter.Get(ctx, app.EnvId)
+		var envName string
+		if env, err := b.environmentGetter.Get(ctx, app.EnvId); err == nil {
+			envName = env.Name
+		}
 
-		r := model.MakeApplicationPlanPreviewResult(*app, env)
+		r := model.MakeApplicationPlanPreviewResult(*app, envName)
 		results = append(results, r)
 
 		strategy, changes, err := b.plan(repo, app, cmd)

--- a/pkg/app/piped/planpreview/handler_test.go
+++ b/pkg/app/piped/planpreview/handler_test.go
@@ -61,7 +61,7 @@ func TestHandler(t *testing.T) {
 	var mu sync.Mutex
 	var wg sync.WaitGroup
 
-	handler := NewHandler(nil, cl, nil, nil,
+	handler := NewHandler(nil, cl, nil, nil, nil, nil,
 		WithWorkerNum(2),
 		// Use a long interval because we will directly call enqueueNewCommands function in this test.
 		WithCommandCheckInterval(time.Hour),

--- a/pkg/app/piped/trigger/BUILD.bazel
+++ b/pkg/app/piped/trigger/BUILD.bazel
@@ -3,13 +3,17 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "cache.go",
         "deployment.go",
+        "determiner.go",
         "trigger.go",
     ],
     importpath = "github.com/pipe-cd/pipe/pkg/app/piped/trigger",
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/app/api/service/pipedservice:go_default_library",
+        "//pkg/cache:go_default_library",
+        "//pkg/cache/memorycache:go_default_library",
         "//pkg/config:go_default_library",
         "//pkg/filematcher:go_default_library",
         "//pkg/git:go_default_library",
@@ -25,7 +29,7 @@ go_library(
 go_test(
     name = "go_default_test",
     size = "small",
-    srcs = ["trigger_test.go"],
+    srcs = ["determiner_test.go"],
     embed = [":go_default_library"],
     deps = ["@com_github_stretchr_testify//assert:go_default_library"],
 )

--- a/pkg/app/piped/trigger/cache.go
+++ b/pkg/app/piped/trigger/cache.go
@@ -1,0 +1,79 @@
+// Copyright 2021 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trigger
+
+import (
+	"context"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/pipe-cd/pipe/pkg/app/api/service/pipedservice"
+	"github.com/pipe-cd/pipe/pkg/cache"
+	"github.com/pipe-cd/pipe/pkg/model"
+)
+
+type lastTriggeredCommitStore struct {
+	apiClient apiClient
+	cache     cache.Cache
+}
+
+func (s *lastTriggeredCommitStore) Get(ctx context.Context, applicationID string) (string, error) {
+	// Firstly, find from memory cache.
+	commit, err := s.cache.Get(applicationID)
+	if err == nil {
+		return commit.(string), nil
+	}
+
+	// No data in memorycache so we have to cost a RPC call to get from control-plane.
+	deploy, err := s.getLastTriggeredDeployment(ctx, applicationID)
+	switch {
+	case err == nil:
+		return deploy.Trigger.Commit.Hash, nil
+
+	case status.Code(err) == codes.NotFound:
+		// It seems this application has not been deployed anytime.
+		return "", nil
+
+	default:
+		return "", err
+	}
+}
+
+func (s *lastTriggeredCommitStore) Put(applicationID, commit string) error {
+	return s.cache.Put(applicationID, commit)
+}
+
+func (s *lastTriggeredCommitStore) getLastTriggeredDeployment(ctx context.Context, applicationID string) (*model.ApplicationDeploymentReference, error) {
+	var (
+		err   error
+		resp  *pipedservice.GetApplicationMostRecentDeploymentResponse
+		retry = pipedservice.NewRetry(3)
+		req   = &pipedservice.GetApplicationMostRecentDeploymentRequest{
+			ApplicationId: applicationID,
+			Status:        model.DeploymentStatus_DEPLOYMENT_PENDING,
+		}
+	)
+
+	for retry.WaitNext(ctx) {
+		if resp, err = s.apiClient.GetApplicationMostRecentDeployment(ctx, req); err == nil {
+			return resp.Deployment, nil
+		}
+		if !pipedservice.Retriable(err) {
+			return nil, err
+		}
+	}
+	return nil, err
+}

--- a/pkg/app/piped/trigger/determiner.go
+++ b/pkg/app/piped/trigger/determiner.go
@@ -1,0 +1,150 @@
+// Copyright 2021 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trigger
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"go.uber.org/zap"
+
+	"github.com/pipe-cd/pipe/pkg/config"
+	"github.com/pipe-cd/pipe/pkg/filematcher"
+	"github.com/pipe-cd/pipe/pkg/git"
+	"github.com/pipe-cd/pipe/pkg/model"
+)
+
+type LastTriggeredCommitGetter interface {
+	Get(ctx context.Context, applicationID string) (string, error)
+}
+
+type Determiner struct {
+	repo         git.Repo
+	targetCommit string
+	commitGetter LastTriggeredCommitGetter
+	logger       *zap.Logger
+}
+
+func NewDeterminer(repo git.Repo, targetCommit string, cg LastTriggeredCommitGetter, logger *zap.Logger) *Determiner {
+	return &Determiner{
+		repo:         repo,
+		targetCommit: targetCommit,
+		commitGetter: cg,
+		logger:       logger.Named("determiner"),
+	}
+}
+
+// ShouldTrigger decides whether a given application should be triggered or not.
+func (d *Determiner) ShouldTrigger(ctx context.Context, app *model.Application) (bool, error) {
+	logger := d.logger.With(
+		zap.String("app", app.Name),
+		zap.String("app-id", app.Id),
+		zap.String("target-commit", d.targetCommit),
+	)
+
+	preCommit, err := d.commitGetter.Get(ctx, app.Id)
+	if err != nil {
+		logger.Error("failed to get last triggered commit", zap.Error(err))
+		return false, err
+	}
+	if preCommit == "" {
+		logger.Info("no previously triggered deployment was found")
+	}
+
+	// Check whether the most recently applied one is the target commit or not.
+	// If so, nothing to do for this time.
+	if preCommit == d.targetCommit {
+		logger.Info(fmt.Sprintf("no update to sync for application, hash: %s", d.targetCommit))
+		return false, nil
+	}
+
+	// There is no previous deployment so we don't need to check anymore.
+	// Just do it.
+	if preCommit == "" {
+		return true, nil
+	}
+
+	// List the changed files between those two commits and
+	// determine whether this application was touch by those changed files.
+	changedFiles, err := d.repo.ChangedFiles(ctx, preCommit, d.targetCommit)
+	if err != nil {
+		return false, err
+	}
+
+	deployConfig, err := loadDeploymentConfiguration(d.repo.GetPath(), app)
+	if err != nil {
+		return false, err
+	}
+
+	touched, err := isTouchedByChangedFiles(app.GitPath.Path, deployConfig.TriggerPaths, changedFiles)
+	if err != nil {
+		return false, err
+	}
+
+	if !touched {
+		logger.Info("application was not touched by any new commits", zap.String("last-triggered-commit", preCommit))
+		return false, nil
+	}
+
+	return true, nil
+}
+
+func loadDeploymentConfiguration(repoPath string, app *model.Application) (*config.GenericDeploymentSpec, error) {
+	path := filepath.Join(repoPath, app.GitPath.GetDeploymentConfigFilePath())
+	cfg, err := config.LoadFromYAML(path)
+	if err != nil {
+		return nil, err
+	}
+	if appKind, ok := config.ToApplicationKind(cfg.Kind); !ok || appKind != app.Kind {
+		return nil, fmt.Errorf("invalid application kind in the deployment config file, got: %s, expected: %s", appKind, app.Kind)
+	}
+
+	spec, ok := cfg.GetGenericDeployment()
+	if !ok {
+		return nil, fmt.Errorf("unsupported application kind: %s", app.Kind)
+	}
+
+	return &spec, nil
+}
+
+func isTouchedByChangedFiles(appDir string, changes []string, changedFiles []string) (bool, error) {
+	if !strings.HasSuffix(appDir, "/") {
+		appDir += "/"
+	}
+
+	// If any files inside the application directory was changed
+	// this application is considered as touched.
+	for _, cf := range changedFiles {
+		if ok := strings.HasPrefix(cf, appDir); ok {
+			return true, nil
+		}
+	}
+
+	// If any changed files matches the specified "changes"
+	// this application is consided as touched too.
+	for _, change := range changes {
+		matcher, err := filematcher.NewPatternMatcher([]string{change})
+		if err != nil {
+			return false, err
+		}
+		if matcher.MatchesAny(changedFiles) {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}

--- a/pkg/app/piped/trigger/determiner.go
+++ b/pkg/app/piped/trigger/determiner.go
@@ -61,8 +61,12 @@ func (d *Determiner) ShouldTrigger(ctx context.Context, app *model.Application) 
 		logger.Error("failed to get last triggered commit", zap.Error(err))
 		return false, err
 	}
+
+	// There is no previous deployment so we don't need to check anymore.
+	// Just do it.
 	if preCommit == "" {
 		logger.Info("no previously triggered deployment was found")
+		return true, nil
 	}
 
 	// Check whether the most recently applied one is the target commit or not.
@@ -70,12 +74,6 @@ func (d *Determiner) ShouldTrigger(ctx context.Context, app *model.Application) 
 	if preCommit == d.targetCommit {
 		logger.Info(fmt.Sprintf("no update to sync for application, hash: %s", d.targetCommit))
 		return false, nil
-	}
-
-	// There is no previous deployment so we don't need to check anymore.
-	// Just do it.
-	if preCommit == "" {
-		return true, nil
 	}
 
 	// List the changed files between those two commits and

--- a/pkg/app/piped/trigger/determiner_test.go
+++ b/pkg/app/piped/trigger/determiner_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 The PipeCD Authors.
+// Copyright 2021 The PipeCD Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/model/planpreview.go
+++ b/pkg/model/planpreview.go
@@ -24,20 +24,17 @@ func (r *PlanPreviewCommandResult) FillURLs(baseURL string) {
 	}
 }
 
-func MakeApplicationPlanPreviewResult(app Application, env *Environment) *ApplicationPlanPreviewResult {
+func MakeApplicationPlanPreviewResult(app Application, envName string) *ApplicationPlanPreviewResult {
 	r := &ApplicationPlanPreviewResult{
 		ApplicationId:        app.Id,
 		ApplicationName:      app.Name,
 		ApplicationKind:      app.Kind,
 		ApplicationDirectory: app.GitPath.Path,
 		EnvId:                app.EnvId,
-		EnvName:              env.Name,
+		EnvName:              envName,
 		PipedId:              app.PipedId,
 		ProjectId:            app.ProjectId,
 		CreatedAt:            time.Now().Unix(),
-	}
-	if env != nil {
-		r.EnvName = env.Name
 	}
 	return r
 }

--- a/pkg/model/planpreview.go
+++ b/pkg/model/planpreview.go
@@ -14,10 +14,30 @@
 
 package model
 
+import "time"
+
 func (r *PlanPreviewCommandResult) FillURLs(baseURL string) {
 	r.PipedUrl = MakePipedURL(baseURL, r.PipedId)
 	for _, ar := range r.Results {
 		ar.ApplicationUrl = MakeApplicationURL(baseURL, ar.ApplicationId)
 		ar.EnvUrl = MakeEnvironmentURL(baseURL, ar.EnvId)
 	}
+}
+
+func MakeApplicationPlanPreviewResult(app Application, env *Environment) *ApplicationPlanPreviewResult {
+	r := &ApplicationPlanPreviewResult{
+		ApplicationId:        app.Id,
+		ApplicationName:      app.Name,
+		ApplicationKind:      app.Kind,
+		ApplicationDirectory: app.GitPath.Path,
+		EnvId:                app.EnvId,
+		EnvName:              env.Name,
+		PipedId:              app.PipedId,
+		ProjectId:            app.ProjectId,
+		CreatedAt:            time.Now().Unix(),
+	}
+	if env != nil {
+		r.EnvName = env.Name
+	}
+	return r
 }

--- a/pkg/model/planpreview.proto
+++ b/pkg/model/planpreview.proto
@@ -45,7 +45,7 @@ message ApplicationPlanPreviewResult {
     string application_directory = 5 [(validate.rules).string.min_len = 1];
 
     string env_id = 6 [(validate.rules).string.min_len = 1];
-    string env_name = 7 [(validate.rules).string.min_len = 1];
+    string env_name = 7;
     // Web URL to the environment page.
     // This is only filled before returning to the client.
     string env_url = 8;
@@ -54,8 +54,8 @@ message ApplicationPlanPreviewResult {
     string project_id = 10 [(validate.rules).string.min_len = 1];
 
     // Target commit information.
-    string target_branch = 20 [(validate.rules).string.min_len = 1];
-    string target_head_commit = 21 [(validate.rules).string.min_len = 1];
+    string head_branch = 20 [(validate.rules).string.min_len = 1];
+    string head_commit = 21 [(validate.rules).string.min_len = 1];
 
     // Planpreview result.
     SyncStrategy sync_strategy = 30;


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR updates the `builder` of planpreview package to be able to find the list of applications that should be triggered.
And in order to reuse code from the `trigger` package, this also refactors `trigger` package by moving the part used to decide triggered applications into an independent struct.

**Which issue(s) this PR fixes**:

Fixes #2145

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
