### PR TITLE
Disable to collect cluster-level stats by default

### DIFF
--- a/manifests/pipecd/templates/configmap.yaml
+++ b/manifests/pipecd/templates/configmap.yaml
@@ -11,9 +11,9 @@ data:
 {{- end }}
 
 {{- if .Values.monitoring.enabled }}
+{{- if .Values.monitoring.clusterStats }}
 ---
 
-{{- if .Values.monitoring.clusterStats }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -28,8 +28,8 @@ data:
   {{ trimPrefix "grafana-dashboards/cluster/" $path | nindent 2 }}: |-
     {{ $.Files.Get $path | nindent 4 }}
 {{ end }}
----
 {{- end }}
+---
 
 apiVersion: v1
 kind: ConfigMap

--- a/manifests/pipecd/templates/configmap.yaml
+++ b/manifests/pipecd/templates/configmap.yaml
@@ -13,6 +13,7 @@ data:
 {{- if .Values.monitoring.enabled }}
 ---
 
+{{- if .Values.monitoring.clusterStats }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -28,6 +29,7 @@ data:
     {{ $.Files.Get $path | nindent 4 }}
 {{ end }}
 ---
+{{- end }}
 
 apiVersion: v1
 kind: ConfigMap
@@ -48,7 +50,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: pipecd-prometheus-server-rules
+  name: {{ include "pipecd.fullname" . }}-{{ .Values.prometheus.server.configMapOverrideName }}
   labels:
     {{- include "pipecd.labels" . | nindent 4 }}
 data:
@@ -56,4 +58,226 @@ data:
   {{ trimPrefix "prom-rules/" $path | nindent 2 }}: |-
     {{ $.Files.Get $path | nindent 4 }}
 {{ end }}
-{{- end }}
+  prometheus.yml: |-
+    global:
+      scrape_interval: 1m
+      scrape_timeout: 10s
+      evaluation_interval: 1m
+
+    rule_files:
+      - /etc/config/recording_rules.yml
+      - /etc/config/alerting_rules.yml
+
+    scrape_configs:
+      - job_name: pipecd-gateway
+        scrape_interval: 1m
+        metrics_path: /stats/prometheus
+        kubernetes_sd_configs:
+          - role: endpoints
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_service_label_app_kubernetes_io_name]
+            action: keep
+            regex: pipecd
+          - source_labels: [__meta_kubernetes_service_label_app_kubernetes_io_component]
+            action: keep
+            regex: gateway
+          - source_labels: [__meta_kubernetes_pod_container_port_name]
+            action: keep
+            regex: envoy-admin
+        metric_relabel_configs:
+          - source_labels: [__name__]
+            target_label: method
+            regex: envoy_cluster_grpc_(.+)_(.+)_(.+)_(.+)_upstream_rq_time_bucket$
+            replacement: $4
+          - source_labels: [__name__]
+            target_label: __name__
+            regex: envoy_cluster_grpc_(.+)_(.+)_(.+)_(.+)_upstream_rq_time_bucket$
+            replacement: pipecd_gateway_requests_duration_bucket
+          - source_labels: [__name__]
+            target_label: method
+            regex: envoy_cluster_grpc_(.+)_(.+)_(.+)_(.+)_upstream_rq_time_sum$
+            replacement: $4
+          - source_labels: [__name__]
+            target_label: __name__
+            regex: envoy_cluster_grpc_(.+)_(.+)_(.+)_(.+)_upstream_rq_time_sum$
+            replacement: pipecd_gateway_requests_duration_sum
+          - source_labels: [__name__]
+            target_label: method
+            regex: envoy_cluster_grpc_(.+)_(.+)_(.+)_(.+)_upstream_rq_time_count$
+            replacement: $4
+          - source_labels: [__name__]
+            target_label: __name__
+            regex: envoy_cluster_grpc_(.+)_(.+)_(.+)_(.+)_upstream_rq_time_count$
+            replacement: pipecd_gateway_requests_duration_count
+
+      - job_name: pipecd-server
+        scrape_interval: 1m
+        kubernetes_sd_configs:
+          - role: endpoints
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_service_label_app_kubernetes_io_name]
+            action: keep
+            regex: pipecd
+          - source_labels: [__meta_kubernetes_service_label_app_kubernetes_io_component]
+            action: keep
+            regex: server
+          - source_labels: [__meta_kubernetes_pod_container_port_name]
+            action: keep
+            regex: admin
+
+      - job_name: pipecd-ops
+        scrape_interval: 1m
+        kubernetes_sd_configs:
+          - role: endpoints
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_service_label_app_kubernetes_io_name]
+            action: keep
+            regex: pipecd
+          - source_labels: [__meta_kubernetes_service_label_app_kubernetes_io_component]
+            action: keep
+            regex: ops
+          - source_labels: [__meta_kubernetes_pod_container_port_name]
+            action: keep
+            regex: admin
+
+    {{- if .Values.monitoring.clusterStats }}
+      - job_name: prometheus
+        static_configs:
+          - targets:
+              - localhost:9090
+
+      # Scrape config for API servers.
+      - job_name: kubernetes-apiservers
+        kubernetes_sd_configs:
+          - role: endpoints
+        scheme: https
+        tls_config:
+          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+          insecure_skip_verify: true
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
+            action: keep
+            regex: default;kubernetes;https
+
+      - job_name: kubernetes-nodes
+        kubernetes_sd_configs:
+          - role: node
+        scheme: https
+        tls_config:
+          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+          insecure_skip_verify: true
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        relabel_configs:
+          - action: labelmap
+            regex: __meta_kubernetes_node_label_(.+)
+          - target_label: __address__
+            replacement: kubernetes.default.svc:443
+          - source_labels: [__meta_kubernetes_node_name]
+            regex: (.+)
+            target_label: __metrics_path__
+            replacement: /api/v1/nodes/$1/proxy/metrics
+
+      # Container stats for PipeCD services
+      - job_name: kubernetes-nodes-cadvisor
+        kubernetes_sd_configs:
+          - role: node
+        scheme: https
+        tls_config:
+          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+          insecure_skip_verify: true
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        relabel_configs:
+          - action: labelmap
+            regex: __meta_kubernetes_node_label_(.+)
+          - target_label: __address__
+            replacement: kubernetes.default.svc:443
+          - source_labels: [__meta_kubernetes_node_name]
+            regex: (.+)
+            target_label: __metrics_path__
+            replacement: /api/v1/nodes/$1/proxy/metrics/cadvisor
+        metric_relabel_configs:
+          - source_labels: [pod]
+            target_label: service
+            regex: (.+)-[0-9a-zA-Z]+(-[0-9a-zA-Z]+)$
+            replacement: $1
+
+      # Cluster stats for PipeCD services
+      - job_name: kube-state-metrics
+        kubernetes_sd_configs:
+          - role: endpoints
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_service_label_app_kubernetes_io_name]
+            action: keep
+            regex: kube-state-metrics
+          - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape]
+            action: keep
+            regex: true
+          - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scheme]
+            action: replace
+            target_label: __scheme__
+            regex: (https?)
+          - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_path]
+            action: replace
+            target_label: __metrics_path__
+            regex: (.+)
+          - source_labels: [__address__, __meta_kubernetes_service_annotation_prometheus_io_port]
+            action: replace
+            target_label: __address__
+            regex: ([^:]+)(?::\d+)?;(\d+)
+            replacement: $1:$2
+          - action: labelmap
+            regex: __meta_kubernetes_service_label_(.+)
+          - source_labels: [__meta_kubernetes_namespace]
+            action: replace
+            target_label: kubernetes_namespace
+          - source_labels: [__meta_kubernetes_service_name]
+            action: replace
+            target_label: kubernetes_name
+          - source_labels: [__meta_kubernetes_pod_node_name]
+            action: replace
+            target_label: kubernetes_node
+        metric_relabel_configs:
+          - source_labels: [pod]
+            target_label: service
+            regex: (.+)-[0-9a-zA-Z]+(-[0-9a-zA-Z]+)$
+            replacement: $1
+
+      - job_name: node-exporter
+        kubernetes_sd_configs:
+          - role: endpoints
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_service_label_component]
+            action: keep
+            regex: node-exporter
+          - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape]
+            action: keep
+            regex: true
+          - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scheme]
+            action: replace
+            target_label: __scheme__
+            regex: (https?)
+          - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_path]
+            action: replace
+            target_label: __metrics_path__
+            regex: (.+)
+          - source_labels: [__address__, __meta_kubernetes_service_annotation_prometheus_io_port]
+            action: replace
+            target_label: __address__
+            regex: ([^:]+)(?::\d+)?;(\d+)
+            replacement: $1:$2
+          - action: labelmap
+            regex: __meta_kubernetes_service_label_(.+)
+          - source_labels: [__meta_kubernetes_namespace]
+            action: replace
+            target_label: kubernetes_namespace
+          - source_labels: [__meta_kubernetes_service_name]
+            action: replace
+            target_label: kubernetes_name
+          - source_labels: [__meta_kubernetes_pod_node_name]
+            action: replace
+            target_label: kubernetes_node
+    {{- end }}
+
+
+  {{- end }}

