### PR TITLE
Migrate dgrijalva/jwt-go to golang-jwt/jwt

### DIFF
--- a/cmd/pipecd/BUILD.bazel
+++ b/cmd/pipecd/BUILD.bazel
@@ -48,7 +48,7 @@ go_library(
         "//pkg/redis:go_default_library",
         "//pkg/rpc:go_default_library",
         "//pkg/version:go_default_library",
-        "@com_github_dgrijalva_jwt_go//:go_default_library",
+        "@com_github_golang_jwt_jwt//:go_default_library",
         "@com_github_prometheus_client_golang//prometheus:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",
         "@org_golang_x_sync//errgroup:go_default_library",

--- a/cmd/pipecd/server.go
+++ b/cmd/pipecd/server.go
@@ -20,7 +20,7 @@ import (
 	"net/http"
 	"time"
 
-	jwtgo "github.com/dgrijalva/jwt-go"
+	jwtgo "github.com/golang-jwt/jwt"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"

--- a/go.mod
+++ b/go.mod
@@ -19,11 +19,11 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/lambda v1.1.1
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.2.0
 	github.com/creasty/defaults v1.5.1
-	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/envoyproxy/protoc-gen-validate v0.1.0
 	github.com/fsouza/fake-gcs-server v1.21.0
 	github.com/go-sql-driver/mysql v1.5.0
 	github.com/goccy/go-yaml v1.9.0
+	github.com/golang-jwt/jwt v3.2.1+incompatible
 	github.com/golang/mock v1.4.4
 	github.com/golang/protobuf v1.4.2
 	github.com/gomodule/redigo v2.0.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -248,6 +248,8 @@ github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zV
 github.com/gogo/protobuf v1.3.0/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.1 h1:DqDEcV5aeaTmdFBePNpYsp3FlcVH/2ISVVM9Qf8PSls=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
+github.com/golang-jwt/jwt v3.2.1+incompatible h1:73Z+4BJcrTC+KczS6WvTPvRGOp1WmfEP4Q1lOd9Z/+c=
+github.com/golang-jwt/jwt v3.2.1+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=

--- a/pkg/jwt/BUILD.bazel
+++ b/pkg/jwt/BUILD.bazel
@@ -11,7 +11,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/model:go_default_library",
-        "@com_github_dgrijalva_jwt_go//:go_default_library",
+        "@com_github_golang_jwt_jwt//:go_default_library",
     ],
 )
 
@@ -26,7 +26,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/model:go_default_library",
-        "@com_github_dgrijalva_jwt_go//:go_default_library",
+        "@com_github_golang_jwt_jwt//:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",
         "@com_github_stretchr_testify//require:go_default_library",
     ],

--- a/pkg/jwt/jwt.go
+++ b/pkg/jwt/jwt.go
@@ -19,7 +19,7 @@ import (
 	"io/ioutil"
 	"time"
 
-	jwtgo "github.com/dgrijalva/jwt-go"
+	jwtgo "github.com/golang-jwt/jwt"
 
 	"github.com/pipe-cd/pipe/pkg/model"
 )

--- a/pkg/jwt/signer.go
+++ b/pkg/jwt/signer.go
@@ -17,7 +17,7 @@ package jwt
 import (
 	"fmt"
 
-	jwtgo "github.com/dgrijalva/jwt-go"
+	jwtgo "github.com/golang-jwt/jwt"
 )
 
 type Signer interface {

--- a/pkg/jwt/signer_test.go
+++ b/pkg/jwt/signer_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 	"time"
 
-	jwtgo "github.com/dgrijalva/jwt-go"
+	jwtgo "github.com/golang-jwt/jwt"
 	"github.com/stretchr/testify/require"
 
 	"github.com/pipe-cd/pipe/pkg/model"

--- a/pkg/jwt/verifier.go
+++ b/pkg/jwt/verifier.go
@@ -17,7 +17,7 @@ package jwt
 import (
 	"fmt"
 
-	jwtgo "github.com/dgrijalva/jwt-go"
+	jwtgo "github.com/golang-jwt/jwt"
 )
 
 type Verifier interface {

--- a/pkg/jwt/verifier_test.go
+++ b/pkg/jwt/verifier_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 	"time"
 
-	jwtgo "github.com/dgrijalva/jwt-go"
+	jwtgo "github.com/golang-jwt/jwt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -564,6 +564,13 @@ def go_repositories():
         version = "v0.0.0-20200121045136-8c9f03a8e57e",
     )
     go_repository(
+        name = "com_github_golang_jwt_jwt",
+        importpath = "github.com/golang-jwt/jwt",
+        sum = "h1:73Z+4BJcrTC+KczS6WvTPvRGOp1WmfEP4Q1lOd9Z/+c=",
+        version = "v3.2.1+incompatible",
+    )
+
+    go_repository(
         name = "com_github_golang_mock",
         importpath = "github.com/golang/mock",
         sum = "h1:l75CXGRSwbaYNpl/Z2X1XIIAMSCquvXgpVZDhwEIJsc=",


### PR DESCRIPTION
**What this PR does / why we need it**:

Because `jwt` lib was moved to a new home.

https://github.com/golang-jwt/jwt

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
