### PR TITLE
Allow embedding piped-key and ssh-key in config file

### DIFF
--- a/docs/content/en/docs/operator-manual/piped/configuration-reference.md
+++ b/docs/content/en/docs/operator-manual/piped/configuration-reference.md
@@ -22,6 +22,7 @@ spec:
 | projectID | string | The identifier of the PipeCD project where this piped belongs to. | Yes |
 | pipedID | string | The generated ID for this piped. | Yes |
 | pipedKeyFile | string | The path to the file containing the generated key string for this piped. | Yes |
+| pipedKeyData | string | Base64 encoded string of Piped key. Either pipedKeyFile or pipedKeyData must be set. | Yes |
 | apiAddress | string | The address used to connect to the control-plane's API. | Yes |
 | webAddress | string | The address to the control-plane's Web. | No |
 | syncInterval | duration | How often to check whether an application should be synced. Default is `1m`. | No |
@@ -43,6 +44,7 @@ spec:
 | host | string | The host name. Default is `github.com`. | No |
 | hostName | string | The hostname or IP address of the remote git server. Default is the same value with Host. | No |
 | sshKeyFile | string | The path to the private ssh key file. This will be used to clone the source code of the specified git repositories. | No |
+| sshKeyData | string | Base64 encoded string of SSH key. | No |
 
 ## GitRepository
 

--- a/pkg/config/piped.go
+++ b/pkg/config/piped.go
@@ -194,6 +194,9 @@ func (s *PipedSpec) GetSecretManagement() *SecretManagement {
 }
 
 func (s *PipedSpec) LoadPipedKey() ([]byte, error) {
+	if s.PipedKeyData != "" && s.PipedKeyFile != "" {
+		return nil, errors.New("only either pipedKeyFile or pipedKeyData can be set")
+	}
 	if s.PipedKeyData != "" {
 		return base64.StdEncoding.DecodeString(s.PipedKeyData)
 	}
@@ -233,6 +236,9 @@ func (g PipedGit) ShouldConfigureSSHConfig() bool {
 }
 
 func (g PipedGit) LoadSSHKey() ([]byte, error) {
+	if g.SSHKeyData != "" && g.SSHKeyFile != "" {
+		return nil, errors.New("only either sshKeyFile or sshKeyData can be set")
+	}
 	if g.SSHKeyData != "" {
 		return base64.StdEncoding.DecodeString(g.SSHKeyData)
 	}

--- a/pkg/git/ssh_config.go
+++ b/pkg/git/ssh_config.go
@@ -63,24 +63,22 @@ func AddSSHConfig(cfg config.PipedGit) error {
 		return fmt.Errorf("failed to create a directory %s: %v", sshDir, err)
 	}
 
-	var sshKeyFile string
-	if cfg.SSHKeyFile != "" {
-		f, err := os.CreateTemp(sshDir, "piped-ssh-key-*")
-		if err != nil {
-			return err
-		}
-		key, err := os.ReadFile(cfg.SSHKeyFile)
-		if err != nil {
-			return err
-		}
-		// TODO: Remove this key file when Piped terminating.
-		if _, err := f.Write(key); err != nil {
-			return err
-		}
-		sshKeyFile = f.Name()
+	sshKey, err := cfg.LoadSSHKey()
+	if err != nil {
+		return err
 	}
 
-	configData, err := generateSSHConfig(cfg, sshKeyFile)
+	sshKeyFile, err := os.CreateTemp(sshDir, "piped-ssh-key-*")
+	if err != nil {
+		return err
+	}
+
+	// TODO: Remove this key file when Piped terminating.
+	if _, err := sshKeyFile.Write(sshKey); err != nil {
+		return err
+	}
+
+	configData, err := generateSSHConfig(cfg, sshKeyFile.Name())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

While running Piped on CloudRun, the Piped config and all needed credentials will be stored in Google Secret Manager.
Because the configuration file itself is stored securely,  we don't need to load API-key and SSH-key from other files in that case.
The fewer secrets, the easier it is to manage.
Therefore, this PR allows embedding piped-key and ssh-key into the config file.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Allow embedding piped-key and ssh-key in Piped config file
```
