### PR TITLE
Add relabel config to plot durations for each gRPC method

### DIFF
--- a/manifests/pipecd/values.yaml
+++ b/manifests/pipecd/values.yaml
@@ -194,7 +194,7 @@ prometheus:
             - source_labels: [__name__]
               target_label: __name__
               regex: envoy_cluster_grpc_(.+)_(.+)_(.+)_(.+)_upstream_rq_time_bucket$
-              replacement: pipecd_requests_duration_bucket
+              replacement: pipecd_gateway_requests_duration_bucket
             - source_labels: [__name__]
               target_label: method
               regex: envoy_cluster_grpc_(.+)_(.+)_(.+)_(.+)_upstream_rq_time_sum$
@@ -202,7 +202,7 @@ prometheus:
             - source_labels: [__name__]
               target_label: __name__
               regex: envoy_cluster_grpc_(.+)_(.+)_(.+)_(.+)_upstream_rq_time_sum$
-              replacement: pipecd_requests_duration_sum
+              replacement: pipecd_gateway_requests_duration_sum
             - source_labels: [__name__]
               target_label: method
               regex: envoy_cluster_grpc_(.+)_(.+)_(.+)_(.+)_upstream_rq_time_count$
@@ -210,7 +210,7 @@ prometheus:
             - source_labels: [__name__]
               target_label: __name__
               regex: envoy_cluster_grpc_(.+)_(.+)_(.+)_(.+)_upstream_rq_time_count$
-              replacement: pipecd_requests_duration_count
+              replacement: pipecd_gateway_requests_duration_count
 
         - job_name: pipecd-server
           scrape_interval: 1m

--- a/manifests/pipecd/values.yaml
+++ b/manifests/pipecd/values.yaml
@@ -186,6 +186,31 @@ prometheus:
             - source_labels: [__meta_kubernetes_pod_container_port_name]
               action: keep
               regex: envoy-admin
+          metric_relabel_configs:
+            - source_labels: [__name__]
+              target_label: method
+              regex: envoy_cluster_grpc_(.+)_(.+)_(.+)_(.+)_upstream_rq_time_bucket$
+              replacement: $4
+            - source_labels: [__name__]
+              target_label: __name__
+              regex: envoy_cluster_grpc_(.+)_(.+)_(.+)_(.+)_upstream_rq_time_bucket$
+              replacement: pipecd_requests_duration_bucket
+            - source_labels: [__name__]
+              target_label: method
+              regex: envoy_cluster_grpc_(.+)_(.+)_(.+)_(.+)_upstream_rq_time_sum$
+              replacement: $4
+            - source_labels: [__name__]
+              target_label: __name__
+              regex: envoy_cluster_grpc_(.+)_(.+)_(.+)_(.+)_upstream_rq_time_sum$
+              replacement: pipecd_requests_duration_sum
+            - source_labels: [__name__]
+              target_label: method
+              regex: envoy_cluster_grpc_(.+)_(.+)_(.+)_(.+)_upstream_rq_time_count$
+              replacement: $4
+            - source_labels: [__name__]
+              target_label: __name__
+              regex: envoy_cluster_grpc_(.+)_(.+)_(.+)_(.+)_upstream_rq_time_count$
+              replacement: pipecd_requests_duration_count
 
         - job_name: pipecd-server
           scrape_interval: 1m


### PR DESCRIPTION
**What this PR does / why we need it**:
For durations, stats reported by Envoy is enough to see.

![image](https://user-images.githubusercontent.com/19730728/124569093-98764500-de80-11eb-9c53-c6b1208ea027.png)

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
