### PR TITLE
Remove metrics arg from service manifest used to install Piped on Cloud Run

### DIFF
--- a/docs/content/en/docs/operator-manual/piped/installation/installing-on-cloudrun.md
+++ b/docs/content/en/docs/operator-manual/piped/installation/installing-on-cloudrun.md
@@ -94,7 +94,6 @@ description: >
           - image: gcr.io/pipecd/piped:{{< blocks/latest_version >}}
             args:
               - piped
-              - --metrics=true
               - --config-file=/etc/piped-config/config.yaml
             ports:
               - containerPort: 9085


### PR DESCRIPTION

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
