### PR TITLE
Add a new ops job to clean stale planpreview outputs

### DIFF
--- a/cmd/pipecd/BUILD.bazel
+++ b/cmd/pipecd/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
         "//pkg/app/ops/mysqlensurer:go_default_library",
         "//pkg/app/ops/orphancommandcleaner:go_default_library",
         "//pkg/app/ops/pipedstatsbuilder:go_default_library",
+        "//pkg/app/ops/planpreviewoutputcleaner:go_default_library",
         "//pkg/app/ops/staledpipedstatcleaner:go_default_library",
         "//pkg/cache/cachemetrics:go_default_library",
         "//pkg/cache/rediscache:go_default_library",

--- a/cmd/pipecd/ops.go
+++ b/cmd/pipecd/ops.go
@@ -162,7 +162,7 @@ func (s *ops) run(ctx context.Context, t cli.Telemetry) error {
 
 	// Start running planpreview output cleaner.
 	{
-		cleaner := planpreviewoutputcleaner.NewCleaner(fs, fs, t.Logger)
+		cleaner := planpreviewoutputcleaner.NewCleaner(fs, t.Logger)
 		group.Go(func() error {
 			return cleaner.Run(ctx)
 		})

--- a/pkg/app/ops/planpreviewoutputcleaner/BUILD.bazel
+++ b/pkg/app/ops/planpreviewoutputcleaner/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["cleaner.go"],
+    importpath = "github.com/pipe-cd/pipe/pkg/app/ops/planpreviewoutputcleaner",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/filestore:go_default_library",
+        "@org_uber_go_zap//:go_default_library",
+    ],
+)

--- a/pkg/app/ops/planpreviewoutputcleaner/cleaner.go
+++ b/pkg/app/ops/planpreviewoutputcleaner/cleaner.go
@@ -1,0 +1,97 @@
+// Copyright 2021 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package planpreviewoutputcleaner
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/pipe-cd/pipe/pkg/filestore"
+)
+
+const (
+	outputTTL = 48 * time.Hour
+	interval  = 24 * time.Hour
+	prefix    = "command-output/"
+)
+
+type Cleaner struct {
+	lister  filestore.Lister
+	deleter filestore.Deleter
+	logger  *zap.Logger
+}
+
+func NewCleaner(l filestore.Lister, d filestore.Deleter, logger *zap.Logger) *Cleaner {
+	return &Cleaner{
+		lister:  l,
+		deleter: d,
+		logger:  logger.Named("planpreview-output-cleaner"),
+	}
+}
+
+func (c *Cleaner) Run(ctx context.Context) error {
+	c.logger.Info("start running planpreview ouput cleaner")
+
+	t := time.NewTicker(interval)
+	for {
+		select {
+		case <-ctx.Done():
+			break
+
+		case t := <-t.C:
+			c.clean(ctx, t)
+		}
+	}
+
+	c.logger.Info("planpreview output cleaner has been stopped")
+	return nil
+}
+
+func (c *Cleaner) clean(ctx context.Context, now time.Time) error {
+	objects, err := c.lister.List(ctx, prefix)
+	if err != nil {
+		c.logger.Error("failed to list planpreview output objects",
+			zap.String("prefix", prefix),
+			zap.Error(err),
+		)
+		return err
+	}
+
+	ttl := outputTTL.Seconds()
+	deletes := 0
+
+	for _, obj := range objects {
+		if float64(now.Unix()-obj.UpdatedAt) <= ttl {
+			continue
+		}
+		if err := c.deleter.Delete(ctx, obj.Path); err != nil {
+			c.logger.Error("failed to delete planpreview output object",
+				zap.String("path", obj.Path),
+				zap.Error(err),
+			)
+			continue
+		}
+		c.logger.Info("successfully deleted a stale planpreview output",
+			zap.String("path", obj.Path),
+		)
+		deletes++
+	}
+
+	c.logger.Info(fmt.Sprintf("deleted %d/%d stale planpreview outputs", deletes, len(objects)))
+	return nil
+}

--- a/pkg/app/ops/planpreviewoutputcleaner/cleaner.go
+++ b/pkg/app/ops/planpreviewoutputcleaner/cleaner.go
@@ -56,8 +56,8 @@ func (c *Cleaner) Run(ctx context.Context) error {
 		case <-ctx.Done():
 			break
 
-		case t := <-t.C:
-			c.clean(ctx, t)
+		case <-t.C:
+			c.clean(ctx)
 		}
 	}
 
@@ -65,7 +65,7 @@ func (c *Cleaner) Run(ctx context.Context) error {
 	return nil
 }
 
-func (c *Cleaner) clean(ctx context.Context, now time.Time) error {
+func (c *Cleaner) clean(ctx context.Context) error {
 	objects, err := c.store.List(ctx, prefix)
 	if err != nil {
 		c.logger.Error("failed to list planpreview output objects",
@@ -76,6 +76,7 @@ func (c *Cleaner) clean(ctx context.Context, now time.Time) error {
 	}
 
 	ttl := outputTTL.Seconds()
+	now := time.Now()
 	deletes := 0
 
 	for _, obj := range objects {


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #2285

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Add a new ops job to clean stale plan-preview outputs
```
