### PR TITLE
Return InvalidArgument code when Piped tries to operate deleted app

### DIFF
--- a/pkg/datastore/applicationstore.go
+++ b/pkg/datastore/applicationstore.go
@@ -73,7 +73,7 @@ func (s *applicationStore) EnableApplication(ctx context.Context, id string) err
 	return s.ds.Update(ctx, ApplicationModelKind, id, applicationFactory, func(e interface{}) error {
 		app := e.(*model.Application)
 		if app.Deleted {
-			return errors.New("unable to enable a deleted application")
+			return fmt.Errorf("can't enable a deleted application: %w", ErrInvalidArgument)
 		}
 		app.Disabled = false
 		app.UpdatedAt = s.nowFunc().Unix()
@@ -85,7 +85,7 @@ func (s *applicationStore) DisableApplication(ctx context.Context, id string) er
 	return s.ds.Update(ctx, ApplicationModelKind, id, applicationFactory, func(e interface{}) error {
 		app := e.(*model.Application)
 		if app.Deleted {
-			return errors.New("unable to disable a deleted application")
+			return fmt.Errorf("can't disable a deleted application: %w", ErrInvalidArgument)
 		}
 		app.Disabled = true
 		app.UpdatedAt = s.nowFunc().Unix()

--- a/pkg/datastore/applicationstore.go
+++ b/pkg/datastore/applicationstore.go
@@ -16,7 +16,6 @@ package datastore
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 

--- a/pkg/datastore/applicationstore.go
+++ b/pkg/datastore/applicationstore.go
@@ -73,7 +73,7 @@ func (s *applicationStore) EnableApplication(ctx context.Context, id string) err
 	return s.ds.Update(ctx, ApplicationModelKind, id, applicationFactory, func(e interface{}) error {
 		app := e.(*model.Application)
 		if app.Deleted {
-			return fmt.Errorf("can't enable a deleted application: %w", ErrInvalidArgument)
+			return fmt.Errorf("cannot enable a deleted application: %w", ErrInvalidArgument)
 		}
 		app.Disabled = false
 		app.UpdatedAt = s.nowFunc().Unix()
@@ -85,7 +85,7 @@ func (s *applicationStore) DisableApplication(ctx context.Context, id string) er
 	return s.ds.Update(ctx, ApplicationModelKind, id, applicationFactory, func(e interface{}) error {
 		app := e.(*model.Application)
 		if app.Deleted {
-			return fmt.Errorf("can't disable a deleted application: %w", ErrInvalidArgument)
+			return fmt.Errorf("cannot disable a deleted application: %w", ErrInvalidArgument)
 		}
 		app.Disabled = true
 		app.UpdatedAt = s.nowFunc().Unix()
@@ -147,7 +147,7 @@ func (s *applicationStore) UpdateApplication(ctx context.Context, id string, upd
 	return s.ds.Update(ctx, ApplicationModelKind, id, applicationFactory, func(e interface{}) error {
 		a := e.(*model.Application)
 		if a.Deleted {
-			return fmt.Errorf("can't update a deleted application: %w", ErrInvalidArgument)
+			return fmt.Errorf("cannot update a deleted application: %w", ErrInvalidArgument)
 		}
 		if err := updater(a); err != nil {
 			return err

--- a/pkg/datastore/applicationstore.go
+++ b/pkg/datastore/applicationstore.go
@@ -17,6 +17,7 @@ package datastore
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/pipe-cd/pipe/pkg/model"
@@ -146,7 +147,7 @@ func (s *applicationStore) UpdateApplication(ctx context.Context, id string, upd
 	return s.ds.Update(ctx, ApplicationModelKind, id, applicationFactory, func(e interface{}) error {
 		a := e.(*model.Application)
 		if a.Deleted {
-			return errors.New("unable to update a deleted application")
+			return fmt.Errorf("can't update a deleted application: %w", ErrInvalidArgument)
 		}
 		if err := updater(a); err != nil {
 			return err


### PR DESCRIPTION
**What this PR does / why we need it**:
Updating a deleted application shouldn't handled as an internal error.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
