### PR TITLE
Fix broken layout of error block on plan-preview comment

### DIFF
--- a/dockers/actions-plan-preview/DOCKER_BUILD
+++ b/dockers/actions-plan-preview/DOCKER_BUILD
@@ -1,2 +1,2 @@
-version: 1.1.1
+version: 1.1.2
 registry: gcr.io/pipecd/actions-plan-preview

--- a/dockers/actions-plan-preview/planpreview.go
+++ b/dockers/actions-plan-preview/planpreview.go
@@ -180,7 +180,7 @@ func makeCommentBody(event *githubEvent, r *PlanPreviewResult) string {
 		fmt.Fprintf(&b, "**An error occurred while building plan-preview for the following applications**\n")
 
 		for _, app := range r.FailureApplications {
-			fmt.Fprintf(&b, "## app: [%s](%s), env: [%s](%s), kind: %s\n", app.ApplicationName, app.ApplicationURL, app.EnvName, app.EnvURL, strings.ToLower(app.ApplicationKind))
+			fmt.Fprintf(&b, "\n## app: [%s](%s), env: [%s](%s), kind: %s\n", app.ApplicationName, app.ApplicationURL, app.EnvName, app.EnvURL, strings.ToLower(app.ApplicationKind))
 			fmt.Fprintf(&b, "Reason: %s\n\n", app.Reason)
 
 			var lang = "diff"
@@ -195,7 +195,7 @@ func makeCommentBody(event *githubEvent, r *PlanPreviewResult) string {
 		fmt.Fprintf(&b, "**An error occurred while building plan-preview for applications of the following Pipeds**\n")
 
 		for _, piped := range r.FailurePipeds {
-			fmt.Fprintf(&b, "## piped: [%s](%s)\n", piped.PipedID, piped.PipedURL)
+			fmt.Fprintf(&b, "\n## piped: [%s](%s)\n", piped.PipedID, piped.PipedURL)
 			fmt.Fprintf(&b, "Reason: %s\n\n", piped.Reason)
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

We need some line breaks to render the section heading correctly.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
