### PR TITLE
Add sync-strategy field to output of planner

### DIFF
--- a/pkg/app/piped/planner/ecs/ecs.go
+++ b/pkg/app/piped/planner/ecs/ecs.go
@@ -66,6 +66,7 @@ func (p *Planner) Plan(ctx context.Context, in planner.Input) (out planner.Outpu
 	// we rely on the user's decision.
 	switch in.Deployment.Trigger.SyncStrategy {
 	case model.SyncStrategy_QUICK_SYNC:
+		out.SyncStrategy = model.SyncStrategy_QUICK_SYNC
 		out.Stages = buildQuickSyncPipeline(cfg.Input.AutoRollback, time.Now())
 		out.Summary = fmt.Sprintf("Quick sync to deploy image %s and configure all traffic to it (forced via web)", out.Version)
 		return
@@ -74,6 +75,7 @@ func (p *Planner) Plan(ctx context.Context, in planner.Input) (out planner.Outpu
 			err = fmt.Errorf("unable to force sync with pipeline because no pipeline was specified")
 			return
 		}
+		out.SyncStrategy = model.SyncStrategy_PIPELINE
 		out.Stages = buildProgressivePipeline(cfg.Pipeline, cfg.Input.AutoRollback, time.Now())
 		out.Summary = fmt.Sprintf("Sync with pipeline to deploy image %s (forced via web)", out.Version)
 		return
@@ -82,6 +84,7 @@ func (p *Planner) Plan(ctx context.Context, in planner.Input) (out planner.Outpu
 	// If this is the first time to deploy this application or it was unable to retrieve last successful commit,
 	// we perform the quick sync strategy.
 	if in.MostRecentSuccessfulCommitHash == "" {
+		out.SyncStrategy = model.SyncStrategy_QUICK_SYNC
 		out.Stages = buildQuickSyncPipeline(cfg.Input.AutoRollback, time.Now())
 		out.Summary = fmt.Sprintf("Quick sync to deploy image %s and configure all traffic to it (it seems this is the first deployment)", out.Version)
 		return
@@ -89,6 +92,7 @@ func (p *Planner) Plan(ctx context.Context, in planner.Input) (out planner.Outpu
 
 	// When no pipeline was configured, perform the quick sync.
 	if cfg.Pipeline == nil || len(cfg.Pipeline.Stages) == 0 {
+		out.SyncStrategy = model.SyncStrategy_QUICK_SYNC
 		out.Stages = buildQuickSyncPipeline(cfg.Input.AutoRollback, time.Now())
 		out.Summary = fmt.Sprintf("Quick sync to deploy image %s and configure all traffic to it (pipeline was not configured)", out.Version)
 		return
@@ -98,12 +102,14 @@ func (p *Planner) Plan(ctx context.Context, in planner.Input) (out planner.Outpu
 	ds, err = in.RunningDSP.Get(ctx, ioutil.Discard)
 	if err == nil {
 		if lastVersion, e := determineVersion(ds.AppDir, cfg.Input.TaskDefinitionFile); e == nil {
+			out.SyncStrategy = model.SyncStrategy_PIPELINE
 			out.Stages = buildProgressivePipeline(cfg.Pipeline, cfg.Input.AutoRollback, time.Now())
 			out.Summary = fmt.Sprintf("Sync with pipeline to update image from %s to %s", lastVersion, out.Version)
 			return
 		}
 	}
 
+	out.SyncStrategy = model.SyncStrategy_PIPELINE
 	out.Stages = buildProgressivePipeline(cfg.Pipeline, cfg.Input.AutoRollback, time.Now())
 	out.Summary = "Sync with the specified pipeline"
 	return

--- a/pkg/app/piped/planner/lambda/lambda.go
+++ b/pkg/app/piped/planner/lambda/lambda.go
@@ -66,6 +66,7 @@ func (p *Planner) Plan(ctx context.Context, in planner.Input) (out planner.Outpu
 	// we rely on the user's decision.
 	switch in.Deployment.Trigger.SyncStrategy {
 	case model.SyncStrategy_QUICK_SYNC:
+		out.SyncStrategy = model.SyncStrategy_QUICK_SYNC
 		out.Stages = buildQuickSyncPipeline(cfg.Input.AutoRollback, time.Now())
 		out.Summary = fmt.Sprintf("Quick sync to deploy image %s and configure all traffic to it (forced via web)", out.Version)
 		return
@@ -74,6 +75,7 @@ func (p *Planner) Plan(ctx context.Context, in planner.Input) (out planner.Outpu
 			err = fmt.Errorf("unable to force sync with pipeline because no pipeline was specified")
 			return
 		}
+		out.SyncStrategy = model.SyncStrategy_PIPELINE
 		out.Stages = buildProgressivePipeline(cfg.Pipeline, cfg.Input.AutoRollback, time.Now())
 		out.Summary = fmt.Sprintf("Sync with pipeline to deploy image %s (forced via web)", out.Version)
 		return
@@ -82,6 +84,7 @@ func (p *Planner) Plan(ctx context.Context, in planner.Input) (out planner.Outpu
 	// If this is the first time to deploy this application or it was unable to retrieve last successful commit,
 	// we perform the quick sync strategy.
 	if in.MostRecentSuccessfulCommitHash == "" {
+		out.SyncStrategy = model.SyncStrategy_QUICK_SYNC
 		out.Stages = buildQuickSyncPipeline(cfg.Input.AutoRollback, time.Now())
 		out.Summary = fmt.Sprintf("Quick sync to deploy image %s and configure all traffic to it (it seems this is the first deployment)", out.Version)
 		return
@@ -89,6 +92,7 @@ func (p *Planner) Plan(ctx context.Context, in planner.Input) (out planner.Outpu
 
 	// When no pipeline was configured, perform the quick sync.
 	if cfg.Pipeline == nil || len(cfg.Pipeline.Stages) == 0 {
+		out.SyncStrategy = model.SyncStrategy_QUICK_SYNC
 		out.Stages = buildQuickSyncPipeline(cfg.Input.AutoRollback, time.Now())
 		out.Summary = fmt.Sprintf("Quick sync to deploy image %s and configure all traffic to it (pipeline was not configured)", out.Version)
 		return
@@ -98,12 +102,14 @@ func (p *Planner) Plan(ctx context.Context, in planner.Input) (out planner.Outpu
 	ds, err = in.RunningDSP.Get(ctx, ioutil.Discard)
 	if err == nil {
 		if lastVersion, e := determineVersion(ds.AppDir, cfg.Input.FunctionManifestFile); e == nil {
+			out.SyncStrategy = model.SyncStrategy_PIPELINE
 			out.Stages = buildProgressivePipeline(cfg.Pipeline, cfg.Input.AutoRollback, time.Now())
 			out.Summary = fmt.Sprintf("Sync with pipeline to update image from %s to %s", lastVersion, out.Version)
 			return
 		}
 	}
 
+	out.SyncStrategy = model.SyncStrategy_PIPELINE
 	out.Stages = buildProgressivePipeline(cfg.Pipeline, cfg.Input.AutoRollback, time.Now())
 	out.Summary = "Sync with the specified pipeline"
 	return

--- a/pkg/app/piped/planner/planner.go
+++ b/pkg/app/piped/planner/planner.go
@@ -49,9 +49,10 @@ type Input struct {
 }
 
 type Output struct {
-	Version string
-	Stages  []*model.PipelineStage
-	Summary string
+	Version      string
+	SyncStrategy model.SyncStrategy
+	Summary      string
+	Stages       []*model.PipelineStage
 }
 
 // MakeInitialStageMetadata makes the initial metadata for the given state configuration.


### PR DESCRIPTION
**What this PR does / why we need it**:

PlanPreview feature needs this field to build its result.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
