### PR TITLE
Add Cloud SQL Proxy as server and ops sidecar

### DIFF
--- a/manifests/pipecd/templates/deployment.yaml
+++ b/manifests/pipecd/templates/deployment.yaml
@@ -85,6 +85,24 @@ spec:
         app.kubernetes.io/component: server
     spec:
       containers:
+{{- if .Value.cloudSQLProxy.enabled }}
+        - name: cloud-sql-proxy
+          image: "gcr.io/cloudsql-docker/gce-proxy:{{ .Values.cloudSQLProxy.version }}"
+          command:
+            - "/cloud_sql_proxy"
+            - "-instances={{ .Values.cloudSQLProxy.args.instanceConnectionName }}=tcp:{{ .Values.cloudSQLProxy.args.port }}"
+            - "-credential_file={{ .Values.secret.mountPath }}/service_account.json"
+          securityContext:
+            runAsNonRoot: true
+          volumeMounts:
+            - name: pipecd-secret
+              mountPath: {{ .Values.secret.mountPath }}
+              readOnly: true
+{{- if .Values.cloudSQLProxy.resources }}
+          resources:
+            {{- toYaml .Values.cloudSQLProxy.resources | nindent 12 }}
+{{- end }}
+{{- end }}
         - name: server
           image: "{{ .Values.server.image.repository }}:{{ .Chart.AppVersion }}"
           imagePullPolicy: IfNotPresent
@@ -210,6 +228,20 @@ spec:
         app.kubernetes.io/component: ops
     spec:
       containers:
+{{- if .Value.cloudSQLProxy.enabled }}
+        - name: cloud-sql-proxy
+          image: "gcr.io/cloudsql-docker/gce-proxy:{{ .Values.cloudSQLProxy.version }}"
+          command:
+            - "/cloud_sql_proxy"
+            - "-instances={{ .Values.cloudSQLProxy.args.instanceConnectionName }}=tcp:{{ .Values.cloudSQLProxy.args.port }}"
+            - "-credential_file={{ .Values.secret.mountPath }}/service_account.json"
+          securityContext:
+            runAsNonRoot: true
+          volumeMounts:
+            - name: pipecd-secret
+              mountPath: {{ .Values.secret.mountPath }}
+              readOnly: true
+{{- end }}
         - name: ops
           image: "{{ .Values.ops.image.repository }}:{{ .Chart.AppVersion }}"
           imagePullPolicy: IfNotPresent

--- a/manifests/pipecd/templates/deployment.yaml
+++ b/manifests/pipecd/templates/deployment.yaml
@@ -91,7 +91,7 @@ spec:
           command:
             - "/cloud_sql_proxy"
             - "-instances={{ .Values.cloudSQLProxy.args.instanceConnectionName }}=tcp:{{ .Values.cloudSQLProxy.args.port }}"
-            - "-credential_file={{ .Values.secret.mountPath }}/service_account.json"
+            - "-credential_file={{ .Values.secret.mountPath }}/cloud-sql-service-account"
           securityContext:
             runAsNonRoot: true
           volumeMounts:
@@ -234,7 +234,7 @@ spec:
           command:
             - "/cloud_sql_proxy"
             - "-instances={{ .Values.cloudSQLProxy.args.instanceConnectionName }}=tcp:{{ .Values.cloudSQLProxy.args.port }}"
-            - "-credential_file={{ .Values.secret.mountPath }}/service_account.json"
+            - "-credential_file={{ .Values.secret.mountPath }}/cloud-sql-service-account"
           securityContext:
             runAsNonRoot: true
           volumeMounts:

--- a/manifests/pipecd/templates/deployment.yaml
+++ b/manifests/pipecd/templates/deployment.yaml
@@ -91,7 +91,7 @@ spec:
           command:
             - "/cloud_sql_proxy"
             - "-instances={{ .Values.cloudSQLProxy.args.instanceConnectionName }}=tcp:{{ .Values.cloudSQLProxy.args.port }}"
-            - "-credential_file={{ .Values.secret.mountPath }}/cloud-sql-service-account"
+            - "-credential_file={{ .Values.secret.mountPath }}/{{ .Values.secret.cloudSQLServiceAccount.fileName }}"
           securityContext:
             runAsNonRoot: true
           volumeMounts:
@@ -234,7 +234,7 @@ spec:
           command:
             - "/cloud_sql_proxy"
             - "-instances={{ .Values.cloudSQLProxy.args.instanceConnectionName }}=tcp:{{ .Values.cloudSQLProxy.args.port }}"
-            - "-credential_file={{ .Values.secret.mountPath }}/cloud-sql-service-account"
+            - "-credential_file={{ .Values.secret.mountPath }}/{{ .Values.secret.cloudSQLServiceAccount.fileName }}"
           securityContext:
             runAsNonRoot: true
           volumeMounts:

--- a/manifests/pipecd/values.yaml
+++ b/manifests/pipecd/values.yaml
@@ -45,6 +45,14 @@ ops:
     metrics: true
   resources: {}
 
+cloudSQLProxy:
+  enable: false
+  version: 1.17
+  args:
+    instanceConnectionName: ""
+    port: 3306
+  resources: {}
+
 mysql:
   imageTag: "8.0.23"
   resources: {}

--- a/manifests/pipecd/values.yaml
+++ b/manifests/pipecd/values.yaml
@@ -46,7 +46,7 @@ ops:
   resources: {}
 
 cloudSQLProxy:
-  enable: false
+  enabled: false
   version: 1.17
   args:
     instanceConnectionName: ""


### PR DESCRIPTION
**What this PR does / why we need it**:

Add `cloud-sql-proxy` container as server and ops sidecar to enable connect to GCP Cloud SQL using Cloud SQL Auth proxy.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
