### PR TITLE
Update the size of PersistentVolume Prometheus uses

### DIFF
--- a/manifests/pipecd/values.yaml
+++ b/manifests/pipecd/values.yaml
@@ -151,6 +151,9 @@ prometheus:
       receivers: []
   server:
     configMapOverrideName: prometheus-server
+    retention: 7d
+    persistentVolume:
+      size: 4Gi
 
 # All directives inside this section will be directly sent to the grafana chart.
 # Head to the below link to see all available values.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR changes the Prometheus retention to `1w` and disk size of PersistentVolume

**How many times does Prometheus pull within a week?**
Prometheus tries to pull per 60 seconds so:
604800s(=1w) / 60 = **10080**

**The number of series is currently:**
`count({__name__=~“.+“})` **57114**

**How many samples should Prometheus hold?**
57114 * 10080 = **575,709,120**

**How much space should we prepare?**
On average, Prometheus uses only [around 1-2 bytes per sample](https://prometheus.io/docs/prometheus/latest/storage/#operational-aspects). All are 2bytes in worst case scenario.
575,709,120 * 2 = 1,151,418,240 bytes ≈ **1.072 GB**

Plus there are others like indexes so we need about `1.2GB` at this point.

It's enough to have 2Gi so far. But we can't expect the size of cluster stats because it's depending on the cluster Pipecd runs on. Besides, considering the possibility of getting more time series (as it's in the middle of improving), I settled on allocating 4Gi for now.  For those who use a huge cluster that makes series cardinality higher, it's good to change the size through the Helm value.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
