### PR TITLE
Update k8s-app-canary-with-pod-selector docs

### DIFF
--- a/docs/content/en/docs/user-guide/examples/k8s-app-canary-with-pod-selector.md
+++ b/docs/content/en/docs/user-guide/examples/k8s-app-canary-with-pod-selector.md
@@ -45,12 +45,12 @@ spec:
   selector:
     matchLabels:
       app: helloworld
-      pipecd.dev/variant: primary    # This is required.
+      pipecd.dev/variant: primary
   template:
     metadata:
       labels:
         app: helloworld
-        pipecd.dev/variant: primary  # This is required.
+        pipecd.dev/variant: primary
     spec:
       containers:
       - name: helloworld


### PR DESCRIPTION
**What this PR does / why we need it**:

I think the `pipecd.dev/variant: primary` label is unnecessary if `K8S_TRAFFIC_ROUTING` is not present in the canary step. 

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
