### PR TITLE
Fix bug that all plan-preview commands that come after Piped has been running for 5 minutes will not be handled

### DIFF
--- a/pkg/app/piped/planpreview/handler.go
+++ b/pkg/app/piped/planpreview/handler.go
@@ -164,8 +164,8 @@ func (h *Handler) Run(ctx context.Context) error {
 		for {
 			select {
 			case cmd := <-cmdCh:
-				ctx, _ = context.WithTimeout(ctx, h.options.commandHandleTimeout)
-				h.handleCommand(ctx, cmd)
+				childCtx, _ := context.WithTimeout(ctx, h.options.commandHandleTimeout)
+				h.handleCommand(childCtx, cmd)
 
 			case <-ctx.Done():
 				return
@@ -284,6 +284,8 @@ func (h *Handler) handleCommand(ctx context.Context, cmd model.ReportableCommand
 
 	if err := cmd.Report(ctx, model.CommandStatus_COMMAND_SUCCEEDED, nil, output); err != nil {
 		logger.Error("failed to report command status", zap.Error(err))
+		return
 	}
+
 	logger.Info("successfully reported a success command")
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Because all workers will exit after the `commandHandleTimeout`.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Fix bug that all plan-preview commands that come after Piped has been running for 5 minutes are not handled
```
