### PR TITLE
Add an interceptor to track stats about gRPC calls

### DIFF
--- a/cmd/pipecd/server.go
+++ b/cmd/pipecd/server.go
@@ -218,6 +218,9 @@ func (s *server) run(ctx context.Context, t cli.Telemetry) error {
 		if s.enableGRPCReflection {
 			opts = append(opts, rpc.WithGRPCReflection())
 		}
+		if t.Flags.Metrics {
+			opts = append(opts, rpc.WithPrometheusUnaryInterceptor())
+		}
 
 		server := rpc.NewServer(service, opts...)
 		group.Go(func() error {
@@ -245,6 +248,9 @@ func (s *server) run(ctx context.Context, t cli.Telemetry) error {
 		)
 		if s.tls {
 			opts = append(opts, rpc.WithTLS(s.certFile, s.keyFile))
+		}
+		if t.Flags.Metrics {
+			opts = append(opts, rpc.WithPrometheusUnaryInterceptor())
 		}
 
 		server := rpc.NewServer(service, opts...)
@@ -280,6 +286,9 @@ func (s *server) run(ctx context.Context, t cli.Telemetry) error {
 		}
 		if s.enableGRPCReflection {
 			opts = append(opts, rpc.WithGRPCReflection())
+		}
+		if t.Flags.Metrics {
+			opts = append(opts, rpc.WithPrometheusUnaryInterceptor())
 		}
 
 		server := rpc.NewServer(service, opts...)

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/google/go-github/v29 v29.0.3
 	github.com/google/uuid v1.2.0
 	github.com/googleapis/gnostic v0.2.2 // indirect
+	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/hashicorp/golang-lru v0.5.3
 	github.com/minio/minio-go/v7 v7.0.5
 	github.com/prometheus/client_golang v1.6.0

--- a/pkg/rpc/BUILD.bazel
+++ b/pkg/rpc/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
     deps = [
         "//pkg/jwt:go_default_library",
         "//pkg/rpc/rpcauth:go_default_library",
+        "@com_github_grpc_ecosystem_go_grpc_prometheus//:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//codes:go_default_library",
         "@org_golang_google_grpc//credentials:go_default_library",

--- a/pkg/rpc/server.go
+++ b/pkg/rpc/server.go
@@ -20,7 +20,7 @@ import (
 	"net"
 	"time"
 
-	"github.com/grpc-ecosystem/go-grpc-prometheus"
+	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -216,6 +216,9 @@ func (s *Server) init() error {
 	}
 	if s.requestValidationUnaryInterceptor != nil {
 		unaryInterceptors = append(unaryInterceptors, s.requestValidationUnaryInterceptor)
+	}
+	if s.prometheusUnaryInterceptor != nil {
+		unaryInterceptors = append(unaryInterceptors, s.prometheusUnaryInterceptor)
 	}
 	if len(unaryInterceptors) > 0 {
 		c := ChainUnaryServerInterceptors(unaryInterceptors...)


### PR DESCRIPTION
**What this PR does / why we need it**:
In order to track error rates and req/res sizes for each gRPC method, we need to expose metrics labeled with code and method. With this PR, we will be able to expose a couple of counter type metrics like:

```
# HELP grpc_server_handled_total Total number of RPCs completed on the server, regardless of success or failure.
# TYPE grpc_server_handled_total counter
grpc_server_handled_total{grpc_code="Internal",grpc_method="AddApplication",grpc_service="pipe.api.service.apiservice.APIService",grpc_type="unary"} 0

# HELP grpc_server_msg_received_total Total number of RPC stream messages received on the server.
# TYPE grpc_server_msg_received_total counter
grpc_server_msg_received_total{grpc_method="AddApplication",grpc_service="pipe.api.service.apiservice.APIService",grpc_type="unary"} 0

# HELP grpc_server_msg_sent_total Total number of gRPC stream messages sent by the server.
# TYPE grpc_server_msg_sent_total counter
grpc_server_msg_sent_total{grpc_method="AddApplication",grpc_service="pipe.api.service.apiservice.APIService",grpc_type="unary"} 0

# HELP grpc_server_started_total Total number of RPCs started on the server.
# TYPE grpc_server_started_total counter
grpc_server_started_total{grpc_method="AddApplication",grpc_service="pipe.api.service.apiservice.APIService",grpc_type="unary"} 0
```

Seems like [go-grpc-prometheus](https://github.com/grpc-ecosystem/go-grpc-prometheus) is in the middle of moving to [go-grpc-middleware v2](https://github.com/grpc-ecosystem/go-grpc-middleware/tree/v2) which is still under development. We may have to replace with it after it becomes stable.



**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
