### PR TITLE
Make plan-preview comment more readable in case there are some unchanged applications

### DIFF
--- a/dockers/actions-plan-preview/DOCKER_BUILD
+++ b/dockers/actions-plan-preview/DOCKER_BUILD
@@ -1,2 +1,2 @@
-version: 1.1.2
+version: 1.1.3
 registry: gcr.io/pipecd/actions-plan-preview

--- a/dockers/actions-plan-preview/Dockerfile
+++ b/dockers/actions-plan-preview/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.16.5-alpine3.14 as builder
 COPY . /app
 RUN cd /app && go build -o /plan-preview .
 
-FROM gcr.io/pipecd/pipectl:v0.13.0
+FROM gcr.io/pipecd/pipectl:v0.13.1-4-gec4b78b
 COPY --from=builder /plan-preview /
 ENV PATH $PATH:/app/cmd/pipectl
 RUN chmod +x /plan-preview

--- a/dockers/actions-plan-preview/Dockerfile
+++ b/dockers/actions-plan-preview/Dockerfile
@@ -2,6 +2,7 @@ FROM golang:1.16.5-alpine3.14 as builder
 COPY . /app
 RUN cd /app && go build -o /plan-preview .
 
+# TODO: Update pipectl version to v0.13.2 once it's rolled out.
 FROM gcr.io/pipecd/pipectl:v0.13.1-4-gec4b78b
 COPY --from=builder /plan-preview /
 ENV PATH $PATH:/app/cmd/pipectl

--- a/dockers/actions-plan-preview/go.mod
+++ b/dockers/actions-plan-preview/go.mod
@@ -4,5 +4,6 @@ go 1.16
 
 require (
 	github.com/google/go-github/v36 v36.0.0
+	github.com/stretchr/testify v1.7.0
 	golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be
 )

--- a/dockers/actions-plan-preview/go.sum
+++ b/dockers/actions-plan-preview/go.sum
@@ -1,3 +1,5 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
@@ -6,6 +8,11 @@ github.com/google/go-github/v36 v36.0.0 h1:ndCzM616/oijwufI7nBRa+5eZHLldT+4yIB68
 github.com/google/go-github/v36 v36.0.0/go.mod h1:LFlKC047IOqiglRGNqNb9s/iAPTnnjtlshm+bxp+kwk=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a h1:oWX7TPOiFAMXLq8o0ikBYfCJVlRHBcsciT5bXOrH628=
