### PR TITLE
Explicitly use string as type for key in cache package

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -25,18 +25,18 @@ var (
 
 // Getter wraps a method to read from cache.
 type Getter interface {
-	Get(key interface{}) (interface{}, error)
-	GetAll() (map[interface{}]interface{}, error)
+	Get(key string) (interface{}, error)
+	GetAll() (map[string]interface{}, error)
 }
 
 // Putter wraps a method to write to cache.
 type Putter interface {
-	Put(key interface{}, value interface{}) error
+	Put(key string, value interface{}) error
 }
 
 // Deleter wraps a method to delete from cache.
 type Deleter interface {
-	Delete(key interface{}) error
+	Delete(key string) error
 }
 
 // Cache groups Getter, Putter and Deleter.
@@ -65,7 +65,7 @@ func MultiGetter(getters ...Getter) Getter {
 	}
 }
 
-func (mg *multiGetter) Get(key interface{}) (interface{}, error) {
+func (mg *multiGetter) Get(key string) (interface{}, error) {
 	if len(mg.getters) == 0 {
 		return nil, ErrNotFound
 	}
@@ -85,6 +85,6 @@ func (mg *multiGetter) Get(key interface{}) (interface{}, error) {
 	return nil, firstErr
 }
 
-func (mg *multiGetter) GetAll() (map[interface{}]interface{}, error) {
+func (mg *multiGetter) GetAll() (map[string]interface{}, error) {
 	return nil, ErrUnimplemented
 }

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -21,13 +21,13 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type getterFunc func(key interface{}) (interface{}, error)
+type getterFunc func(key string) (interface{}, error)
 
-func (f getterFunc) Get(key interface{}) (interface{}, error) {
+func (f getterFunc) Get(key string) (interface{}, error) {
 	return f(key)
 }
 
-func (f getterFunc) GetAll() (map[interface{}]interface{}, error) {
+func (f getterFunc) GetAll() (map[string]interface{}, error) {
 	return nil, ErrUnimplemented
 }
 
@@ -36,11 +36,11 @@ func TestMultiGetter(t *testing.T) {
 	err := errors.New("err")
 	var calls int
 
-	successGetter := getterFunc(func(key interface{}) (interface{}, error) {
+	successGetter := getterFunc(func(key string) (interface{}, error) {
 		calls++
 		return value, nil
 	})
-	failureGetter := getterFunc(func(key interface{}) (interface{}, error) {
+	failureGetter := getterFunc(func(key string) (interface{}, error) {
 		calls++
 		return nil, err
 	})

--- a/pkg/cache/memorycache/cache.go
+++ b/pkg/cache/memorycache/cache.go
@@ -29,7 +29,7 @@ func NewCache() *Cache {
 	return &Cache{}
 }
 
-func (c *Cache) Get(key interface{}) (interface{}, error) {
+func (c *Cache) Get(key string) (interface{}, error) {
 	item, ok := c.values.Load(key)
 	if !ok {
 		cachemetrics.IncGetOperationCounter(
@@ -45,16 +45,16 @@ func (c *Cache) Get(key interface{}) (interface{}, error) {
 	return item, nil
 }
 
-func (c *Cache) Put(key interface{}, value interface{}) error {
+func (c *Cache) Put(key string, value interface{}) error {
 	c.values.Store(key, value)
 	return nil
 }
 
-func (c *Cache) Delete(key interface{}) error {
+func (c *Cache) Delete(key string) error {
 	c.values.Delete(key)
 	return nil
 }
 
-func (c *Cache) GetAll() (map[interface{}]interface{}, error) {
+func (c *Cache) GetAll() (map[string]interface{}, error) {
 	return nil, cache.ErrUnimplemented
 }

--- a/pkg/cache/memorycache/lru_cache.go
+++ b/pkg/cache/memorycache/lru_cache.go
@@ -35,7 +35,7 @@ func NewLRUCache(size int) (*LRUCache, error) {
 	}, nil
 }
 
-func (c *LRUCache) Get(key interface{}) (interface{}, error) {
+func (c *LRUCache) Get(key string) (interface{}, error) {
 	item, ok := c.cache.Get(key)
 	if !ok {
 		cachemetrics.IncGetOperationCounter(
@@ -51,16 +51,16 @@ func (c *LRUCache) Get(key interface{}) (interface{}, error) {
 	return item, nil
 }
 
-func (c *LRUCache) Put(key interface{}, value interface{}) error {
+func (c *LRUCache) Put(key string, value interface{}) error {
 	c.cache.Add(key, value)
 	return nil
 }
 
-func (c *LRUCache) Delete(key interface{}) error {
+func (c *LRUCache) Delete(key string) error {
 	c.cache.Remove(key)
 	return nil
 }
 
-func (c *LRUCache) GetAll() (map[interface{}]interface{}, error) {
+func (c *LRUCache) GetAll() (map[string]interface{}, error) {
 	return nil, cache.ErrUnimplemented
 }

--- a/pkg/cache/memorycache/ttl_cache.go
+++ b/pkg/cache/memorycache/ttl_cache.go
@@ -68,7 +68,7 @@ func (c *TTLCache) evictExpired(t time.Time) {
 	})
 }
 
-func (c *TTLCache) Get(key interface{}) (interface{}, error) {
+func (c *TTLCache) Get(key string) (interface{}, error) {
 	item, ok := c.entries.Load(key)
 	if !ok {
 		cachemetrics.IncGetOperationCounter(
@@ -84,7 +84,7 @@ func (c *TTLCache) Get(key interface{}) (interface{}, error) {
 	return item.(*entry).value, nil
 }
 
-func (c *TTLCache) Put(key interface{}, value interface{}) error {
+func (c *TTLCache) Put(key string, value interface{}) error {
 	e := &entry{
 		value:      value,
 		expiration: time.Now().Add(c.ttl),
@@ -93,11 +93,11 @@ func (c *TTLCache) Put(key interface{}, value interface{}) error {
 	return nil
 }
 
-func (c *TTLCache) Delete(key interface{}) error {
+func (c *TTLCache) Delete(key string) error {
 	c.entries.Delete(key)
 	return nil
 }
 
-func (c *TTLCache) GetAll() (map[interface{}]interface{}, error) {
+func (c *TTLCache) GetAll() (map[string]interface{}, error) {
 	return nil, cache.ErrUnimplemented
 }

--- a/pkg/cache/rediscache/cache.go
+++ b/pkg/cache/rediscache/cache.go
@@ -42,7 +42,7 @@ func NewTTLCache(redis redis.Redis, ttl time.Duration) *RedisCache {
 	}
 }
 
-func (c *RedisCache) Get(k interface{}) (interface{}, error) {
+func (c *RedisCache) Get(k string) (interface{}, error) {
 	conn := c.redis.Get()
 	defer conn.Close()
 	reply, err := conn.Do("GET", k)
@@ -77,7 +77,7 @@ func (c *RedisCache) Get(k interface{}) (interface{}, error) {
 	return reply, nil
 }
 
-func (c *RedisCache) Put(k interface{}, v interface{}) error {
+func (c *RedisCache) Put(k string, v interface{}) error {
 	conn := c.redis.Get()
 	defer conn.Close()
 	var err error
@@ -89,13 +89,13 @@ func (c *RedisCache) Put(k interface{}, v interface{}) error {
 	return err
 }
 
-func (c *RedisCache) Delete(k interface{}) error {
+func (c *RedisCache) Delete(k string) error {
 	conn := c.redis.Get()
 	defer conn.Close()
 	_, err := conn.Do("DEL", k)
 	return err
 }
 
-func (c *RedisCache) GetAll() (map[interface{}]interface{}, error) {
+func (c *RedisCache) GetAll() (map[string]interface{}, error) {
 	return nil, cache.ErrUnimplemented
 }

--- a/pkg/cache/rediscache/hashcache.go
+++ b/pkg/cache/rediscache/hashcache.go
@@ -45,7 +45,7 @@ func NewTTLHashCache(redis redis.Redis, ttl time.Duration, key string) *RedisHas
 	}
 }
 
-func (r *RedisHashCache) Get(k interface{}) (interface{}, error) {
+func (r *RedisHashCache) Get(k string) (interface{}, error) {
 	conn := r.redis.Get()
 	defer conn.Close()
 	reply, err := conn.Do("HGET", r.key, k)
@@ -64,7 +64,7 @@ func (r *RedisHashCache) Get(k interface{}) (interface{}, error) {
 	return reply, nil
 }
 
-func (r *RedisHashCache) Put(k interface{}, v interface{}) error {
+func (r *RedisHashCache) Put(k string, v interface{}) error {
 	conn := r.redis.Get()
 	defer conn.Close()
 	_, err := conn.Do("HSET", r.key, k, v)
@@ -74,14 +74,14 @@ func (r *RedisHashCache) Put(k interface{}, v interface{}) error {
 	return err
 }
 
-func (r *RedisHashCache) Delete(k interface{}) error {
+func (r *RedisHashCache) Delete(k string) error {
 	conn := r.redis.Get()
 	defer conn.Close()
 	_, err := conn.Do("HDEL", r.key, k)
 	return err
 }
 
-func (r *RedisHashCache) GetAll() (map[interface{}]interface{}, error) {
+func (r *RedisHashCache) GetAll() (map[string]interface{}, error) {
 	conn := r.redis.Get()
 	defer conn.Close()
 	reply, err := redigo.Values(conn.Do("HGETALL", r.key))
@@ -98,7 +98,7 @@ func (r *RedisHashCache) GetAll() (map[interface{}]interface{}, error) {
 		return nil, errors.New("invalid key-value pair contained")
 	}
 
-	out := make(map[interface{}]interface{}, len(reply)/2)
+	out := make(map[string]interface{}, len(reply)/2)
 	for i := 0; i < len(reply); i += 2 {
 		key, okKey := reply[i].([]byte)
 		if !okKey {


### PR DESCRIPTION
**What this PR does / why we need it**:

This simplifies the cache interface.

**Which issue(s) this PR fixes**:

Fixes #2199

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
