### PR TITLE
Allow dynamically specify plan-preview command timeout from pipectl

### DIFF
--- a/pkg/app/api/grpcapi/api.go
+++ b/pkg/app/api/grpcapi/api.go
@@ -467,6 +467,7 @@ func (a *API) RequestPlanPreview(ctx context.Context, req *apiservice.RequestPla
 				HeadBranch:   req.HeadBranch,
 				HeadCommit:   req.HeadCommit,
 				BaseBranch:   req.BaseBranch,
+				Timeout:      req.Timeout,
 			},
 		}
 		if err := addCommand(ctx, a.commandStore, &cmd, a.logger); err != nil {

--- a/pkg/app/api/service/apiservice/service.proto
+++ b/pkg/app/api/service/apiservice/service.proto
@@ -131,6 +131,8 @@ message RequestPlanPreviewRequest {
     string head_branch = 2 [(validate.rules).string.min_len = 1];
     string head_commit = 3 [(validate.rules).string.min_len = 1];
     string base_branch = 4 [(validate.rules).string.min_len = 1];
+    // Maximum number of seconds a Piped can take to handle a command.
+    int64 timeout = 5 [(validate.rules).int64.gte = 0];
 }
 
 message RequestPlanPreviewResponse {

--- a/pkg/app/pipectl/cmd/planpreview/planpreview.go
+++ b/pkg/app/pipectl/cmd/planpreview/planpreview.go
@@ -99,6 +99,7 @@ func (c *command) run(ctx context.Context, _ cli.Telemetry) error {
 		HeadBranch:    c.headBranch,
 		HeadCommit:    c.headCommit,
 		BaseBranch:    c.baseBranch,
+		Timeout:       int64(c.pipedHandleTimeout.Seconds()),
 	}
 
 	resp, err := cli.RequestPlanPreview(ctx, req)

--- a/pkg/app/piped/planpreview/handler.go
+++ b/pkg/app/piped/planpreview/handler.go
@@ -274,7 +274,11 @@ func (h *Handler) handleCommand(ctx context.Context, cmd model.ReportableCommand
 		return
 	}
 
-	buildCtx, cancel := context.WithTimeout(ctx, h.options.commandHandleTimeout)
+	timeout := time.Duration(cmd.BuildPlanPreview.Timeout) * time.Second
+	if timeout == 0 {
+		timeout = h.options.commandHandleTimeout
+	}
+	buildCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	b := h.builderFactory()

--- a/pkg/model/command.proto
+++ b/pkg/model/command.proto
@@ -64,6 +64,7 @@ message Command {
         string head_branch = 2 [(validate.rules).string.min_len = 1];
         string head_commit = 3 [(validate.rules).string.min_len = 1];
         string base_branch = 4 [(validate.rules).string.min_len = 1];
+        int64 timeout = 5 [(validate.rules).int64.gte = 0];
     }
 
     // The generated unique identifier.


### PR DESCRIPTION

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #2297

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Allow dynamically specify plan-preview command timeout from pipectl
```
