### PR TITLE
Use diff command to render K8s manifests diff for plan-preview

### DIFF
--- a/pkg/app/piped/cloudprovider/kubernetes/diff.go
+++ b/pkg/app/piped/cloudprovider/kubernetes/diff.go
@@ -180,9 +180,8 @@ func diffByCommand(old, new Manifest) ([]byte, error) {
 	}
 
 	// Remote two-line header from output.
-	endLineMark := []byte("\n")
-	data = bytes.TrimPrefix(data, endLineMark)
-	rows := bytes.SplitN(data, endLineMark, 3)
+	data = bytes.TrimSpace(data)
+	rows := bytes.SplitN(data, []byte("\n"), 3)
 	if len(rows) == 3 {
 		return rows[2], nil
 	}

--- a/pkg/app/piped/cloudprovider/kubernetes/diff_test.go
+++ b/pkg/app/piped/cloudprovider/kubernetes/diff_test.go
@@ -153,8 +153,7 @@ func TestDiffByCommand(t *testing.T) {
 -        - yy
          - zz
          image: gcr.io/pipecd/second:v1.0.0
-         name: second
-`,
+         name: second`,
 		},
 	}
 

--- a/pkg/app/piped/cloudprovider/kubernetes/diff_test.go
+++ b/pkg/app/piped/cloudprovider/kubernetes/diff_test.go
@@ -117,17 +117,28 @@ func TestGroupManifests(t *testing.T) {
 
 func TestDiffByCommand(t *testing.T) {
 	testcases := []struct {
-		name      string
-		manifests string
-		expected  string
+		name        string
+		command     string
+		manifests   string
+		expected    string
+		expectedErr bool
 	}{
 		{
+			name:        "no command",
+			command:     "non-existent-diff",
+			manifests:   "testdata/diff_by_command_no_change.yaml",
+			expected:    "",
+			expectedErr: true,
+		},
+		{
 			name:      "no diff",
+			command:   diffCommand,
 			manifests: "testdata/diff_by_command_no_change.yaml",
 			expected:  "",
 		},
 		{
 			name:      "has diff",
+			command:   diffCommand,
 			manifests: "testdata/diff_by_command.yaml",
 			expected: `@@ -6,7 +6,7 @@
      pipecd.dev/managed-by: piped
@@ -163,8 +174,12 @@ func TestDiffByCommand(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, 2, len(manifests))
 
-			got, err := diffByCommand(manifests[0], manifests[1])
-			require.NoError(t, err)
+			got, err := diffByCommand(tc.command, manifests[0], manifests[1])
+			if tc.expectedErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
 			assert.Equal(t, tc.expected, string(got))
 		})
 	}

--- a/pkg/app/piped/cloudprovider/kubernetes/testdata/diff_by_command.yaml
+++ b/pkg/app/piped/cloudprovider/kubernetes/testdata/diff_by_command.yaml
@@ -1,0 +1,69 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: simple
+  labels:
+    app: simple
+    pipecd.dev/managed-by: piped
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: simple
+  template:
+    metadata:
+      labels:
+        app: simple
+    spec:
+      containers:
+      - name: first
+        image: gcr.io/pipecd/first:v1.0.0
+        args:
+          - a
+          - b
+          - c
+        ports:
+        - containerPort: 9085
+      - name: second
+        image: gcr.io/pipecd/second:v1.0.0
+        args:
+          - xx
+          - yy
+          - zz
+        ports:
+        - containerPort: 9085
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: simple
+  labels:
+    app: simple
+    pipecd.dev/managed-by: piped
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: simple
+  template:
+    metadata:
+      labels:
+        app: simple
+    spec:
+      containers:
+      - name: first
+        image: gcr.io/pipecd/first:v1.0.0
+        args:
+          - a
+          - d
+          - b
+          - c
+        ports:
+        - containerPort: 9085
+      - name: second
+        image: gcr.io/pipecd/second:v1.0.0
+        args:
+          - xx
+          - zz
+        ports:
+        - containerPort: 9085

--- a/pkg/app/piped/cloudprovider/kubernetes/testdata/diff_by_command_no_change.yaml
+++ b/pkg/app/piped/cloudprovider/kubernetes/testdata/diff_by_command_no_change.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: simple
+  labels:
+    app: simple
+    pipecd.dev/managed-by: piped
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: simple
+  template:
+    metadata:
+      labels:
+        app: simple
+    spec:
+      containers:
+      - name: helloworld
+        image: gcr.io/pipecd/helloworld:v1.0.0
+        args:
+          - hi
+          - hello
+        ports:
+        - containerPort: 9085
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: simple
+  labels:
+    app: simple
+    pipecd.dev/managed-by: piped
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: simple
+  template:
+    metadata:
+      labels:
+        app: simple
+    spec:
+      containers:
+      - name: helloworld
+        image: gcr.io/pipecd/helloworld:v1.0.0
+        args:
+          - hi
+          - hello
+        ports:
+        - containerPort: 9085

--- a/pkg/app/piped/driftdetector/kubernetes/detector.go
+++ b/pkg/app/piped/driftdetector/kubernetes/detector.go
@@ -369,9 +369,9 @@ func makeSyncState(r *provider.DiffListResult, commit string) model.ApplicationS
 		MaskSecret:          true,
 		MaskConfigMap:       true,
 		MaxChangedManifests: 3,
-		// Currrently, we do not use use diff command to render the result
-		// because Kubernetes is adding a large number of default values into the running manifest
-		// that causes a wrong diff text.
+		// Currently, we do not use the diff command to render the result
+		// because Kubernetes adds a large number of default values to the
+		// running manifest that causes a wrong diff text.
 		UseDiffCommand: false,
 	})
 	b.WriteString(details)

--- a/pkg/app/piped/driftdetector/kubernetes/detector.go
+++ b/pkg/app/piped/driftdetector/kubernetes/detector.go
@@ -364,7 +364,17 @@ func makeSyncState(r *provider.DiffListResult, commit string) model.ApplicationS
 	var b strings.Builder
 	b.WriteString(fmt.Sprintf("Diff between the defined state in Git at commit %s and actual state in cluster:\n\n", commit))
 	b.WriteString("--- Expected\n+++ Actual\n\n")
-	b.WriteString(r.DiffString())
+
+	details := r.Render(provider.DiffRenderOptions{
+		MaskSecret:          true,
+		MaskConfigMap:       true,
+		MaxChangedManifests: 3,
+		// Currrently, we do not use use diff command to render the result
+		// because Kubernetes is adding a large number of default values into the running manifest
+		// that causes a wrong diff text.
+		UseDiffCommand: false,
+	})
+	b.WriteString(details)
 
 	return model.ApplicationSyncState{
 		Status:      model.ApplicationSyncStatus_OUT_OF_SYNC,

--- a/pkg/app/piped/planpreview/kubernetesdiff.go
+++ b/pkg/app/piped/planpreview/kubernetesdiff.go
@@ -96,7 +96,12 @@ func (b *builder) kubernetesDiff(
 	}
 
 	summary := fmt.Sprintf("%d added manifests, %d changed manifests, %d deleted manifests", len(result.Adds), len(result.Changes), len(result.Deletes))
-	fmt.Fprintf(buf, "--- Last Deploy\n+++ Head Commit\n\n%s\n", result.DiffString())
+	details := result.Render(provider.DiffRenderOptions{
+		MaskSecret:     true,
+		MaskConfigMap:  true,
+		UseDiffCommand: true,
+	})
+	fmt.Fprintf(buf, "--- Last Deploy\n+++ Head Commit\n\n%s\n", details)
 
 	return summary, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

For more readable diff between 2 Kubernetes manifests.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Use diff command to render K8s manifests diff for plan-preview
```
