### PR TITLE
Fix flaky piped stat builder test

### DIFF
--- a/pkg/app/ops/pipedstatsbuilder/builder_test.go
+++ b/pkg/app/ops/pipedstatsbuilder/builder_test.go
@@ -65,10 +65,10 @@ func TestBuildPipedStat(t *testing.T) {
 
 	buf := new(strings.Builder)
 	io.Copy(buf, rc)
-	actOutElements := strings.Split(buf.String(), "\n\n")
+	actOutElements := strings.Split(strings.TrimSuffix(buf.String(), "\n"), "\n\n")
 
 	data, _ := os.ReadFile("./testdata/expected")
-	expOutElements := strings.Split(string(data), "\n\n")
+	expOutElements := strings.Split(strings.TrimSuffix(string(data), "\n"), "\n\n")
 
 	require.Equal(t, len(expOutElements), len(actOutElements))
 	assert.ElementsMatch(t, expOutElements, actOutElements)

--- a/pkg/app/ops/pipedstatsbuilder/builder_test.go
+++ b/pkg/app/ops/pipedstatsbuilder/builder_test.go
@@ -62,8 +62,14 @@ func TestBuildPipedStat(t *testing.T) {
 	rc, err := builder.Build()
 	require.NoError(t, err)
 	require.NotNil(t, rc)
+
 	buf := new(strings.Builder)
 	io.Copy(buf, rc)
+	actOutElements := strings.Split(buf.String(), "\n\n")
+
 	data, _ := os.ReadFile("./testdata/expected")
-	assert.Equal(t, string(data), buf.String())
+	expOutElements := strings.Split(string(data), "\n\n")
+
+	require.Equal(t, len(expOutElements), len(actOutElements))
+	assert.ElementsMatch(t, expOutElements, actOutElements)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, the bytes stream returned by `PipedStatsBuilder.Build` has inconsistent order (cause by Golang hash map[string]interface which provided by its backend `hashcache.GetAll` call). Since we don't care about the order of that bytes stream, lets update the test assert to make it compares in a more flexible way.

ref: https://github.com/pipe-cd/pipe/blob/master/pkg/app/ops/pipedstatsbuilder/builder.go#L47

**Which issue(s) this PR fixes**:

Related to https://github.com/pipe-cd/pipe/pull/2299#issuecomment-886516252

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
