### PR TITLE
Fix wrong generated URLs for application, env and piped

### DIFF
--- a/pkg/model/BUILD.bazel
+++ b/pkg/model/BUILD.bazel
@@ -79,7 +79,9 @@ go_test(
     size = "small",
     srcs = [
         "apikey_test.go",
+        "application_test.go",
         "common_test.go",
+        "environment_test.go",
         "event_test.go",
         "model_test.go",
         "piped_test.go",

--- a/pkg/model/application.go
+++ b/pkg/model/application.go
@@ -15,8 +15,9 @@
 package model
 
 import (
-	"path"
+	"fmt"
 	"path/filepath"
+	"strings"
 )
 
 const DefaultDeploymentConfigFileName = ".pipe.yaml"
@@ -46,5 +47,5 @@ func (s ApplicationSyncState) HasChanged(next ApplicationSyncState) bool {
 }
 
 func MakeApplicationURL(baseURL, applicationID string) string {
-	return path.Join(baseURL, "applications", applicationID)
+	return fmt.Sprintf("%s/applications/%s", strings.TrimSuffix(baseURL, "/"), applicationID)
 }

--- a/pkg/model/application_test.go
+++ b/pkg/model/application_test.go
@@ -1,0 +1,49 @@
+// Copyright 2021 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMakeApplicationURL(t *testing.T) {
+	testcases := []struct {
+		name          string
+		baseURL       string
+		applicationID string
+		expected      string
+	}{
+		{
+			name:          "baseURL has no suffix",
+			baseURL:       "https://pipecd.dev",
+			applicationID: "app-1",
+			expected:      "https://pipecd.dev/applications/app-1",
+		},
+		{
+			name:          "baseURL suffixed by /",
+			baseURL:       "https://pipecd.dev/",
+			applicationID: "app-2",
+			expected:      "https://pipecd.dev/applications/app-2",
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := MakeApplicationURL(tc.baseURL, tc.applicationID)
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+}

--- a/pkg/model/environment.go
+++ b/pkg/model/environment.go
@@ -14,8 +14,11 @@
 
 package model
 
-import "path"
+import (
+	"fmt"
+	"strings"
+)
 
 func MakeEnvironmentURL(baseURL, environmentID string) string {
-	return path.Join(baseURL, "settings", "environment")
+	return fmt.Sprintf("%s/settings/environment", strings.TrimSuffix(baseURL, "/"))
 }

--- a/pkg/model/environment_test.go
+++ b/pkg/model/environment_test.go
@@ -1,0 +1,49 @@
+// Copyright 2021 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMakeEnvironmentURL(t *testing.T) {
+	testcases := []struct {
+		name          string
+		baseURL       string
+		environmentID string
+		expected      string
+	}{
+		{
+			name:          "baseURL has no suffix",
+			baseURL:       "https://pipecd.dev",
+			environmentID: "env-1",
+			expected:      "https://pipecd.dev/settings/environment",
+		},
+		{
+			name:          "baseURL suffixed by /",
+			baseURL:       "https://pipecd.dev/",
+			environmentID: "env-1",
+			expected:      "https://pipecd.dev/settings/environment",
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := MakeEnvironmentURL(tc.baseURL, tc.environmentID)
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+}

--- a/pkg/model/piped.go
+++ b/pkg/model/piped.go
@@ -17,7 +17,7 @@ package model
 import (
 	"errors"
 	"fmt"
-	"path"
+	"strings"
 	"time"
 
 	"golang.org/x/crypto/bcrypt"
@@ -140,5 +140,5 @@ func (p *Piped) RedactSensitiveData() {
 }
 
 func MakePipedURL(baseURL, pipedID string) string {
-	return path.Join(baseURL, "settings", "piped")
+	return fmt.Sprintf("%s/settings/piped", strings.TrimSuffix(baseURL, "/"))
 }

--- a/pkg/model/piped_test.go
+++ b/pkg/model/piped_test.go
@@ -236,3 +236,31 @@ func TestPipedRedactSensitiveData(t *testing.T) {
 		})
 	}
 }
+
+func TestMakePipedURL(t *testing.T) {
+	testcases := []struct {
+		name     string
+		baseURL  string
+		pipedID  string
+		expected string
+	}{
+		{
+			name:     "baseURL has no suffix",
+			baseURL:  "https://pipecd.dev",
+			pipedID:  "piped-id",
+			expected: "https://pipecd.dev/settings/piped",
+		},
+		{
+			name:     "baseURL suffixed by /",
+			baseURL:  "https://pipecd.dev/",
+			pipedID:  "piped-id",
+			expected: "https://pipecd.dev/settings/piped",
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := MakePipedURL(tc.baseURL, tc.pipedID)
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

`path` package should not be used to deal with `URL`. It changes all `https://foo` to `https:/foo` then worng URLs were generated.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
