### PR TITLE
Re-enable to track request response size statistics

### DIFF
--- a/manifests/pipecd/templates/envoy-configmap.yaml
+++ b/manifests/pipecd/templates/envoy-configmap.yaml
@@ -103,6 +103,8 @@ data:
                   socket_address:
                     address: {{ include "pipecd.fullname" . }}-server
                     port_value: 9080
+        track_cluster_stats:
+          request_response_sizes: true
       - name: server-web-api
         http2_protocol_options: {}
         connect_timeout: 0.25s
@@ -117,6 +119,8 @@ data:
                   socket_address:
                     address: {{ include "pipecd.fullname" . }}-server
                     port_value: 9081
+        track_cluster_stats:
+          request_response_sizes: true
       - name: server-api
         http2_protocol_options: {}
         connect_timeout: 0.25s
@@ -131,6 +135,8 @@ data:
                   socket_address:
                     address: {{ include "pipecd.fullname" . }}-server
                     port_value: 9083
+        track_cluster_stats:
+          request_response_sizes: true
       - name: server-http
         connect_timeout: 0.25s
         type: STRICT_DNS
@@ -144,3 +150,5 @@ data:
                   socket_address:
                     address: {{ include "pipecd.fullname" . }}-server
                     port_value: 9082
+        track_cluster_stats:
+          request_response_sizes: true


### PR DESCRIPTION
This reverts commit 19061452b81a93773eb0d66d129100de8041e968.

**What this PR does / why we need it**:
Since it merged https://github.com/pipe-cd/pipe/pull/2169 that bump Envoy to 1.83 which supports `track_cluster_stats`, we can re-enable these stats.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
