### PR TITLE
Do not mask the diff output of ConfigMap

### DIFF
--- a/pkg/app/piped/planpreview/kubernetesdiff.go
+++ b/pkg/app/piped/planpreview/kubernetesdiff.go
@@ -79,7 +79,6 @@ func (b *builder) kubernetesDiff(
 	summary := fmt.Sprintf("%d added manifests, %d changed manifests, %d deleted manifests", len(result.Adds), len(result.Changes), len(result.Deletes))
 	details := result.Render(provider.DiffRenderOptions{
 		MaskSecret:     true,
-		MaskConfigMap:  true,
 		UseDiffCommand: true,
 	})
 	fmt.Fprintf(buf, "--- Last Deploy\n+++ Head Commit\n\n%s\n", details)


### PR DESCRIPTION
**What this PR does / why we need it**:

Because the ConfigMap is expected to not contain sensitive data.

I am not sure we should make a minor change for this or just a patch is enough.
This feature is under alpha status but this might be an unexpected change for some users.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Do not mask the diff output of ConfigMap
```
