### PR TITLE
Add relabel configs to identify gRPC service name

### DIFF
--- a/manifests/pipecd/templates/configmap.yaml
+++ b/manifests/pipecd/templates/configmap.yaml
@@ -148,6 +148,10 @@ data:
             target_label: __name__
             regex: envoy_cluster_grpc_(.+)_(.+)_(.+)_(.+)_upstream_rq_time_count$
             replacement: pipecd_gateway_requests_duration_count
+          - source_labels: [envoy_cluster_name]
+            target_label: pipecd_grpc_service
+            regex: grpc-(.+)-service
+            replacement: $1
 
       - job_name: pipecd-server
         scrape_interval: 1m
@@ -163,6 +167,11 @@ data:
           - source_labels: [__meta_kubernetes_pod_container_port_name]
             action: keep
             regex: admin
+        metric_relabel_configs:
+          - source_labels: [grpc_service]
+            target_label: pipecd_grpc_service
+            regex: pipe.api.service.(.+)service.(.+)
+            replacement: $1
 
       - job_name: pipecd-ops
         scrape_interval: 1m

--- a/manifests/pipecd/templates/envoy-configmap.yaml
+++ b/manifests/pipecd/templates/envoy-configmap.yaml
@@ -65,17 +65,17 @@ data:
                         prefix: /pipe.api.service.pipedservice.PipedService/
                         grpc:
                       route:
-                        cluster: server-piped-api
+                        cluster: grpc-piped-service
                     - match:
                         prefix: /pipe.api.service.webservice.WebService/
                         grpc:
                       route:
-                        cluster: server-web-api
+                        cluster: grpc-web-service
                     - match:
                         prefix: /pipe.api.service.apiservice.APIService/
                         grpc:
                       route:
-                        cluster: server-api
+                        cluster: grpc-api-service
                     - match:
                         prefix: /
                       route:
@@ -94,13 +94,13 @@ data:
                 alpn_protocols: h2
 {{- end }}
       clusters:
-      - name: server-piped-api
+      - name: grpc-piped-service
         http2_protocol_options: {}
         connect_timeout: 0.25s
         type: STRICT_DNS
         lb_policy: ROUND_ROBIN
         load_assignment:
-          cluster_name: server-piped-api
+          cluster_name: grpc-piped-service
           endpoints:
           - lb_endpoints:
             - endpoint:
@@ -110,13 +110,13 @@ data:
                     port_value: 9080
         track_cluster_stats:
           request_response_sizes: true
-      - name: server-web-api
+      - name: grpc-web-service
         http2_protocol_options: {}
         connect_timeout: 0.25s
         type: STRICT_DNS
         lb_policy: ROUND_ROBIN
         load_assignment:
-          cluster_name: server-web-api
+          cluster_name: grpc-web-service
           endpoints:
           - lb_endpoints:
             - endpoint:
@@ -126,13 +126,13 @@ data:
                     port_value: 9081
         track_cluster_stats:
           request_response_sizes: true
-      - name: server-api
+      - name: grpc-api-service
         http2_protocol_options: {}
         connect_timeout: 0.25s
         type: STRICT_DNS
         lb_policy: ROUND_ROBIN
         load_assignment:
-          cluster_name: server-api
+          cluster_name: grpc-api-service
           endpoints:
           - lb_endpoints:
             - endpoint:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the Prometheus relabel configs to extract gRPC service names to be used for Grafana variables (candidates are `piped`, `web` and `api`).

![image](https://user-images.githubusercontent.com/19730728/125599737-5f10a0be-b3fa-47c1-9940-3cf7e26008fc.png)

It also changes the Envoy cluster names in order to easily relabel using regex. Tell me a better name if any (actually whatever is fine as long as it's according to some kind of pattern)


**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
