### PR TITLE
Fix TTL for stat metrics is reset on stat commit

### DIFF
--- a/pkg/cache/rediscache/hashcache.go
+++ b/pkg/cache/rediscache/hashcache.go
@@ -64,6 +64,11 @@ func (r *RedisHashCache) Get(k string) (interface{}, error) {
 	return reply, nil
 }
 
+// Put implementation for Putter interface.
+// For TTLHashCache, Put acts mostly as normal Cache except it will
+// check if the TTL for hashkey (not the key k), in case the TTL for
+// hashkey is not yet existed or unset, EXPIRE will be called and set
+// TTL time for the whole hashkey.
 func (r *RedisHashCache) Put(k string, v interface{}) error {
 	conn := r.redis.Get()
 	defer conn.Close()


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, while storing new committed stat from pipeds, Redis `EXPIRE` is always called that reset the TTL set for the stat metrics hash key, lead to piped stat metrics keep available even after piped has stopped.

```
127.0.0.1:6379> TTL HASHKEY:PIPED:STATS
(integer) 266
127.0.0.1:6379> TTL HASHKEY:PIPED:STATS
(integer) 300                    /// TTL is reset here 👀
127.0.0.1:6379> TTL HASHKEY:PIPED:STATS
(integer) 299
```

**Which issue(s) this PR fixes**:

Fixes #2234 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
