### PR TITLE
Fix EventWatcher so that it doesn't delete comments

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/envoyproxy/protoc-gen-validate v0.1.0
 	github.com/fsouza/fake-gcs-server v1.21.0
 	github.com/go-sql-driver/mysql v1.5.0
-	github.com/goccy/go-yaml v1.8.8
+	github.com/goccy/go-yaml v1.9.0
 	github.com/golang/mock v1.4.4
 	github.com/golang/protobuf v1.4.2
 	github.com/gomodule/redigo v2.0.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -239,8 +239,8 @@ github.com/go-sql-driver/mysql v1.5.0 h1:ozyZYNQW3x3HtqT1jira07DN2PArx2v7/mN66gG
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0 h1:5SgMzNM5HxrEjV0ww2lTmX6E2Izsfxas4+YHWRs3Lsk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
-github.com/goccy/go-yaml v1.8.8 h1:MGfRB1GeSn/hWXYWS2Pt67iC2GJNnebdIro01ddyucA=
-github.com/goccy/go-yaml v1.8.8/go.mod h1:U/jl18uSupI5rdI2jmuCswEA2htH9eXfferR3KfscvA=
+github.com/goccy/go-yaml v1.9.0 h1:EW/739A64xN38nuzq5MbV1yH0e5N2auppHOJGHTSVL8=
+github.com/goccy/go-yaml v1.9.0/go.mod h1:U/jl18uSupI5rdI2jmuCswEA2htH9eXfferR3KfscvA=
 github.com/gofrs/uuid v3.2.0+incompatible h1:y12jRkkFxsd7GpqdSZ+/KCs/fJbqpEXSGd4+jfEaewE=
 github.com/gofrs/uuid v3.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=

--- a/pkg/yamlprocessor/yamlprocessor.go
+++ b/pkg/yamlprocessor/yamlprocessor.go
@@ -71,7 +71,7 @@ func ReplaceValue(yml []byte, path string, value string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	file, err := parser.ParseBytes(yml, 0)
+	file, err := parser.ParseBytes(yml, parser.ParseComments)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/yamlprocessor/yamlprocessor_test.go
+++ b/pkg/yamlprocessor/yamlprocessor_test.go
@@ -176,6 +176,16 @@ func TestReplaceValue(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "valid value with comment given",
+			yml: `# comments
+foo: bar`,
+			path:  "$.foo",
+			value: "new-text",
+			want: []byte(`# comments
+foo: new-text`),
+			wantErr: false,
+		},
+		{
 			name: "array in block style",
 			yml: `foo:
   - bar

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -535,8 +535,8 @@ def go_repositories():
     go_repository(
         name = "com_github_goccy_go_yaml",
         importpath = "github.com/goccy/go-yaml",
-        sum = "h1:MGfRB1GeSn/hWXYWS2Pt67iC2GJNnebdIro01ddyucA=",
-        version = "v1.8.8",
+        sum = "h1:EW/739A64xN38nuzq5MbV1yH0e5N2auppHOJGHTSVL8=",
+        version = "v1.9.0",
     )
     go_repository(
         name = "com_github_gofrs_uuid",


### PR DESCRIPTION
**What this PR does / why we need it**:
goccy/go-yaml [v1.9.0](https://github.com/goccy/go-yaml/releases/tag/v1.9.0) with comment encoding support got released. 

I checked it never delete comments.

```diff
❯ g diff 4ff48b4 3e35e53
diff --git a/tmp-for-event-watcher/foo-local.yaml b/tmp-for-event-watcher/foo-local.yaml
index 21c1d5e..525bfad 100644
--- a/tmp-for-event-watcher/foo-local.yaml
+++ b/tmp-for-event-watcher/foo-local.yaml
@@ -1,3 +1,3 @@
 foo:
   # comments
-  bar: yes
+  bar: no
```

**Which issue(s) this PR fixes**:

Fixes https://github.com/pipe-cd/pipe/issues/2118

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Fix a bug that Event Watcher deletes all comments in YAML
```
