### PR TITLE
Add sql service account

### DIFF
--- a/manifests/pipecd/templates/secret.yaml
+++ b/manifests/pipecd/templates/secret.yaml
@@ -16,6 +16,9 @@ data:
 {{- if .Values.secret.gcsServiceAccount.data }}
   {{ .Values.secret.gcsServiceAccount.fileName }}: {{ .Values.secret.gcsServiceAccount.data | b64enc | quote }}
 {{- end }}
+{{- if .Values.secret.sqlServiceAccount.data }}
+  {{ .Values.secret.sqlServiceAccount.fileName }}: {{ .Values.secret.sqlServiceAccount.data | b64enc | quote }}
+{{- end }}
 {{- if .Values.secret.minioAccessKey.data }}
   {{ .Values.secret.minioAccessKey.fileName }}: {{ .Values.secret.minioAccessKey.data | b64enc | quote }}
 {{- end }}

--- a/manifests/pipecd/templates/secret.yaml
+++ b/manifests/pipecd/templates/secret.yaml
@@ -16,8 +16,8 @@ data:
 {{- if .Values.secret.gcsServiceAccount.data }}
   {{ .Values.secret.gcsServiceAccount.fileName }}: {{ .Values.secret.gcsServiceAccount.data | b64enc | quote }}
 {{- end }}
-{{- if .Values.secret.sqlServiceAccount.data }}
-  {{ .Values.secret.sqlServiceAccount.fileName }}: {{ .Values.secret.sqlServiceAccount.data | b64enc | quote }}
+{{- if .Values.secret.cloudSQLServiceAccount.data }}
+  {{ .Values.secret.cloudSQLServiceAccount.fileName }}: {{ .Values.secret.cloudSQLServiceAccount.data | b64enc | quote }}
 {{- end }}
 {{- if .Values.secret.minioAccessKey.data }}
   {{ .Values.secret.minioAccessKey.fileName }}: {{ .Values.secret.minioAccessKey.data | b64enc | quote }}

--- a/manifests/pipecd/values.yaml
+++ b/manifests/pipecd/values.yaml
@@ -83,6 +83,9 @@ secret:
   gcsServiceAccount:
     fileName: "gcs-service-account"
     data: ""
+  sqlServiceAccount:
+    fileName: "sql-service-account"
+    data: ""
   minioAccessKey:
     fileName: "minio-access-key"
     data: ""

--- a/manifests/pipecd/values.yaml
+++ b/manifests/pipecd/values.yaml
@@ -83,8 +83,8 @@ secret:
   gcsServiceAccount:
     fileName: "gcs-service-account"
     data: ""
-  sqlServiceAccount:
-    fileName: "sql-service-account"
+  cloudSQLServiceAccount:
+    fileName: "cloud-sql-service-account"
     data: ""
   minioAccessKey:
     fileName: "minio-access-key"


### PR DESCRIPTION
**What this PR does / why we need it**:

Add sqlServiceAccount as helm values. It will be used to enable connect from PipeCD workload to GCP Cloud SQL using Cloud SQL Auth proxy.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
