### PR TITLE
Make it possible to create ManagedCertificate dedicated for Grafana

### DIFF
--- a/manifests/pipecd/templates/managed-certificate.yaml
+++ b/manifests/pipecd/templates/managed-certificate.yaml
@@ -9,3 +9,16 @@ spec:
   - {{ . }}
   {{- end }}
 {{- end }}
+
+{{- if .Values.monitoring.managedCertificate.enabled -}}
+---
+apiVersion: networking.gke.io/v1beta2
+kind: ManagedCertificate
+metadata:
+  name: {{ include "pipecd.fullname" . }}-grafana
+spec:
+  domains:
+  {{- range .Values.monitoring.managedCertificate.domains }}
+  - {{ . }}
+  {{- end }}
+{{- end }}

--- a/manifests/pipecd/values.yaml
+++ b/manifests/pipecd/values.yaml
@@ -127,6 +127,9 @@ monitoring:
     iap:
       enabled: false
       secretName: pipecd-monitoring-iap
+  managedCertificate:
+    enabled: false
+    domains: []
 
 # All directives inside this section will be directly sent to the prometheus chart.
 # Head to the below link to see all available values.


### PR DESCRIPTION
**What this PR does / why we need it**:
Different resources can't share the same ManagedCertificate. So I settled on creating a new one.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
