### PR TITLE
Show event id when registering event succeeded

### DIFF
--- a/pkg/app/api/grpcapi/api.go
+++ b/pkg/app/api/grpcapi/api.go
@@ -389,9 +389,10 @@ func (a *API) RegisterEvent(ctx context.Context, req *apiservice.RegisterEventRe
 	if err != nil {
 		return nil, err
 	}
+	id := uuid.New().String()
 
 	err = a.eventStore.AddEvent(ctx, model.Event{
-		Id:        uuid.New().String(),
+		Id:        id,
 		Name:      req.Name,
 		Data:      req.Data,
 		Labels:    req.Labels,
@@ -406,7 +407,9 @@ func (a *API) RegisterEvent(ctx context.Context, req *apiservice.RegisterEventRe
 		return nil, status.Error(codes.Internal, "Failed to register event")
 	}
 
-	return &apiservice.RegisterEventResponse{}, nil
+	return &apiservice.RegisterEventResponse{
+		EventId: id,
+	}, nil
 }
 
 func (a *API) RequestPlanPreview(ctx context.Context, req *apiservice.RequestPlanPreviewRequest) (*apiservice.RequestPlanPreviewResponse, error) {

--- a/pkg/app/api/service/apiservice/service.proto
+++ b/pkg/app/api/service/apiservice/service.proto
@@ -124,6 +124,7 @@ message RegisterEventRequest {
 }
 
 message RegisterEventResponse {
+    string event_id = 1 [(validate.rules).string.min_len = 1];
 }
 
 message RequestPlanPreviewRequest {

--- a/pkg/app/pipectl/cmd/event/BUILD.bazel
+++ b/pkg/app/pipectl/cmd/event/BUILD.bazel
@@ -13,5 +13,6 @@ go_library(
         "//pkg/app/pipectl/client:go_default_library",
         "//pkg/cli:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",
+        "@org_uber_go_zap//:go_default_library",
     ],
 )

--- a/pkg/app/pipectl/cmd/event/register.go
+++ b/pkg/app/pipectl/cmd/event/register.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+	"go.uber.org/zap"
 
 	"github.com/pipe-cd/pipe/pkg/app/api/service/apiservice"
 	"github.com/pipe-cd/pipe/pkg/cli"
@@ -65,10 +66,13 @@ func (r *register) run(ctx context.Context, t cli.Telemetry) error {
 		Labels: r.labels,
 	}
 
-	if _, err := cli.RegisterEvent(ctx, req); err != nil {
+	res, err := cli.RegisterEvent(ctx, req)
+	if err != nil {
 		return fmt.Errorf("failed to register event: %w", err)
 	}
 
-	t.Logger.Info("Successfully registered event")
+	t.Logger.Info("Successfully registered event",
+		zap.String("id", res.EventId),
+	)
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Once got successful, it shows like
```
Successfully registered event {"id": "xxx"}
```

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
