### PR TITLE
Update version number for actions-plan-preview

### DIFF
--- a/dockers/actions-plan-preview/DOCKER_BUILD
+++ b/dockers/actions-plan-preview/DOCKER_BUILD
@@ -1,2 +1,2 @@
-version: 1.0.0
+version: 1.0.1
 registry: gcr.io/pipecd/actions-plan-preview


### PR DESCRIPTION
**What this PR does / why we need it**:

To be synced with the incoming version number of https://github.com/pipe-cd/actions-plan-preview

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
