### PR TITLE
Change to manage Grafana datasources as a ConfigMap

### DIFF
--- a/manifests/pipecd/templates/configmap.yaml
+++ b/manifests/pipecd/templates/configmap.yaml
@@ -50,6 +50,29 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
+{{- range .Values.grafana.extraConfigmapMounts }}
+{{- if eq .name "datasources" }}
+  name: {{ .configMap }}
+{{- end }}
+{{- end }}
+  labels:
+    {{- include "pipecd.labels" . | nindent 4 }}
+    grafana_datasources: "1"
+data:
+  datasources.yaml: |-
+    apiVersion: 1
+    datasources:
+      - name: Prometheus
+        type: prometheus
+        url: http://{{ include "pipecd.fullname" . }}-prometheus-server
+        access: proxy
+        version: 1
+        isDefault: true
+---
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
   name: {{ include "pipecd.fullname" . }}-{{ .Values.prometheus.server.configMapOverrideName }}
   labels:
     {{- include "pipecd.labels" . | nindent 4 }}

--- a/manifests/pipecd/values.yaml
+++ b/manifests/pipecd/values.yaml
@@ -150,9 +150,6 @@ prometheus:
       # A list of notification receivers.
       receivers: []
   server:
-    # Must be fixed so that Grafana can find out statically.
-    # FIXME: Make Prometheus service name changeable as well as Grafana datasource URL
-    fullnameOverride: pipecd-prometheus-server
     configMapOverrideName: prometheus-server
 
 # All directives inside this section will be directly sent to the grafana chart.
@@ -160,6 +157,24 @@ prometheus:
 # https://github.com/grafana/helm-charts/tree/main/charts/grafana
 grafana:
   adminPassword: admin
+  sidecar:
+    datasources:
+      enabled: true
+      # Label that the configmaps with datasources are marked with
+      label: grafana_datasource
+    dashboards:
+      enabled: true
+      # Label that the configmaps with dashboards are marked with
+      label: grafana_dashboard
+      provider:
+        foldersFromFilesStructure: true
+  extraConfigmapMounts:
+    - name: datasources
+      configMap: pipecd-grafana-datasources
+      mountPath: "/etc/grafana/provisioning/datasources/datasources.yaml"
+      subPath: datasources.yaml
+      readOnly: true
+  # TODO: Manage Grafana dashboard providers as a ConfigMap
   dashboardProviders:
     dashboardproviders.yaml:
       apiVersion: 1
@@ -182,21 +197,3 @@ grafana:
           allowUiUpdates: true
           options:
             path: /tmp/dashboards/control-plane
-  sidecar:
-    datasources:
-      enabled: true
-    dashboards:
-      enabled: true
-      # Label that the configmaps with dashboards are marked with
-      label: grafana_dashboard
-      provider:
-        foldersFromFilesStructure: true
-  datasources:
-    datasources.yaml:
-      apiVersion: 1
-      datasources:
-        - name: Prometheus
-          type: prometheus
-          url: http://pipecd-prometheus-server
-          access: proxy
-          version: 1


### PR DESCRIPTION
**What this PR does / why we need it**:
We used to fix the Prometheus service name as `pipecd-prometheus-server` to discover it from Grafana statically. This PR resolves that problem by changing to manage the datasources config as our ConfigMap, which can template with the release name.

On the other hand, still we have to fix that ConfigMap name. It is `pipecd-grafana-datasources` by default. If you want to change the name, you can change it by setting `.Values.grafana.extraConfigmapMounts[0].configMap`.

**Which issue(s) this PR fixes**:

Fixes https://github.com/pipe-cd/pipe/issues/2226

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
