### PR TITLE
Use custom piped metrics registry instead of the default one

### DIFF
--- a/pkg/app/api/service/pipedservice/service.proto
+++ b/pkg/app/api/service/pipedservice/service.proto
@@ -165,7 +165,7 @@ message PingResponse {
 
 message ReportStatRequest {
     // Metrics byte sequence in OpenMetrics format.
-    bytes piped_stats = 1 [(validate.rules).bytes.min_len = 1];
+    bytes piped_stats = 1;
 }
 
 message ReportStatResponse {

--- a/pkg/app/piped/cmd/piped/piped.go
+++ b/pkg/app/piped/cmd/piped/piped.go
@@ -618,9 +618,11 @@ func (p *piped) insertLoginUserToPasswd(ctx context.Context) error {
 
 func registerMetrics(pipedID string) *prometheus.Registry {
 	r := prometheus.NewRegistry()
-	// TODO: Add piped version as label.
 	wrapped := prometheus.WrapRegistererWith(
-		prometheus.Labels{"piped": pipedID},
+		prometheus.Labels{
+			"piped":         pipedID,
+			"piped_version": version.Get().Version,
+		},
 		r,
 	)
 

--- a/pkg/app/piped/cmd/piped/piped.go
+++ b/pkg/app/piped/cmd/piped/piped.go
@@ -625,6 +625,8 @@ func registerMetrics(pipedID string) *prometheus.Registry {
 		},
 		r,
 	)
+	wrapped.Register(prometheus.NewGoCollector())
+	wrapped.Register(prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}))
 
 	k8scloudprovidermetrics.Register(wrapped)
 	k8slivestatestoremetrics.Register(wrapped)

--- a/pkg/app/piped/cmd/piped/piped.go
+++ b/pkg/app/piped/cmd/piped/piped.go
@@ -134,7 +134,7 @@ func (p *piped) run(ctx context.Context, t cli.Telemetry) (runErr error) {
 	}
 
 	// Register all metrics.
-	registerMetrics(cfg.PipedID)
+	registry := registerMetrics(cfg.PipedID)
 
 	// Initialize notifier and add piped events.
 	notifier, err := notifier.NewNotifier(cfg, t.Logger)
@@ -202,7 +202,7 @@ func (p *piped) run(ctx context.Context, t cli.Telemetry) (runErr error) {
 		admin.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
 			w.Write([]byte("ok"))
 		})
-		admin.Handle("/metrics", t.PrometheusMetricsHandler())
+		admin.Handle("/metrics", t.PrometheusMetricsHandlerFor(registry))
 
 		group.Go(func() error {
 			return admin.Run(ctx)
@@ -616,8 +616,8 @@ func (p *piped) insertLoginUserToPasswd(ctx context.Context) error {
 	return nil
 }
 
-func registerMetrics(pipedID string) {
-	r := prometheus.DefaultRegisterer
+func registerMetrics(pipedID string) *prometheus.Registry {
+	r := prometheus.NewRegistry()
 	// TODO: Add piped version as label.
 	wrapped := prometheus.WrapRegistererWith(
 		prometheus.Labels{"piped": pipedID},
@@ -626,4 +626,6 @@ func registerMetrics(pipedID string) {
 
 	k8scloudprovidermetrics.Register(wrapped)
 	k8slivestatestoremetrics.Register(wrapped)
+
+	return r
 }

--- a/pkg/cli/BUILD.bazel
+++ b/pkg/cli/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     deps = [
         "//pkg/log:go_default_library",
         "//pkg/version:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus:go_default_library",
         "@com_github_prometheus_client_golang//prometheus/promhttp:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",
         "@com_github_spf13_pflag//:go_default_library",

--- a/pkg/cli/cmd.go
+++ b/pkg/cli/cmd.go
@@ -23,6 +23,7 @@ import (
 	"syscall"
 
 	"cloud.google.com/go/profiler"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
@@ -119,6 +120,16 @@ func startProfiler(service, version, credentialsFile string, debugLogging bool, 
 func (t Telemetry) PrometheusMetricsHandler() http.Handler {
 	if t.Flags.Metrics {
 		return promhttp.Handler()
+	}
+	var empty http.HandlerFunc = func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(""))
+	}
+	return empty
+}
+
+func (t Telemetry) PrometheusMetricsHandlerFor(r *prometheus.Registry) http.Handler {
+	if t.Flags.Metrics {
+		return promhttp.HandlerFor(r, promhttp.HandlerOpts{})
 	}
 	var empty http.HandlerFunc = func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(""))


### PR DESCRIPTION
**What this PR does / why we need it**:
- address https://github.com/pipe-cd/pipe/pull/2181#discussion_r664169954
- fix https://github.com/pipe-cd/pipe/issues/2182
- remove unnecessary validation in ReportStatRequest message. We should always allow the report stat to be push to the control-plane, the validation better is handled by control-plane.

**Which issue(s) this PR fixes**:

Fixes #2182 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
