### PR TITLE
Use labels to distinguish what component's metrics

### DIFF
--- a/cmd/pipecd/ops.go
+++ b/cmd/pipecd/ops.go
@@ -234,7 +234,9 @@ func ensureSQLDatabase(ctx context.Context, cfg *config.ControlPlaneSpec, logger
 
 func registerOpsMetrics(col ...prometheus.Collector) *prometheus.Registry {
 	r := prometheus.NewRegistry()
-	wrapped := prometheus.WrapRegistererWithPrefix("pipecd_ops_", r)
+	wrapped := prometheus.WrapRegistererWith(map[string]string{
+		"pipecd_component": "ops",
+	}, r)
 
 	wrapped.Register(prometheus.NewGoCollector())
 	wrapped.Register(prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}))

--- a/cmd/pipecd/server.go
+++ b/cmd/pipecd/server.go
@@ -474,7 +474,7 @@ func registerMetrics() *prometheus.Registry {
 	wrapped.Register(prometheus.NewGoCollector())
 	wrapped.Register(prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}))
 
-	cachemetrics.Register(r)
-	httpapimetrics.Register(r)
+	cachemetrics.Register(wrapped)
+	httpapimetrics.Register(wrapped)
 	return r
 }

--- a/pkg/app/piped/cmd/piped/piped.go
+++ b/pkg/app/piped/cmd/piped/piped.go
@@ -678,16 +678,11 @@ func (p *piped) getConfigDataFromSecretManager(ctx context.Context) ([]byte, err
 
 func registerMetrics(pipedID string) *prometheus.Registry {
 	r := prometheus.NewRegistry()
-	wrapped := prometheus.WrapRegistererWithPrefix(
-		"piped_",
-		prometheus.WrapRegistererWith(
-			prometheus.Labels{
-				"piped":         pipedID,
-				"piped_version": version.Get().Version,
-			},
-			r,
-		),
-	)
+	wrapped := prometheus.WrapRegistererWith(map[string]string{
+		"pipecd_component": "piped",
+		"piped":            pipedID,
+		"piped_version":    version.Get().Version,
+	}, r)
 	wrapped.Register(prometheus.NewGoCollector())
 	wrapped.Register(prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}))
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR stops distinguishing component by using other metrics name, instead settled on using labels like `go_goroutines{pipecd_component="ops"} 23`

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
