### PR TITLE
Copy SSH key into ssh config dir to use instead of using the given one directly

### DIFF
--- a/pkg/git/ssh_config.go
+++ b/pkg/git/ssh_config.go
@@ -73,6 +73,7 @@ func AddSSHConfig(cfg config.PipedGit) error {
 		if err != nil {
 			return err
 		}
+		// TODO: Remove this key file when Piped terminating.
 		if _, err := f.Write(key); err != nil {
 			return err
 		}

--- a/pkg/git/ssh_config.go
+++ b/pkg/git/ssh_config.go
@@ -17,7 +17,6 @@ package git
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -66,7 +65,7 @@ func AddSSHConfig(cfg config.PipedGit) error {
 
 	var sshKeyFile string
 	if cfg.SSHKeyFile != "" {
-		f, err := ioutil.TempFile(sshDir, "piped-ssh-key-*")
+		f, err := os.CreateTemp(sshDir, "piped-ssh-key-*")
 		if err != nil {
 			return err
 		}

--- a/pkg/git/ssh_config_test.go
+++ b/pkg/git/ssh_config_test.go
@@ -32,7 +32,7 @@ func TestGenerateSSHConfig(t *testing.T) {
 		{
 			name: "default",
 			cfg: config.PipedGit{
-				SSHKeyFile: "/etc/piped-secret/ssh-key",
+				SSHKeyFile: "/tmp/piped-secret/ssh-key",
 			},
 			expected: `
 Host github.com
@@ -48,7 +48,7 @@ Host github.com
 			name: "host is configured",
 			cfg: config.PipedGit{
 				Host:       "gitlab.com",
-				SSHKeyFile: "/etc/piped-secret/ssh-key",
+				SSHKeyFile: "/tmp/piped-secret/ssh-key",
 			},
 			expected: `
 Host gitlab.com
@@ -65,7 +65,7 @@ Host gitlab.com
 			cfg: config.PipedGit{
 				Host:       "gitlab.com",
 				HostName:   "gitlab.com",
-				SSHKeyFile: "/etc/piped-secret/ssh-key",
+				SSHKeyFile: "/tmp/piped-secret/ssh-key",
 			},
 			expected: `
 Host gitlab.com
@@ -81,7 +81,8 @@ Host gitlab.com
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := generateSSHConfig(tc.cfg)
+			sshKeyFile := "/etc/piped-secret/ssh-key"
+			got, err := generateSSHConfig(tc.cfg, sshKeyFile)
 			assert.Equal(t, tc.expected, got)
 			assert.Equal(t, tc.expectedErr, err)
 		})


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, we are writing an SSH config file to use the given SSH key file directly.
In that way, ssh-agent will consider the directory which contains the given SSH key file as a dedicated directory to deal with key/cert files.

In some cases, users are expecting that the Piped should use the given SSH key file and do nothing with its directory.
So this PR copies the given key into ssh config directory with a random name to use.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
