### PR TITLE
Remove metrics arg from command to install Piped on google cloud vm

### DIFF
--- a/docs/content/en/docs/operator-manual/piped/installation/installing-on-google-cloud-vm.md
+++ b/docs/content/en/docs/operator-manual/piped/installation/installing-on-google-cloud-vm.md
@@ -106,7 +106,6 @@ description: >
   gcloud compute instances create-with-container vm-piped \
     --container-image="gcr.io/pipecd/piped:{{< blocks/latest_version >}}" \
     --container-arg="piped" \
-    --container-arg="--metrics=true" \
     --container-arg="--config-gcp-secret=projects/{GCP_PROJECT_ID}/secrets/vm-piped-config/versions/{SECRET_VERSION}" \
     --network="{VPC_NETWORK}" \
     --subnet="{VPC_SUBNET}" \


### PR DESCRIPTION
**What this PR does / why we need it**:

Because the metrics arg is already enabled by default.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
