### PR TITLE
Support Google IAP for Grafana Ingress

### DIFF
--- a/manifests/pipecd/templates/backend-config.yaml
+++ b/manifests/pipecd/templates/backend-config.yaml
@@ -8,7 +8,6 @@ spec:
     enabled: {{ .Values.backendConfig.iap.enabled }}
     oauthclientCredentials:
       secretName: {{ .Values.backendConfig.iap.secretName }}
-
 {{- end }}
 
 {{- if .Values.monitoring.backendConfig.enabled -}}

--- a/manifests/pipecd/templates/backend-config.yaml
+++ b/manifests/pipecd/templates/backend-config.yaml
@@ -8,4 +8,18 @@ spec:
     enabled: {{ .Values.backendConfig.iap.enabled }}
     oauthclientCredentials:
       secretName: {{ .Values.backendConfig.iap.secretName }}
+
+
+{{- if .Values.grafana.ingress.enabled -}}
+---
+apiVersion: cloud.google.com/v1beta1
+kind: BackendConfig
+metadata:
+  name: {{ include "pipecd.fullname" . }}-grafana
+spec:
+  iap:
+    enabled: {{ .Values.backendConfig.iap.enabled }}
+    oauthclientCredentials:
+      secretName: {{ .Values.backendConfig.iap.secretName }}
+{{- end }}
 {{- end }}

--- a/manifests/pipecd/templates/backend-config.yaml
+++ b/manifests/pipecd/templates/backend-config.yaml
@@ -9,8 +9,9 @@ spec:
     oauthclientCredentials:
       secretName: {{ .Values.backendConfig.iap.secretName }}
 
+{{- end }}
 
-{{- if .Values.grafana.ingress.enabled -}}
+{{- if .Values.monitoring.backendConfig.enabled -}}
 ---
 apiVersion: cloud.google.com/v1beta1
 kind: BackendConfig
@@ -18,8 +19,7 @@ metadata:
   name: {{ include "pipecd.fullname" . }}-grafana
 spec:
   iap:
-    enabled: {{ .Values.backendConfig.iap.enabled }}
+    enabled: {{ .Values.monitoring.backendConfig.iap.enabled }}
     oauthclientCredentials:
-      secretName: {{ .Values.backendConfig.iap.secretName }}
-{{- end }}
+      secretName: {{ .Values.monitoring.backendConfig.iap.secretName }}
 {{- end }}

--- a/manifests/pipecd/values.yaml
+++ b/manifests/pipecd/values.yaml
@@ -160,6 +160,10 @@ prometheus:
 # https://github.com/grafana/helm-charts/tree/main/charts/grafana
 grafana:
   adminPassword: admin
+  ingress:
+    enabled: false
+    hosts: []
+    path: /*
   sidecar:
     datasources:
       enabled: true

--- a/manifests/pipecd/values.yaml
+++ b/manifests/pipecd/values.yaml
@@ -121,6 +121,12 @@ monitoring:
   # If true, cluster stats will be collected and shown on the dashboard.
   # It includes stats for Nodes, Pods and so on.
   clusterStats: false
+  # Optional configuration for GKE.
+  backendConfig:
+    enabled: false
+    iap:
+      enabled: false
+      secretName: pipecd-grafana-iap
 
 # All directives inside this section will be directly sent to the prometheus chart.
 # Head to the below link to see all available values.

--- a/manifests/site/templates/ingress.yaml
+++ b/manifests/site/templates/ingress.yaml
@@ -22,4 +22,4 @@ spec:
   backend:
     serviceName: {{ $fullName }}
     servicePort: {{ $svcPort }}
-  {{- end }}
+{{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR allows creating BackendConfig for Grafana through Helm value. This is quite useful for those who want their members to authenticate to Grafana using Google IAP.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
