### PR TITLE
Remove cache package from pkg/cli dependencies list

### DIFF
--- a/pkg/app/ops/pipedstatsbuilder/builder.go
+++ b/pkg/app/ops/pipedstatsbuilder/builder.go
@@ -46,8 +46,12 @@ func NewPipedStatsBuilder(c cache.Cache, logger *zap.Logger) *PipedStatsBuilder 
 func (b *PipedStatsBuilder) Build() (io.Reader, error) {
 	res, err := b.backend.GetAll()
 	if err != nil {
-		b.logger.Error("failed to fetch piped stats from cache", zap.Error(err))
-		return nil, err
+		// Only show error in case it's not cache not found error.
+		if !errors.Is(err, cache.ErrNotFound) {
+			b.logger.Error("failed to fetch piped stats from cache", zap.Error(err))
+			return nil, err
+		}
+		return bytes.NewReader([]byte("")), nil
 	}
 	data := make([][]byte, 0, len(res))
 	for _, v := range res {

--- a/pkg/cli/BUILD.bazel
+++ b/pkg/cli/BUILD.bazel
@@ -9,7 +9,6 @@ go_library(
     importpath = "github.com/pipe-cd/pipe/pkg/cli",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/cache:go_default_library",
         "//pkg/log:go_default_library",
         "//pkg/version:go_default_library",
         "@com_github_prometheus_client_golang//prometheus:go_default_library",

--- a/pkg/cli/cmd.go
+++ b/pkg/cli/cmd.go
@@ -16,7 +16,6 @@ package cli
 
 import (
 	"context"
-	"errors"
 	"io"
 	"net/http"
 	"os"
@@ -32,7 +31,6 @@ import (
 	"go.uber.org/zap"
 	"google.golang.org/api/option"
 
-	"github.com/pipe-cd/pipe/pkg/cache"
 	"github.com/pipe-cd/pipe/pkg/log"
 	"github.com/pipe-cd/pipe/pkg/version"
 )
@@ -178,10 +176,7 @@ func (t Telemetry) CustomMetricsHandlerFor(reg prometheus.Gatherer, mb MetricsBu
 
 		rc, err := mb.Build()
 		if err != nil {
-			// Only show error in case it's not cache not found error.
-			if !errors.Is(err, cache.ErrNotFound) {
-				http.Error(w, err.Error(), http.StatusInternalServerError)
-			}
+			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Should handle cache.ErrNotFound error in pipedStatBuilder instead of handler layer.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
