### PR TITLE
Fix bug that SAVE button at admin account form is not enabled when using the same username

### DIFF
--- a/pkg/app/web/src/components/settings-page/project/components/static-admin-form/index.tsx
+++ b/pkg/app/web/src/components/settings-page/project/components/static-admin-form/index.tsx
@@ -102,8 +102,7 @@ const StaticAdminDialog: FC<{
             type="submit"
             color="primary"
             disabled={
-              formik.isValid === false ||
-              formik.values.username === ""
+              formik.isValid === false
             }
           >
             {UI_TEXT_SAVE}

--- a/pkg/app/web/src/components/settings-page/project/components/static-admin-form/index.tsx
+++ b/pkg/app/web/src/components/settings-page/project/components/static-admin-form/index.tsx
@@ -73,6 +73,7 @@ const StaticAdminDialog: FC<{
             id="username"
             name="username"
             value={formik.values.username}
+            defaultValue={formik.values.username}
             variant="outlined"
             margin="dense"
             label="Username"
@@ -102,7 +103,7 @@ const StaticAdminDialog: FC<{
             color="primary"
             disabled={
               formik.isValid === false ||
-              formik.values.username === currentUsername
+              formik.values.username === ""
             }
           >
             {UI_TEXT_SAVE}


### PR DESCRIPTION


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #2208

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Fix bug that SAVE button at admin account form is not enabled when using the same username
```
