### PR TITLE
Change Prometheus pod update strategy to Recreate

### DIFF
--- a/manifests/pipecd/values.yaml
+++ b/manifests/pipecd/values.yaml
@@ -163,6 +163,8 @@ prometheus:
     retention: 7d
     persistentVolume:
       size: 4Gi
+    strategy:
+      type: Recreate
 
 # All directives inside this section will be directly sent to the grafana chart.
 # Head to the below link to see all available values.


### PR DESCRIPTION
**What this PR does / why we need it**:
Using `--storage.tsdb.no-lockfile` is a bit dangerous because possibly a newly created process could try to write the disk where the old one is writing.

This change causes a bit down time but seems like it's better as a workaround at least compared to using that flag.

**Which issue(s) this PR fixes**:

Fixes https://github.com/pipe-cd/pipe/issues/2348

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