--- a/manifests/pipecd/values.yaml
+++ b/manifests/pipecd/values.yaml
@@ -118,6 +118,9 @@ quickstart: false
 monitoring:
   # If true, prometheus and grafana sub-charts will be installed
   enabled: false
+  # If true, cluster stats will be collected and shown on the dashboard.
+  # It includes stats for Nodes, Pods and so on.
+  clusterStats: false
 
 # All directives inside this section will be directly sent to the prometheus chart.
 # Head to the below link to see all available values.
@@ -135,13 +138,6 @@ prometheus:
   configmapReload:
     prometheus:
       enabled: true
-      extraVolumeDirs:
-        - /etc/rules
-      extraConfigmapMounts:
-        - name: rules
-          mountPath: /etc/rules
-          readOnly: true
-          configMap: pipecd-prometheus-server-rules
     alertmanager:
       enabled: true
   alertmanager:
@@ -155,226 +151,9 @@ prometheus:
       receivers: []
   server:
     # Must be fixed so that Grafana can find out statically.
+    # FIXME: Make Prometheus service name changeable as well as Grafana datasource URL
     fullnameOverride: pipecd-prometheus-server
-    extraConfigmapMounts:
-      - name: rules
-        mountPath: /etc/rules
-        readOnly: true
-        configMap: pipecd-prometheus-server-rules
-  serverFiles:
-    prometheus.yml:
-      rule_files:
-        - /etc/config/recording_rules.yml
-        - /etc/rules/alerting_rules.yml
-
-      scrape_configs:
-        - job_name: prometheus
-          static_configs:
-            - targets:
-                - localhost:9090
-
-        - job_name: pipecd-gateway
-          scrape_interval: 1m
-          metrics_path: /stats/prometheus
-          kubernetes_sd_configs:
-            - role: endpoints
-          relabel_configs:
-            - source_labels: [__meta_kubernetes_service_label_app_kubernetes_io_name]
-              action: keep
-              regex: pipecd
-            - source_labels: [__meta_kubernetes_service_label_app_kubernetes_io_component]
-              action: keep
-              regex: gateway
-            - source_labels: [__meta_kubernetes_pod_container_port_name]
-              action: keep
-              regex: envoy-admin
-          metric_relabel_configs:
-            - source_labels: [__name__]
-              target_label: method
-              regex: envoy_cluster_grpc_(.+)_(.+)_(.+)_(.+)_upstream_rq_time_bucket$
-              replacement: $4
-            - source_labels: [__name__]
-              target_label: __name__
-              regex: envoy_cluster_grpc_(.+)_(.+)_(.+)_(.+)_upstream_rq_time_bucket$
-              replacement: pipecd_gateway_requests_duration_bucket
-            - source_labels: [__name__]
-              target_label: method
-              regex: envoy_cluster_grpc_(.+)_(.+)_(.+)_(.+)_upstream_rq_time_sum$
-              replacement: $4
-            - source_labels: [__name__]
-              target_label: __name__
-              regex: envoy_cluster_grpc_(.+)_(.+)_(.+)_(.+)_upstream_rq_time_sum$
-              replacement: pipecd_gateway_requests_duration_sum
-            - source_labels: [__name__]
-              target_label: method
-              regex: envoy_cluster_grpc_(.+)_(.+)_(.+)_(.+)_upstream_rq_time_count$
-              replacement: $4
-            - source_labels: [__name__]
-              target_label: __name__
-              regex: envoy_cluster_grpc_(.+)_(.+)_(.+)_(.+)_upstream_rq_time_count$
-              replacement: pipecd_gateway_requests_duration_count
-
-        - job_name: pipecd-server
-          scrape_interval: 1m
-          kubernetes_sd_configs:
-            - role: endpoints
-          relabel_configs:
-            - source_labels: [__meta_kubernetes_service_label_app_kubernetes_io_name]
-              action: keep
-              regex: pipecd
-            - source_labels: [__meta_kubernetes_service_label_app_kubernetes_io_component]
-              action: keep
-              regex: server
-            - source_labels: [__meta_kubernetes_pod_container_port_name]
-              action: keep
-              regex: admin
-
-        - job_name: pipecd-ops
-          scrape_interval: 1m
-          kubernetes_sd_configs:
-            - role: endpoints
-          relabel_configs:
-            - source_labels: [__meta_kubernetes_service_label_app_kubernetes_io_name]
-              action: keep
-              regex: pipecd
-            - source_labels: [__meta_kubernetes_service_label_app_kubernetes_io_component]
-              action: keep
-              regex: ops
-            - source_labels: [__meta_kubernetes_pod_container_port_name]
-              action: keep
-              regex: admin
-
-        # Scrape config for API servers.
-        - job_name: kubernetes-apiservers
-          kubernetes_sd_configs:
-            - role: endpoints
-          scheme: https
-          tls_config:
-            ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-            insecure_skip_verify: true
-          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-          relabel_configs:
-            - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
-              action: keep
-              regex: default;kubernetes;https
-
-        - job_name: kubernetes-nodes
-          kubernetes_sd_configs:
-            - role: node
-          scheme: https
-          tls_config:
-            ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-            insecure_skip_verify: true
-          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-          relabel_configs:
-            - action: labelmap
-              regex: __meta_kubernetes_node_label_(.+)
-            - target_label: __address__
-              replacement: kubernetes.default.svc:443
-            - source_labels: [__meta_kubernetes_node_name]
-              regex: (.+)
-              target_label: __metrics_path__
-              replacement: /api/v1/nodes/$1/proxy/metrics
-
-        # Container stats for PipeCD services
-        - job_name: kubernetes-nodes-cadvisor
-          kubernetes_sd_configs:
-            - role: node
-          scheme: https
-          tls_config:
-            ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-            insecure_skip_verify: true
-          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-          relabel_configs:
-            - action: labelmap
-              regex: __meta_kubernetes_node_label_(.+)
-            - target_label: __address__
-              replacement: kubernetes.default.svc:443
-            - source_labels: [__meta_kubernetes_node_name]
-              regex: (.+)
-              target_label: __metrics_path__
-              replacement: /api/v1/nodes/$1/proxy/metrics/cadvisor
-          metric_relabel_configs:
-            - source_labels: [pod]
-              target_label: service
-              regex: (.+)-[0-9a-zA-Z]+(-[0-9a-zA-Z]+)$
-              replacement: $1
-
-        # Cluster stats for PipeCD services
-        - job_name: kube-state-metrics
-          kubernetes_sd_configs:
-            - role: endpoints
-          relabel_configs:
-            - source_labels: [__meta_kubernetes_service_label_app_kubernetes_io_name]
-              action: keep
-              regex: kube-state-metrics
-            - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape]
-              action: keep
-              regex: true
-            - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scheme]
-              action: replace
-              target_label: __scheme__
-              regex: (https?)
-            - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_path]
-              action: replace
-              target_label: __metrics_path__
-              regex: (.+)
-            - source_labels: [__address__, __meta_kubernetes_service_annotation_prometheus_io_port]
-              action: replace
-              target_label: __address__
-              regex: ([^:]+)(?::\d+)?;(\d+)
-              replacement: $1:$2
-            - action: labelmap
-              regex: __meta_kubernetes_service_label_(.+)
-            - source_labels: [__meta_kubernetes_namespace]
-              action: replace
-              target_label: kubernetes_namespace
-            - source_labels: [__meta_kubernetes_service_name]
-              action: replace
-              target_label: kubernetes_name
-            - source_labels: [__meta_kubernetes_pod_node_name]
-              action: replace
-              target_label: kubernetes_node
-          metric_relabel_configs:
-            - source_labels: [pod]
-              target_label: service
-              regex: (.+)-[0-9a-zA-Z]+(-[0-9a-zA-Z]+)$
-              replacement: $1
-
-        - job_name: node-exporter
-          kubernetes_sd_configs:
-            - role: endpoints
-          relabel_configs:
-            - source_labels: [__meta_kubernetes_service_label_component]
-              action: keep
-              regex: node-exporter
-            - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape]
-              action: keep
-              regex: true
-            - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scheme]
-              action: replace
-              target_label: __scheme__
-              regex: (https?)
-            - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_path]
-              action: replace
-              target_label: __metrics_path__
-              regex: (.+)
-            - source_labels: [__address__, __meta_kubernetes_service_annotation_prometheus_io_port]
-              action: replace
-              target_label: __address__
-              regex: ([^:]+)(?::\d+)?;(\d+)
-              replacement: $1:$2
-            - action: labelmap
-              regex: __meta_kubernetes_service_label_(.+)
-            - source_labels: [__meta_kubernetes_namespace]
-              action: replace
-              target_label: kubernetes_namespace
-            - source_labels: [__meta_kubernetes_service_name]
-              action: replace
-              target_label: kubernetes_name
-            - source_labels: [__meta_kubernetes_pod_node_name]
-              action: replace
-              target_label: kubernetes_node
+    configMapOverrideName: prometheus-server
 
 # All directives inside this section will be directly sent to the grafana chart.
 # Head to the below link to see all available values.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR allows us to switch monitoring scope using `.Values.monitoring.clusterStats`.
To make Prometheus config possible to template, I moved it to configmap.yaml.

If `.Values.monitoring.clusterStats` true:
- Prometheus scrape cluster stats such as Nodes, Pods and Prometheus itself
- Grafana shows cluster dashboards

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
