### PR TITLE
Avoid nil pointer dereference around using backoff

### DIFF
--- a/pkg/app/piped/planpreview/BUILD.bazel
+++ b/pkg/app/piped/planpreview/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//pkg/app/piped/planpreview/planpreviewmetrics:go_default_library",
         "//pkg/app/piped/toolregistry:go_default_library",
         "//pkg/app/piped/trigger:go_default_library",
+        "//pkg/backoff:go_default_library",
         "//pkg/cache:go_default_library",
         "//pkg/config:go_default_library",
         "//pkg/diff:go_default_library",

--- a/pkg/app/piped/planpreview/builder.go
+++ b/pkg/app/piped/planpreview/builder.go
@@ -350,10 +350,10 @@ func (b *builder) getMostRecentlySuccessfulDeployment(ctx context.Context, appli
 			ApplicationId: applicationID,
 			Status:        model.DeploymentStatus_DEPLOYMENT_SUCCESS,
 		})
-		if err == nil {
-			return resp.Deployment, nil
+		if err != nil {
+			return nil, backoff.NewError(err, pipedservice.Retriable(err))
 		}
-		return nil, backoff.NewError(err, pipedservice.Retriable(err))
+		return resp.Deployment, nil
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/backoff/backoff.go
+++ b/pkg/backoff/backoff.go
@@ -91,6 +91,10 @@ func (r *retry) WaitNext(ctx context.Context) bool {
 	}
 }
 
+// Do executes and returns the results of the given operation.
+// It automatically retries if the operation returns an error.
+// To control which error should be retriable or not,
+// you can wrap the error from operation with NewError function.
 func (r *retry) Do(ctx context.Context, operation func() (interface{}, error)) (interface{}, error) {
 	var err error
 


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Fix panic error log that occasionally occurs while running plan preview tasks
```
