### PR TITLE
Ensure to use merged-commits to run plan-preview tasks

### DIFF
--- a/pkg/app/piped/controller/planner.go
+++ b/pkg/app/piped/controller/planner.go
@@ -175,22 +175,16 @@ func (p *planner) Run(ctx context.Context) error {
 
 	in.TargetDSP = deploysource.NewProvider(
 		filepath.Join(p.workingDir, "target-deploysource"),
-		repoCfg,
-		"target",
-		p.deployment.Trigger.Commit.Hash,
-		p.gitClient,
-		p.deployment.GitPath,
+		deploysource.NewGitSourceCloner(p.gitClient, repoCfg, "target", p.deployment.Trigger.Commit.Hash),
+		*p.deployment.GitPath,
 		p.secretDecrypter,
 	)
 
 	if p.lastSuccessfulCommitHash != "" {
 		in.RunningDSP = deploysource.NewProvider(
 			filepath.Join(p.workingDir, "running-deploysource"),
-			repoCfg,
-			"running",
-			p.lastSuccessfulCommitHash,
-			p.gitClient,
-			p.deployment.GitPath,
+			deploysource.NewGitSourceCloner(p.gitClient, repoCfg, "running", p.lastSuccessfulCommitHash),
+			*p.deployment.GitPath,
 			p.secretDecrypter,
 		)
 	}

--- a/pkg/app/piped/controller/scheduler.go
+++ b/pkg/app/piped/controller/scheduler.go
@@ -223,22 +223,16 @@ func (s *scheduler) Run(ctx context.Context) error {
 
 	s.targetDSP = deploysource.NewProvider(
 		filepath.Join(s.workingDir, "target-deploysource"),
-		repoCfg,
-		"target",
-		s.deployment.Trigger.Commit.Hash,
-		s.gitClient,
-		s.deployment.GitPath,
+		deploysource.NewGitSourceCloner(s.gitClient, repoCfg, "target", s.deployment.Trigger.Commit.Hash),
+		*s.deployment.GitPath,
 		s.secretDecrypter,
 	)
 
 	if s.deployment.RunningCommitHash != "" {
 		s.runningDSP = deploysource.NewProvider(
 			filepath.Join(s.workingDir, "running-deploysource"),
-			repoCfg,
-			"running",
-			s.deployment.RunningCommitHash,
-			s.gitClient,
-			s.deployment.GitPath,
+			deploysource.NewGitSourceCloner(s.gitClient, repoCfg, "running", s.deployment.RunningCommitHash),
+			*s.deployment.GitPath,
 			s.secretDecrypter,
 		)
 	}
@@ -249,11 +243,8 @@ func (s *scheduler) Run(ctx context.Context) error {
 	// We need only the deployment configuration spec.
 	configDSP := deploysource.NewProvider(
 		filepath.Join(s.workingDir, "target-config"),
-		repoCfg,
-		"target",
-		s.deployment.Trigger.Commit.Hash,
-		s.gitClient,
-		s.deployment.GitPath,
+		deploysource.NewGitSourceCloner(s.gitClient, repoCfg, "target", s.deployment.Trigger.Commit.Hash),
+		*s.deployment.GitPath,
 		nil,
 	)
 	ds, err := configDSP.GetReadOnly(ctx, ioutil.Discard)

--- a/pkg/app/piped/deploysource/BUILD.bazel
+++ b/pkg/app/piped/deploysource/BUILD.bazel
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["deploysource.go"],
+    srcs = [
+        "deploysource.go",
+        "sourcecloner.go",
+    ],
     importpath = "github.com/pipe-cd/pipe/pkg/app/piped/deploysource",
     visibility = ["//visibility:public"],
     deps = [

--- a/pkg/app/piped/deploysource/sourcecloner.go
+++ b/pkg/app/piped/deploysource/sourcecloner.go
@@ -1,0 +1,94 @@
+// Copyright 2021 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deploysource
+
+import (
+	"context"
+
+	"github.com/pipe-cd/pipe/pkg/config"
+	"github.com/pipe-cd/pipe/pkg/git"
+)
+
+type SourceCloner interface {
+	Clone(ctx context.Context, dest string) error
+	Revision() string
+	RevisionName() string
+}
+
+type gitClient interface {
+	Clone(ctx context.Context, repoID, remote, branch, destination string) (git.Repo, error)
+}
+
+func NewGitSourceCloner(gc gitClient, cfg config.PipedRepository, revisionName, revision string) SourceCloner {
+	return &gitSourceCloner{
+		revision:     revision,
+		revisionName: revisionName,
+		gc:           gc,
+		cfg:          cfg,
+	}
+}
+
+type gitSourceCloner struct {
+	revision     string
+	revisionName string
+	gc           gitClient
+	cfg          config.PipedRepository
+}
+
+func (d *gitSourceCloner) Revision() string {
+	return d.revision
+}
+
+func (d *gitSourceCloner) RevisionName() string {
+	return d.revisionName
+}
+
+func (d *gitSourceCloner) Clone(ctx context.Context, dest string) error {
+	repo, err := d.gc.Clone(ctx, d.cfg.RepoID, d.cfg.Remote, d.cfg.Branch, dest)
+	if err != nil {
+		return err
+	}
+	if err := repo.Checkout(ctx, d.revision); err != nil {
+		return err
+	}
+	return nil
+}
+
+type localSourceCloner struct {
+	revision     string
+	revisionName string
+	repo         git.Repo
+}
+
+func NewLocalSourceCloner(repo git.Repo, revisionName, revision string) SourceCloner {
+	return &localSourceCloner{
+		revision:     revision,
+		revisionName: revisionName,
+		repo:         repo,
+	}
+}
+
+func (d *localSourceCloner) Revision() string {
+	return d.revision
+}
+
+func (d *localSourceCloner) RevisionName() string {
+	return d.revisionName
+}
+
+func (d *localSourceCloner) Clone(ctx context.Context, dest string) error {
+	_, err := d.repo.Copy(dest)
+	return err
+}

--- a/pkg/app/piped/executor/cloudrun/cloudrun.go
+++ b/pkg/app/piped/executor/cloudrun/cloudrun.go
@@ -46,7 +46,7 @@ func Register(r registerer) {
 }
 
 func loadServiceManifest(in *executor.Input, serviceManifestFile string, ds *deploysource.DeploySource) (provider.ServiceManifest, bool) {
-	in.LogPersister.Infof("Loading service manifest at the %s commit (%s)", ds.RevisionName, ds.Revision)
+	in.LogPersister.Infof("Loading service manifest at commit %s", ds.Revision)
 
 	sm, err := provider.LoadServiceManifest(ds.AppDir, serviceManifestFile)
 	if err != nil {
@@ -54,7 +54,7 @@ func loadServiceManifest(in *executor.Input, serviceManifestFile string, ds *dep
 		return provider.ServiceManifest{}, false
 	}
 
-	in.LogPersister.Infof("Successfully loaded the service manifest at the %s commit", ds.RevisionName)
+	in.LogPersister.Infof("Successfully loaded the service manifest at commit %s", ds.Revision)
 	return sm, true
 }
 

--- a/pkg/app/piped/executor/ecs/ecs.go
+++ b/pkg/app/piped/executor/ecs/ecs.go
@@ -85,7 +85,7 @@ func findCloudProvider(in *executor.Input) (name string, cfg *config.CloudProvid
 }
 
 func loadServiceDefinition(in *executor.Input, serviceDefinitionFile string, ds *deploysource.DeploySource) (types.Service, bool) {
-	in.LogPersister.Infof("Loading service manifest at the %s commit (%s)", ds.RevisionName, ds.RevisionName)
+	in.LogPersister.Infof("Loading service manifest at commit %s", ds.Revision)
 
 	serviceDefinition, err := provider.LoadServiceDefinition(ds.AppDir, serviceDefinitionFile)
 	if err != nil {
@@ -93,12 +93,12 @@ func loadServiceDefinition(in *executor.Input, serviceDefinitionFile string, ds 
 		return types.Service{}, false
 	}
 
-	in.LogPersister.Infof("Successfully loaded the ECS service definition at the %s commit", ds.RevisionName)
+	in.LogPersister.Infof("Successfully loaded the ECS service definition at commit %s", ds.Revision)
 	return serviceDefinition, true
 }
 
 func loadTaskDefinition(in *executor.Input, taskDefinitionFile string, ds *deploysource.DeploySource) (types.TaskDefinition, bool) {
-	in.LogPersister.Infof("Loading task definition manifest at the %s commit (%s)", ds.RevisionName, ds.RevisionName)
+	in.LogPersister.Infof("Loading task definition manifest at commit %s", ds.Revision)
 
 	taskDefinition, err := provider.LoadTaskDefinition(ds.AppDir, taskDefinitionFile)
 	if err != nil {
@@ -106,12 +106,12 @@ func loadTaskDefinition(in *executor.Input, taskDefinitionFile string, ds *deplo
 		return types.TaskDefinition{}, false
 	}
 
-	in.LogPersister.Infof("Successfully loaded the ECS task definition at the %s commit", ds.RevisionName)
+	in.LogPersister.Infof("Successfully loaded the ECS task definition at commit %s", ds.Revision)
 	return taskDefinition, true
 }
 
 func loadTargetGroups(in *executor.Input, deployCfg *config.ECSDeploymentSpec, ds *deploysource.DeploySource) (*types.LoadBalancer, *types.LoadBalancer, bool) {
-	in.LogPersister.Infof("Loading target groups config at the %s commit (%s)", ds.RevisionName, ds.RevisionName)
+	in.LogPersister.Infof("Loading target groups config at the commit %s", ds.Revision)
 
 	primary, canary, err := provider.LoadTargetGroups(deployCfg.Input.TargetGroups)
 	if err != nil {
@@ -119,7 +119,7 @@ func loadTargetGroups(in *executor.Input, deployCfg *config.ECSDeploymentSpec, d
 		return nil, nil, false
 	}
 
-	in.LogPersister.Infof("Successfully loaded the ECS target groups at the %s commit", ds.RevisionName)
+	in.LogPersister.Infof("Successfully loaded the ECS target groups at commit %s", ds.Revision)
 	return primary, canary, true
 }
 

--- a/pkg/app/piped/executor/lambda/lambda.go
+++ b/pkg/app/piped/executor/lambda/lambda.go
@@ -69,7 +69,7 @@ func findCloudProvider(in *executor.Input) (name string, cfg *config.CloudProvid
 }
 
 func loadFunctionManifest(in *executor.Input, functionManifestFile string, ds *deploysource.DeploySource) (provider.FunctionManifest, bool) {
-	in.LogPersister.Infof("Loading service manifest at the %s commit (%s)", ds.RevisionName, ds.RevisionName)
+	in.LogPersister.Infof("Loading service manifest at commit %s", ds.Revision)
 
 	fm, err := provider.LoadFunctionManifest(ds.AppDir, functionManifestFile)
 	if err != nil {
@@ -77,7 +77,7 @@ func loadFunctionManifest(in *executor.Input, functionManifestFile string, ds *d
 		return provider.FunctionManifest{}, false
 	}
 
-	in.LogPersister.Infof("Successfully loaded the lambda function manifest at the %s commit", ds.RevisionName)
+	in.LogPersister.Infof("Successfully loaded the lambda function manifest at commit %s", ds.Revision)
 	return fm, true
 }
 

--- a/pkg/app/piped/planpreview/builder.go
+++ b/pkg/app/piped/planpreview/builder.go
@@ -137,8 +137,8 @@ func (b *builder) build(ctx context.Context, id string, cmd model.Command_BuildP
 	}
 
 	// Prepare source code at the head commit.
-	// This clones the base branch and merges head banch into it for correct data.
-	// Because new changes were added into base branch after head branch was checked out.
+	// This clones the base branch and merges the head branch into it for correct data.
+	// Because new changes might be added into the base branch after the head branch had checked out.
 	repo, err := b.cloneHeadCommit(ctx, cmd.HeadBranch, cmd.HeadCommit)
 	if err != nil {
 		return nil, err

--- a/pkg/app/piped/planpreview/terraformdiff.go
+++ b/pkg/app/piped/planpreview/terraformdiff.go
@@ -23,14 +23,13 @@ import (
 	terraformprovider "github.com/pipe-cd/pipe/pkg/app/piped/cloudprovider/terraform"
 	"github.com/pipe-cd/pipe/pkg/app/piped/deploysource"
 	"github.com/pipe-cd/pipe/pkg/app/piped/toolregistry"
-	"github.com/pipe-cd/pipe/pkg/config"
 	"github.com/pipe-cd/pipe/pkg/model"
 )
 
 func (b *builder) terraformDiff(
 	ctx context.Context,
 	app *model.Application,
-	cmd model.Command_BuildPlanPreview,
+	targetDSP deploysource.Provider,
 	buf *bytes.Buffer,
 ) (string, error) {
 
@@ -41,22 +40,6 @@ func (b *builder) terraformDiff(
 		return "", err
 	}
 	cpCfg := cp.TerraformConfig
-
-	repoCfg := config.PipedRepository{
-		RepoID: b.repoCfg.RepoID,
-		Remote: b.repoCfg.Remote,
-		Branch: cmd.HeadBranch,
-	}
-
-	targetDSP := deploysource.NewProvider(
-		b.workingDir,
-		repoCfg,
-		"target",
-		cmd.HeadCommit,
-		b.gitClient,
-		app.GitPath,
-		b.secretDecrypter,
-	)
 
 	ds, err := targetDSP.Get(ctx, io.Discard)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

Until now, Piped is cloning the head branch of the pull request to build the plan-preview results.
In that way, we are facing a problem when some new commits were added into the base branch after the PR is created.
Because the source in the head branch is not complete, it is missing the newly added changes into the base branch.

So instead of using the head branch directly, this PR prepares a complete source code for the plan-preview builder by cloning the base branch and merge new head commits into it.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Fix wrong plan-preview result in case the base branch was updated after PR is created
```