@@ -17,3 +24,7 @@ golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0 h1:igQkv0AAhEIvTEpD5LIpAfav2eeVO9HBTjvKHVJPRSs=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/dockers/actions-plan-preview/planpreview.go
+++ b/dockers/actions-plan-preview/planpreview.go
@@ -177,14 +177,14 @@ func makeCommentBody(event *githubEvent, r *PlanPreviewResult) string {
 		b.WriteString("\n## No resource changes were detected but the following apps will also be triggered\n")
 
 		if len(pipelineApps) > 0 {
-			b.WriteString("\n### `PIPELINE`\n")
+			b.WriteString("\n###### `PIPELINE`\n")
 			for _, app := range pipelineApps {
 				fmt.Fprintf(&b, "\n- app: [%s](%s), env: [%s](%s), kind: %s\n", app.ApplicationName, app.ApplicationURL, app.EnvName, app.EnvURL, strings.ToLower(app.ApplicationKind))
 			}
 		}
 
 		if len(quickSyncApps) > 0 {
-			b.WriteString("\n### `QUICK_SYNC`\n")
+			b.WriteString("\n###### `QUICK_SYNC`\n")
 			for _, app := range quickSyncApps {
 				fmt.Fprintf(&b, "\n- app: [%s](%s), env: [%s](%s), kind: %s\n", app.ApplicationName, app.ApplicationURL, app.EnvName, app.EnvURL, strings.ToLower(app.ApplicationKind))
 			}

--- a/dockers/actions-plan-preview/planpreview_test.go
+++ b/dockers/actions-plan-preview/planpreview_test.go
@@ -1,0 +1,212 @@
+// Copyright 2021 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"embed"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+//go:embed testdata/*
+var testdata embed.FS
+
+func TestMakeCommentBody(t *testing.T) {
+	testcases := []struct {
+		name     string
+		event    githubEvent
+		result   PlanPreviewResult
+		expected string
+	}{
+		{
+			name: "no changes",
+			event: githubEvent{
+				HeadCommit: "abc",
+			},
+			result:   PlanPreviewResult{},
+			expected: "testdata/comment-no-changes.txt",
+		},
+		{
+			name: "only changed app",
+			event: githubEvent{
+				HeadCommit: "abc",
+			},
+			result: PlanPreviewResult{
+				Applications: []ApplicationResult{
+					ApplicationResult{
+						ApplicationInfo: ApplicationInfo{
+							ApplicationID:        "app-id-1",
+							ApplicationName:      "app-name-1",
+							ApplicationURL:       "app-url-1",
+							EnvID:                "env-id-1",
+							EnvURL:               "env-url-1",
+							ApplicationKind:      "app-kind-1",
+							ApplicationDirectory: "app-dir-1",
+						},
+						SyncStrategy: "PIPELINE",
+						PlanSummary:  "plan-summary-1",
+						PlanDetails:  "plan-details-1",
+						NoChange:     false,
+					},
+				},
+			},
+			expected: "testdata/comment-only-changed-app.txt",
+		},
+		{
+			name: "has no diff apps",
+			event: githubEvent{
+				HeadCommit: "abc",
+			},
+			result: PlanPreviewResult{
+				Applications: []ApplicationResult{
+					ApplicationResult{
+						ApplicationInfo: ApplicationInfo{
+							ApplicationID:        "app-id-2",
+							ApplicationName:      "app-name-2",
+							ApplicationURL:       "app-url-2",
+							EnvID:                "env-id-2",
+							EnvURL:               "env-url-2",
+							ApplicationKind:      "app-kind-2",
+							ApplicationDirectory: "app-dir-2",
+						},
+						SyncStrategy: "QUICK_SYNC",
+						PlanSummary:  "",
+						PlanDetails:  "",
+						NoChange:     true,
+					},
+					ApplicationResult{
+						ApplicationInfo: ApplicationInfo{
+							ApplicationID:        "app-id-1",
+							ApplicationName:      "app-name-1",
+							ApplicationURL:       "app-url-1",
+							EnvID:                "env-id-1",
+							EnvURL:               "env-url-1",
+							ApplicationKind:      "app-kind-1",
+							ApplicationDirectory: "app-dir-1",
+						},
+						SyncStrategy: "PIPELINE",
+						PlanSummary:  "plan-summary-1",
+						PlanDetails:  "plan-details-1",
+						NoChange:     false,
+					},
+					ApplicationResult{
+						ApplicationInfo: ApplicationInfo{
+							ApplicationID:        "app-id-3",
+							ApplicationName:      "app-name-3",
+							ApplicationURL:       "app-url-3",
+							EnvID:                "env-id-3",
+							EnvURL:               "env-url-3",
+							ApplicationKind:      "app-kind-3",
+							ApplicationDirectory: "app-dir-3",
+						},
+						SyncStrategy: "PIPELINE",
+						PlanSummary:  "",
+						PlanDetails:  "",
+						NoChange:     true,
+					},
+				},
+			},
+			expected: "testdata/comment-has-no-diff-apps.txt",
+		},
+		{
+			name: "has failed app",
+			event: githubEvent{
+				HeadCommit: "abc",
+			},
+			result: PlanPreviewResult{
+				Applications: []ApplicationResult{
+					ApplicationResult{
+						ApplicationInfo: ApplicationInfo{
+							ApplicationID:        "app-id-1",
+							ApplicationName:      "app-name-1",
+							ApplicationURL:       "app-url-1",
+							EnvID:                "env-id-1",
+							EnvURL:               "env-url-1",
+							ApplicationKind:      "app-kind-1",
+							ApplicationDirectory: "app-dir-1",
+						},
+						SyncStrategy: "PIPELINE",
+						PlanSummary:  "plan-summary-1",
+						PlanDetails:  "plan-details-1",
+						NoChange:     false,
+					},
+				},
+				FailureApplications: []FailureApplication{
+					FailureApplication{
+						ApplicationInfo: ApplicationInfo{
+							ApplicationID:        "app-id-2",
+							ApplicationName:      "app-name-2",
+							ApplicationURL:       "app-url-2",
+							EnvID:                "env-id-2",
+							EnvURL:               "env-url-2",
+							ApplicationKind:      "app-kind-2",
+							ApplicationDirectory: "app-dir-2",
+						},
+						Reason:      "reason-2",
+						PlanDetails: "",
+					},
+				},
+			},
+			expected: "testdata/comment-has-failed-app.txt",
+		},
+		{
+			name: "has failed piped",
+			event: githubEvent{
+				HeadCommit: "abc",
+			},
+			result: PlanPreviewResult{
+				Applications: []ApplicationResult{
+					ApplicationResult{
+						ApplicationInfo: ApplicationInfo{
+							ApplicationID:        "app-id-1",
+							ApplicationName:      "app-name-1",
+							ApplicationURL:       "app-url-1",
+							EnvID:                "env-id-1",
+							EnvURL:               "env-url-1",
+							ApplicationKind:      "app-kind-1",
+							ApplicationDirectory: "app-dir-1",
+						},
+						SyncStrategy: "PIPELINE",
+						PlanSummary:  "plan-summary-1",
+						PlanDetails:  "plan-details-1",
+						NoChange:     false,
+					},
+				},
+				FailurePipeds: []FailurePiped{
+					FailurePiped{
+						PipedInfo: PipedInfo{
+							PipedID:  "piped-id-1",
+							PipedURL: "piped-url-1",
+						},
+						Reason: "piped-reason-1",
+					},
+				},
+			},
+			expected: "testdata/comment-has-failed-piped.txt",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			expected, err := testdata.ReadFile(tc.expected)
+			require.NoError(t, err)
+
+			got := makeCommentBody(&tc.event, &tc.result)
+			assert.Equal(t, string(expected), got)
+		})
+	}
+}

--- a/dockers/actions-plan-preview/testdata/comment-has-failed-app.txt
+++ b/dockers/actions-plan-preview/testdata/comment-has-failed-app.txt
@@ -1,0 +1,37 @@
+<!-- pipecd-plan-preview-->
+[![PLAN_PREVIEW](https://img.shields.io/static/v1?label=PipeCD&message=Plan_Preview&color=orange&style=flat)](https://pipecd.dev/docs/user-guide/plan-preview/)
+
+Ran plan-preview against head commit abc of this pull request. PipeCD detected `1` updated applications and here are their plan results. Once this pull request got merged their deployments will be triggered to run as these estimations.
+
+## app: [app-name-1](app-url-1), env: [](env-url-1), kind: app-kind-1
+Sync strategy: PIPELINE
+Summary: plan-summary-1
+
+<details>
+<summary>Details (Click me)</summary>
+<p>
+
+``` diff
+plan-details-1
+```
+</p>
+</details>
+
+---
+
+## NOTE
+
+**An error occurred while building plan-preview for the following applications**
+
+## app: [app-name-2](app-url-2), env: [](env-url-2), kind: app-kind-2
+Reason: reason-2
+
+<details>
+<summary>Details (Click me)</summary>
+<p>
+
+``` diff
+
+```
+</p>
+</details>

--- a/dockers/actions-plan-preview/testdata/comment-has-failed-piped.txt
+++ b/dockers/actions-plan-preview/testdata/comment-has-failed-piped.txt
@@ -1,0 +1,28 @@
+<!-- pipecd-plan-preview-->
+[![PLAN_PREVIEW](https://img.shields.io/static/v1?label=PipeCD&message=Plan_Preview&color=orange&style=flat)](https://pipecd.dev/docs/user-guide/plan-preview/)
+
+Ran plan-preview against head commit abc of this pull request. PipeCD detected `1` updated applications and here are their plan results. Once this pull request got merged their deployments will be triggered to run as these estimations.
+
+## app: [app-name-1](app-url-1), env: [](env-url-1), kind: app-kind-1
+Sync strategy: PIPELINE
+Summary: plan-summary-1
+
+<details>
+<summary>Details (Click me)</summary>
+<p>
+
+``` diff
+plan-details-1
+```
+</p>
+</details>
+
+---
+
+## NOTE
+
+**An error occurred while building plan-preview for applications of the following Pipeds**
+
+## piped: [piped-id-1](piped-url-1)
+Reason: piped-reason-1
+

--- a/dockers/actions-plan-preview/testdata/comment-has-no-diff-apps.txt
+++ b/dockers/actions-plan-preview/testdata/comment-has-no-diff-apps.txt
@@ -1,0 +1,28 @@
+<!-- pipecd-plan-preview-->
+[![PLAN_PREVIEW](https://img.shields.io/static/v1?label=PipeCD&message=Plan_Preview&color=success&style=flat)](https://pipecd.dev/docs/user-guide/plan-preview/)
+
+Ran plan-preview against head commit abc of this pull request. PipeCD detected `3` updated applications and here are their plan results. Once this pull request got merged their deployments will be triggered to run as these estimations.
+
+## app: [app-name-1](app-url-1), env: [](env-url-1), kind: app-kind-1
+Sync strategy: PIPELINE
+Summary: plan-summary-1
+
+<details>
+<summary>Details (Click me)</summary>
+<p>
+
+``` diff
+plan-details-1
+```
+</p>
+</details>
+
+## No resource changes were detected but the following apps will also be triggered
+
+### `PIPELINE`
+
+- app: [app-name-3](app-url-3), env: [](env-url-3), kind: app-kind-3
+
+### `QUICK_SYNC`
+
+- app: [app-name-2](app-url-2), env: [](env-url-2), kind: app-kind-2

--- a/dockers/actions-plan-preview/testdata/comment-has-no-diff-apps.txt
+++ b/dockers/actions-plan-preview/testdata/comment-has-no-diff-apps.txt
@@ -19,10 +19,10 @@ plan-details-1
 
 ## No resource changes were detected but the following apps will also be triggered
 
-### `PIPELINE`
+###### `PIPELINE`
 
 - app: [app-name-3](app-url-3), env: [](env-url-3), kind: app-kind-3
 
-### `QUICK_SYNC`
+###### `QUICK_SYNC`
 
 - app: [app-name-2](app-url-2), env: [](env-url-2), kind: app-kind-2

--- a/dockers/actions-plan-preview/testdata/comment-no-changes.txt
+++ b/dockers/actions-plan-preview/testdata/comment-no-changes.txt
@@ -1,0 +1,4 @@
+<!-- pipecd-plan-preview-->
+[![PLAN_PREVIEW](https://img.shields.io/static/v1?label=PipeCD&message=Plan_Preview&color=success&style=flat)](https://pipecd.dev/docs/user-guide/plan-preview/)
+
+Ran plan-preview against head commit abc of this pull request. PipeCD detected `0` updated application. It means no deployment will be triggered once this pull request got merged.

--- a/dockers/actions-plan-preview/testdata/comment-only-changed-app.txt
+++ b/dockers/actions-plan-preview/testdata/comment-only-changed-app.txt
@@ -1,0 +1,18 @@
+<!-- pipecd-plan-preview-->
+[![PLAN_PREVIEW](https://img.shields.io/static/v1?label=PipeCD&message=Plan_Preview&color=success&style=flat)](https://pipecd.dev/docs/user-guide/plan-preview/)
+
+Ran plan-preview against head commit abc of this pull request. PipeCD detected `1` updated applications and here are their plan results. Once this pull request got merged their deployments will be triggered to run as these estimations.
+
+## app: [app-name-1](app-url-1), env: [](env-url-1), kind: app-kind-1
+Sync strategy: PIPELINE
+Summary: plan-summary-1
+
+<details>
+<summary>Details (Click me)</summary>
+<p>
+
+``` diff
+plan-details-1
+```
+</p>
+</details>

--- a/dockers/actions/plan/preview/planpreview_test.go
+++ b/dockers/actions/plan/preview/planpreview_test.go
@@ -1,0 +1,319 @@
+// Copyright 2021 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMakeCommentBody(t *testing.T) {
+	testcases := []struct {
+		name     string
+		event    githubEvent
+		result   PlanPreviewResult
+		expected string
+	}{
+		{
+			name: "no changes",
+			event: githubEvent{
+				HeadCommit: "abc",
+			},
+			result: PlanPreviewResult{},
+			expected: `<!-- pipecd-plan-preview-->
+[![PLAN_PREVIEW](https://img.shields.io/static/v1?label=PipeCD&message=Plan_Preview&color=success&style=flat)](https://pipecd.dev/docs/user-guide/plan-preview/)
+
+Ran plan-preview against head commit abc of this pull request. PipeCD detected ` + "`0`" + ` updated application. It means no deployment will be triggered once this pull request got merged.
+`,
+		},
+		{
+			name: "only changed app",
+			event: githubEvent{
+				HeadCommit: "abc",
+			},
+			result: PlanPreviewResult{
+				Applications: []ApplicationResult{
+					{
+						ApplicationInfo: ApplicationInfo{
+							ApplicationID:        "app-id-1",
+							ApplicationName:      "app-name-1",
+							ApplicationURL:       "app-url-1",
+							EnvID:                "env-id-1",
+							EnvURL:               "env-url-1",
+							ApplicationKind:      "app-kind-1",
+							ApplicationDirectory: "app-dir-1",
+						},
+						SyncStrategy: "PIPELINE",
+						PlanSummary:  "plan-summary-1",
+						PlanDetails:  "plan-details-1",
+						NoChange:     false,
+					},
+				},
+			},
+			expected: `<!-- pipecd-plan-preview-->
+[![PLAN_PREVIEW](https://img.shields.io/static/v1?label=PipeCD&message=Plan_Preview&color=success&style=flat)](https://pipecd.dev/docs/user-guide/plan-preview/)
+
+Ran plan-preview against head commit abc of this pull request. PipeCD detected ` + "`1`" + ` updated applications and here are their plan results. Once this pull request got merged their deployments will be triggered to run as these estimations.
+
+## app: [app-name-1](app-url-1), env: [](env-url-1), kind: app-kind-1
+Sync strategy: PIPELINE
+Summary: plan-summary-1
+
+<details>
+<summary>Details (Click me)</summary>
+<p>
+
+` + "```" + ` diff
+plan-details-1
+` + "```" + `
+</p>
+</details>
+`,
+		},
+		{
+			name: "has no diff apps",
+			event: githubEvent{
+				HeadCommit: "abc",
+			},
+			result: PlanPreviewResult{
+				Applications: []ApplicationResult{
+					{
+						ApplicationInfo: ApplicationInfo{
+							ApplicationID:        "app-id-2",
+							ApplicationName:      "app-name-2",
+							ApplicationURL:       "app-url-2",
+							EnvID:                "env-id-2",
+							EnvURL:               "env-url-2",
+							ApplicationKind:      "app-kind-2",
+							ApplicationDirectory: "app-dir-2",
+						},
+						SyncStrategy: "QUICK_SYNC",
+						PlanSummary:  "",
+						PlanDetails:  "",
+						NoChange:     true,
+					},
+					{
+						ApplicationInfo: ApplicationInfo{
+							ApplicationID:        "app-id-1",
+							ApplicationName:      "app-name-1",
+							ApplicationURL:       "app-url-1",
+							EnvID:                "env-id-1",
+							EnvURL:               "env-url-1",
+							ApplicationKind:      "app-kind-1",
+							ApplicationDirectory: "app-dir-1",
+						},
+						SyncStrategy: "PIPELINE",
+						PlanSummary:  "plan-summary-1",
+						PlanDetails:  "plan-details-1",
+						NoChange:     false,
+					},
+					{
+						ApplicationInfo: ApplicationInfo{
+							ApplicationID:        "app-id-3",
+							ApplicationName:      "app-name-3",
+							ApplicationURL:       "app-url-3",
+							EnvID:                "env-id-3",
+							EnvURL:               "env-url-3",
+							ApplicationKind:      "app-kind-3",
+							ApplicationDirectory: "app-dir-3",
+						},
+						SyncStrategy: "PIPELINE",
+						PlanSummary:  "",
+						PlanDetails:  "",
+						NoChange:     true,
+					},
+				},
+			},
+			expected: `<!-- pipecd-plan-preview-->
+[![PLAN_PREVIEW](https://img.shields.io/static/v1?label=PipeCD&message=Plan_Preview&color=success&style=flat)](https://pipecd.dev/docs/user-guide/plan-preview/)
+
+Ran plan-preview against head commit abc of this pull request. PipeCD detected ` + "`3`" + ` updated applications and here are their plan results. Once this pull request got merged their deployments will be triggered to run as these estimations.
+
+## app: [app-name-1](app-url-1), env: [](env-url-1), kind: app-kind-1
+Sync strategy: PIPELINE
+Summary: plan-summary-1
+
+<details>
+<summary>Details (Click me)</summary>
+<p>
+
+` + "```" + ` diff
+plan-details-1
+` + "```" + `
+</p>
+</details>
+
+## No resource changes were detected but the following apps will also be triggered
+
+### ` + "`PIPELINE`" + `
+
+- app: [app-name-3](app-url-3), env: [](env-url-3), kind: app-kind-3
+
+### ` + "`QUICK_SYNC`" + `
+
+- app: [app-name-2](app-url-2), env: [](env-url-2), kind: app-kind-2
+`,
+		},
+		{
+			name: "has failed app",
+			event: githubEvent{
+				HeadCommit: "abc",
+			},
+			result: PlanPreviewResult{
+				Applications: []ApplicationResult{
+					{
+						ApplicationInfo: ApplicationInfo{
+							ApplicationID:        "app-id-1",
+							ApplicationName:      "app-name-1",
+							ApplicationURL:       "app-url-1",
+							EnvID:                "env-id-1",
+							EnvURL:               "env-url-1",
+							ApplicationKind:      "app-kind-1",
+							ApplicationDirectory: "app-dir-1",
+						},
+						SyncStrategy: "PIPELINE",
+						PlanSummary:  "plan-summary-1",
+						PlanDetails:  "plan-details-1",
+						NoChange:     false,
+					},
+				},
+				FailureApplications: []FailureApplication{
+					{
+						ApplicationInfo: ApplicationInfo{
+							ApplicationID:        "app-id-2",
+							ApplicationName:      "app-name-2",
+							ApplicationURL:       "app-url-2",
+							EnvID:                "env-id-2",
+							EnvURL:               "env-url-2",
+							ApplicationKind:      "app-kind-2",
+							ApplicationDirectory: "app-dir-2",
+						},
+						Reason:      "reason-2",
+						PlanDetails: "",
+					},
+				},
+			},
+			expected: `<!-- pipecd-plan-preview-->
+[![PLAN_PREVIEW](https://img.shields.io/static/v1?label=PipeCD&message=Plan_Preview&color=orange&style=flat)](https://pipecd.dev/docs/user-guide/plan-preview/)
+
+Ran plan-preview against head commit abc of this pull request. PipeCD detected ` + "`1`" + ` updated applications and here are their plan results. Once this pull request got merged their deployments will be triggered to run as these estimations.
+
+## app: [app-name-1](app-url-1), env: [](env-url-1), kind: app-kind-1
+Sync strategy: PIPELINE
+Summary: plan-summary-1
+
+<details>
+<summary>Details (Click me)</summary>
+<p>
+
+` + "```" + ` diff
+plan-details-1
+` + "```" + `
+</p>
+</details>
+
+---
+
+## NOTE
+
+**An error occurred while building plan-preview for the following applications**
+
+## app: [app-name-2](app-url-2), env: [](env-url-2), kind: app-kind-2
+Reason: reason-2
+
+<details>
+<summary>Details (Click me)</summary>
+<p>
+
+` + "```" + ` diff
+
+` + "```" + `
+</p>
+</details>
+`,
+		},
+		{
+			name: "has failed piped",
+			event: githubEvent{
+				HeadCommit: "abc",
+			},
+			result: PlanPreviewResult{
+				Applications: []ApplicationResult{
+					{
+						ApplicationInfo: ApplicationInfo{
+							ApplicationID:        "app-id-1",
+							ApplicationName:      "app-name-1",
+							ApplicationURL:       "app-url-1",
+							EnvID:                "env-id-1",
+							EnvURL:               "env-url-1",
+							ApplicationKind:      "app-kind-1",
+							ApplicationDirectory: "app-dir-1",
+						},
+						SyncStrategy: "PIPELINE",
+						PlanSummary:  "plan-summary-1",
+						PlanDetails:  "plan-details-1",
+						NoChange:     false,
+					},
+				},
+				FailurePipeds: []FailurePiped{
+					{
+						PipedInfo: PipedInfo{
+							PipedID:  "piped-id-1",
+							PipedURL: "piped-url-1",
+						},
+						Reason: "piped-reason-1",
+					},
+				},
+			},
+			expected: `<!-- pipecd-plan-preview-->
+[![PLAN_PREVIEW](https://img.shields.io/static/v1?label=PipeCD&message=Plan_Preview&color=orange&style=flat)](https://pipecd.dev/docs/user-guide/plan-preview/)
+
+Ran plan-preview against head commit abc of this pull request. PipeCD detected ` + "`1`" + ` updated applications and here are their plan results. Once this pull request got merged their deployments will be triggered to run as these estimations.
+
+## app: [app-name-1](app-url-1), env: [](env-url-1), kind: app-kind-1
+Sync strategy: PIPELINE
+Summary: plan-summary-1
+
+<details>
+<summary>Details (Click me)</summary>
+<p>
+
+` + "```" + ` diff
+plan-details-1
+` + "```" + `
+</p>
+</details>
+
+---
+
+## NOTE
+
+**An error occurred while building plan-preview for applications of the following Pipeds**
+
+## piped: [piped-id-1](piped-url-1)
+Reason: piped-reason-1
+
+`,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := makeCommentBody(&tc.event, &tc.result)
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #2298

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Make plan-preview comment more readable in case there are some unchanged applications
```
