### PR TITLE
Add ability to load Piped config from GCP Secret Manager

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,6 +47,7 @@ require (
 	golang.org/x/sync v0.0.0-20201207232520-09787c993a3a
 	golang.org/x/tools v0.0.0-20200916195026-c9a70fc28ce3 // indirect
 	google.golang.org/api v0.31.0
+	google.golang.org/genproto v0.0.0-20200831141814-d751682dd103
 	google.golang.org/grpc v1.31.1
 	google.golang.org/protobuf v1.25.0
 	gopkg.in/yaml.v2 v2.3.0 // indirect

--- a/pkg/app/piped/cmd/piped/BUILD.bazel
+++ b/pkg/app/piped/cmd/piped/BUILD.bazel
@@ -41,6 +41,8 @@ go_library(
         "//pkg/version:go_default_library",
         "@com_github_prometheus_client_golang//prometheus:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",
+        "@com_google_cloud_go//secretmanager/apiv1:go_default_library",
+        "@go_googleapis//google/cloud/secretmanager/v1:secretmanager_go_proto",
         "@org_golang_google_grpc//credentials:go_default_library",
         "@org_golang_x_sync//errgroup:go_default_library",
         "@org_uber_go_zap//:go_default_library",


### PR DESCRIPTION
**What this PR does / why we need it**:

In some environments like Google Cloud VM, there is no way to mount the config file from Secret Manager.
This will enable the ability to run Piped on a single GCP VM.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Add ability to load Piped config from GCP Secret Manager
```
