### PR TITLE
Allow specifying key pair data used for secret management in piped config

### DIFF
--- a/docs/content/en/docs/operator-manual/piped/configuration-reference.md
+++ b/docs/content/en/docs/operator-manual/piped/configuration-reference.md
@@ -31,7 +31,8 @@ spec:
 | chartRepositories | [][ChartRepository](/docs/operator-manual/piped/configuration-reference/#chartrepository) | List of Helm chart repositories that should be added while starting up. | No |
 | cloudProviders | [][CloudProvider](/docs/operator-manual/piped/configuration-reference/#cloudprovider) | List of cloud providers can be used by this piped. | No |
 | analysisProviders | [][AnalysisProvider](/docs/operator-manual/piped/configuration-reference/#analysisprovider) | List of analysis providers can be used by this piped. | No |
-| eventWatcher | [EventWatcher](/docs/operator-manual/piped/configuration-reference/#eventwatcher) | Optional Event watcher settings | No |
+| eventWatcher | [EventWatcher](/docs/operator-manual/piped/configuration-reference/#eventwatcher) | Optional Event watcher settings. | No |
+| secretManagement | [SecretManagement](/docs/operator-manual/piped/configuration-reference/#secretmanagement) | The using secret management method. | No |
 | notifications | [Notifications](/docs/operator-manual/piped/configuration-reference/#notifications) | Sending notifications to Slack, Webhook... | No |
 
 ## Git
@@ -174,6 +175,30 @@ Must be one of the following structs:
 | commitMessage | string | The commit message used to push after replacing values. Default message is used if not given. | No |
 | includes | []string | The paths to EventWatcher files to be included. Patterns can be used like `foo/*.yaml`. | No |
 | excludes | []string | The paths to EventWatcher files to be excluded. Patterns can be used like `foo/*.yaml`. This is prioritized if both includes and this are given. | No |
+
+## SecretManagement
+
+| Field | Type | Description | Required |
+|-|-|-|-|
+| type | string | Which management method should be used. Default is `KEY_PAIR`. | Yes |
+| config | [SecretManagementConfig](/docs/operator-manual/piped/configuration-reference/#secretmanagementconfig) | Configration for using secret management method. | Yes |
+
+## SecretManagementConfig
+
+Must be one of the following structs:
+
+### SecretManagementKeyPair
+
+| Field | Type | Description | Required |
+|-|-|-|-|
+| privateKeyFile | string | Path to the private RSA key file. | Yes |
+| privateKeyData | string | Base64 encoded string of private RSA key. Either privateKeyFile or privateKeyData must be set. | No |
+| publicKeyFile | string | Path to the public RSA key file. | Yes |
+| publicKeyData | string | Base64 encoded string of public RSA key. Either publicKeyFile or publicKeyData must be set. | No |
+
+### SecretManagementGCPKMS
+
+> WIP
 
 ## Notifications
 

--- a/pkg/app/api/grpcapi/web_api.go
+++ b/pkg/app/api/grpcapi/web_api.go
@@ -942,7 +942,7 @@ func (a *WebAPI) GenerateApplicationSealedSecret(ctx context.Context, req *webse
 		if se.PublicKey == "" {
 			return nil, status.Error(codes.FailedPrecondition, "The piped does not contain a public key")
 		}
-		enc, err = crypto.NewHybridEncrypter(se.PublicKey)
+		enc, err = crypto.NewHybridEncrypter([]byte(se.PublicKey))
 		if err != nil {
 			a.logger.Error("failed to initialize the crypter", zap.Error(err))
 			return nil, status.Error(codes.FailedPrecondition, "Failed to initialize the encrypter")

--- a/pkg/config/piped.go
+++ b/pkg/config/piped.go
@@ -573,18 +573,48 @@ type SecretManagementKeyPair struct {
 	// Configurable fields for SEALING_KEY.
 	// The path to the private RSA key file.
 	PrivateKeyFile string `json:"privateKeyFile"`
+	// Base64 encoded string of private key.
+	PrivateKeyData string `json:"privateKeyData"`
 	// The path to the public RSA key file.
 	PublicKeyFile string `json:"publicKeyFile"`
+	// Base64 encoded string of public key.
+	PublicKeyData string `json:"publicKeyData"`
 }
 
 func (s *SecretManagementKeyPair) Validate() error {
-	if s.PrivateKeyFile == "" {
-		return fmt.Errorf("privateKeyFile must be set")
+	if s.PrivateKeyFile == "" && s.PrivateKeyData == "" {
+		return errors.New("either privateKeyFile or privateKeyData must be set")
 	}
-	if s.PublicKeyFile == "" {
-		return fmt.Errorf("publicKeyFile must be set")
+	if s.PrivateKeyFile != "" && s.PrivateKeyData != "" {
+		return errors.New("only privateKeyFile or privateKeyData can be set")
+	}
+	if s.PublicKeyFile == "" && s.PublicKeyData == "" {
+		return errors.New("either publicKeyFile or publicKeyData must be set")
+	}
+	if s.PublicKeyFile != "" && s.PublicKeyData != "" {
+		return errors.New("only publicKeyFile or publicKeyData can be set")
 	}
 	return nil
+}
+
+func (s *SecretManagementKeyPair) LoadPrivateKey() ([]byte, error) {
+	if s.PrivateKeyData != "" {
+		return base64.StdEncoding.DecodeString(s.PrivateKeyData)
+	}
+	if s.PrivateKeyFile != "" {
+		return os.ReadFile(s.PrivateKeyFile)
+	}
+	return nil, errors.New("either privateKeyFile or privateKeyData must be set")
+}
+
+func (s *SecretManagementKeyPair) LoadPublicKey() ([]byte, error) {
+	if s.PublicKeyData != "" {
+		return base64.StdEncoding.DecodeString(s.PublicKeyData)
+	}
+	if s.PublicKeyFile != "" {
+		return os.ReadFile(s.PublicKeyFile)
+	}
+	return nil, errors.New("either publicKeyFile or publicKeyData must be set")
 }
 
 type SecretManagementGCPKMS struct {

--- a/pkg/crypto/hybrid.go
+++ b/pkg/crypto/hybrid.go
@@ -15,6 +15,7 @@
 package crypto
 
 import (
+	"bytes"
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
@@ -33,8 +34,8 @@ type HybridEncrypter struct {
 	key *rsa.PublicKey
 }
 
-func NewHybridEncrypter(key string) (*HybridEncrypter, error) {
-	k, err := ParseRSAPublicKeyFromPem([]byte(key))
+func NewHybridEncrypter(key []byte) (*HybridEncrypter, error) {
+	k, err := ParseRSAPublicKeyFromPem(bytes.TrimSpace(key))
 	if err != nil {
 		return nil, err
 	}
@@ -91,13 +92,13 @@ type HybridDecrypter struct {
 	key *rsa.PrivateKey
 }
 
-func NewHybridDecrypter(keyFile string) (*HybridDecrypter, error) {
-	key, err := LoadRSAPrivateKey(keyFile)
+func NewHybridDecrypter(key []byte) (*HybridDecrypter, error) {
+	k, err := ParseRSAPrivateKeyFromPem(bytes.TrimSpace(key))
 	if err != nil {
 		return nil, err
 	}
 	return &HybridDecrypter{
-		key: key,
+		key: k,
 	}, nil
 }
 

--- a/pkg/crypto/hybrid.go
+++ b/pkg/crypto/hybrid.go
@@ -15,7 +15,6 @@
 package crypto
 
 import (
-	"bytes"
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
@@ -35,7 +34,7 @@ type HybridEncrypter struct {
 }
 
 func NewHybridEncrypter(key []byte) (*HybridEncrypter, error) {
-	k, err := ParseRSAPublicKeyFromPem(bytes.TrimSpace(key))
+	k, err := ParseRSAPublicKeyFromPem(key)
 	if err != nil {
 		return nil, err
 	}
@@ -93,7 +92,7 @@ type HybridDecrypter struct {
 }
 
 func NewHybridDecrypter(key []byte) (*HybridDecrypter, error) {
-	k, err := ParseRSAPrivateKeyFromPem(bytes.TrimSpace(key))
+	k, err := ParseRSAPrivateKeyFromPem(key)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/crypto/hybrid_test.go
+++ b/pkg/crypto/hybrid_test.go
@@ -15,7 +15,7 @@
 package crypto
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -23,10 +23,10 @@ import (
 )
 
 func TestHybridEncryptDecrypt(t *testing.T) {
-	data, err := ioutil.ReadFile("testdata/public-rsa-pem")
+	data, err := os.ReadFile("testdata/public-rsa-pem")
 	require.NoError(t, err)
 
-	encrypter, err := NewHybridEncrypter(string(data))
+	encrypter, err := NewHybridEncrypter(data)
 	require.NoError(t, err)
 
 	text := `
@@ -45,7 +45,10 @@ data:
 	require.NoError(t, err)
 	assert.True(t, len(encryptedText) > 0)
 
-	decrypter, err := NewHybridDecrypter("testdata/private-rsa-pem")
+	data, err = os.ReadFile("testdata/private-rsa-pem")
+	require.NoError(t, err)
+
+	decrypter, err := NewHybridDecrypter(data)
 	require.NoError(t, err)
 
 	decryptedText, err := decrypter.Decrypt(encryptedText)

--- a/pkg/crypto/key.go
+++ b/pkg/crypto/key.go
@@ -15,11 +15,12 @@
 package crypto
 
 import (
+	"bytes"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
-	"fmt"
+	"errors"
 )
 
 const DefauleRSAKeySize = 2048
@@ -62,6 +63,7 @@ func GenerateRSAPems(size int) (private, public []byte, err error) {
 
 func ParseRSAPublicKeyFromPem(data []byte) (*rsa.PublicKey, error) {
 	var err error
+	data = bytes.TrimSpace(data)
 	block, _ := pem.Decode(data)
 	bytes := block.Bytes
 
@@ -80,11 +82,12 @@ func ParseRSAPublicKeyFromPem(data []byte) (*rsa.PublicKey, error) {
 	if k, ok := key.(*rsa.PublicKey); ok {
 		return k, nil
 	}
-	return nil, fmt.Errorf("invalid key format, it must be a public RSA key")
+	return nil, errors.New("invalid key format, it must be a public RSA key")
 }
 
 func ParseRSAPrivateKeyFromPem(data []byte) (*rsa.PrivateKey, error) {
 	var err error
+	data = bytes.TrimSpace(data)
 	block, _ := pem.Decode(data)
 	bytes := block.Bytes
 
@@ -103,5 +106,5 @@ func ParseRSAPrivateKeyFromPem(data []byte) (*rsa.PrivateKey, error) {
 	if k, ok := key.(*rsa.PrivateKey); ok {
 		return k, nil
 	}
-	return nil, fmt.Errorf("invalid key format, it must be a private RSA key")
+	return nil, errors.New("invalid key format, it must be a private RSA key")
 }

--- a/pkg/crypto/key.go
+++ b/pkg/crypto/key.go
@@ -15,13 +15,11 @@
 package crypto
 
 import (
-	"bytes"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 )
 
 const DefauleRSAKeySize = 2048
@@ -62,15 +60,6 @@ func GenerateRSAPems(size int) (private, public []byte, err error) {
 	return
 }
 
-func LoadRSAPublicKey(path string) (*rsa.PublicKey, error) {
-	data, err := ioutil.ReadFile(path)
-	if err != nil {
-		return nil, err
-	}
-	data = bytes.TrimSpace(data)
-	return ParseRSAPublicKeyFromPem(data)
-}
-
 func ParseRSAPublicKeyFromPem(data []byte) (*rsa.PublicKey, error) {
 	var err error
 	block, _ := pem.Decode(data)
@@ -92,15 +81,6 @@ func ParseRSAPublicKeyFromPem(data []byte) (*rsa.PublicKey, error) {
 		return k, nil
 	}
 	return nil, fmt.Errorf("invalid key format, it must be a public RSA key")
-}
-
-func LoadRSAPrivateKey(path string) (*rsa.PrivateKey, error) {
-	data, err := ioutil.ReadFile(path)
-	if err != nil {
-		return nil, err
-	}
-	data = bytes.TrimSpace(data)
-	return ParseRSAPrivateKeyFromPem(data)
 }
 
 func ParseRSAPrivateKeyFromPem(data []byte) (*rsa.PrivateKey, error) {

--- a/pkg/crypto/key_test.go
+++ b/pkg/crypto/key_test.go
@@ -16,6 +16,7 @@ package crypto
 
 import (
 	"bytes"
+	"os"
 	"strings"
 	"testing"
 
@@ -46,12 +47,18 @@ func TestGenerateRSAPems(t *testing.T) {
 	assert.NotNil(t, publicKey)
 }
 
-func TestLoadRSAKey(t *testing.T) {
-	privateKey, err := LoadRSAPrivateKey("testdata/private-rsa-pem")
+func TestParseRSAKey(t *testing.T) {
+	data, err := os.ReadFile("testdata/private-rsa-pem")
+	require.NoError(t, err)
+
+	privateKey, err := ParseRSAPrivateKeyFromPem(data)
 	require.NoError(t, err)
 	assert.NotNil(t, privateKey)
 
-	publicKey, err := LoadRSAPublicKey("testdata/public-rsa-pem")
+	data, err = os.ReadFile("testdata/public-rsa-pem")
+	require.NoError(t, err)
+
+	publicKey, err := ParseRSAPublicKeyFromPem(data)
 	require.NoError(t, err)
 	assert.NotNil(t, publicKey)
 }

--- a/pkg/crypto/rsa.go
+++ b/pkg/crypto/rsa.go
@@ -15,7 +15,6 @@
 package crypto
 
 import (
-	"bytes"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/sha512"
@@ -27,7 +26,7 @@ type RSAEncrypter struct {
 }
 
 func NewRSAEncrypter(key []byte) (*RSAEncrypter, error) {
-	k, err := ParseRSAPublicKeyFromPem(bytes.TrimSpace(key))
+	k, err := ParseRSAPublicKeyFromPem(key)
 	if err != nil {
 		return nil, err
 	}
@@ -56,7 +55,7 @@ type RSADecrypter struct {
 }
 
 func NewRSADecrypter(key []byte) (*RSADecrypter, error) {
-	k, err := ParseRSAPrivateKeyFromPem(bytes.TrimSpace(key))
+	k, err := ParseRSAPrivateKeyFromPem(key)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/crypto/rsa.go
+++ b/pkg/crypto/rsa.go
@@ -15,6 +15,7 @@
 package crypto
 
 import (
+	"bytes"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/sha512"
@@ -25,8 +26,8 @@ type RSAEncrypter struct {
 	key *rsa.PublicKey
 }
 
-func NewRSAEncrypter(key string) (*RSAEncrypter, error) {
-	k, err := ParseRSAPublicKeyFromPem([]byte(key))
+func NewRSAEncrypter(key []byte) (*RSAEncrypter, error) {
+	k, err := ParseRSAPublicKeyFromPem(bytes.TrimSpace(key))
 	if err != nil {
 		return nil, err
 	}
@@ -54,13 +55,13 @@ type RSADecrypter struct {
 	key *rsa.PrivateKey
 }
 
-func NewRSADecrypter(keyFile string) (*RSADecrypter, error) {
-	key, err := LoadRSAPrivateKey(keyFile)
+func NewRSADecrypter(key []byte) (*RSADecrypter, error) {
+	k, err := ParseRSAPrivateKeyFromPem(bytes.TrimSpace(key))
 	if err != nil {
 		return nil, err
 	}
 	return &RSADecrypter{
-		key: key,
+		key: k,
 	}, nil
 }
 

--- a/pkg/crypto/rsa_test.go
+++ b/pkg/crypto/rsa_test.go
@@ -15,8 +15,7 @@
 package crypto
 
 import (
-	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -24,10 +23,10 @@ import (
 )
 
 func TestRSAEncryptDecrypt(t *testing.T) {
-	data, err := ioutil.ReadFile("testdata/public-rsa-pem")
+	data, err := os.ReadFile("testdata/public-rsa-pem")
 	require.NoError(t, err)
 
-	encrypter, err := NewRSAEncrypter(string(data))
+	encrypter, err := NewRSAEncrypter(data)
 	require.NoError(t, err)
 
 	text := "short-text"
@@ -36,8 +35,10 @@ func TestRSAEncryptDecrypt(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, len(encryptedText) > 0)
 
-	fmt.Println(encryptedText)
-	decrypter, err := NewRSADecrypter("testdata/private-rsa-pem")
+	data, err = os.ReadFile("testdata/private-rsa-pem")
+	require.NoError(t, err)
+
+	decrypter, err := NewRSADecrypter(data)
 	require.NoError(t, err)
 
 	decryptedText, err := decrypter.Decrypt(encryptedText)


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Allow specifying key pair data used for secret management in piped config
```
