### PR TITLE
Ensure to register grpc server metrics to custom Prometheus registerer

### DIFF
--- a/cmd/pipecd/BUILD.bazel
+++ b/cmd/pipecd/BUILD.bazel
@@ -49,6 +49,7 @@ go_library(
         "//pkg/rpc:go_default_library",
         "//pkg/version:go_default_library",
         "@com_github_golang_jwt_jwt//:go_default_library",
+        "@com_github_grpc_ecosystem_go_grpc_prometheus//:go_default_library",
         "@com_github_prometheus_client_golang//prometheus:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",
         "@org_golang_x_sync//errgroup:go_default_library",

--- a/cmd/pipecd/server.go
+++ b/cmd/pipecd/server.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	jwtgo "github.com/golang-jwt/jwt"
+	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
@@ -473,6 +474,7 @@ func registerMetrics() *prometheus.Registry {
 
 	wrapped.Register(prometheus.NewGoCollector())
 	wrapped.Register(prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}))
+	wrapped.Register(grpc_prometheus.DefaultServerMetrics)
 
 	cachemetrics.Register(wrapped)
 	httpapimetrics.Register(wrapped)


### PR DESCRIPTION
**What this PR does / why we need it**:
The `go_grpc_prometheus` package registers its counters to the default registerer in advance, but for custom one, it's needed to register manually. After adopting the custom one, we're losing grpc metrics until now.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
