### PR TITLE
Avoid panic in case of error gathering ops metrics

### DIFF
--- a/pkg/cli/cmd.go
+++ b/pkg/cli/cmd.go
@@ -148,11 +148,13 @@ func (t Telemetry) CustomMetricsHandlerFor(mb MetricsBuilder) http.Handler {
 			rc, err := mb.Build()
 			if err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
 			}
 
 			_, err = io.Copy(w, rc)
 			if err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
 			}
 		})
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Avoid panic in case of error while gathering metrics at ops's metrics endpoint.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
