### PR TITLE
Update ops to run planpreview cleaner at a fixed time

### DIFF
--- a/pkg/app/ops/planpreviewoutputcleaner/BUILD.bazel
+++ b/pkg/app/ops/planpreviewoutputcleaner/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/filestore:go_default_library",
+        "@com_github_robfig_cron_v3//:go_default_library",
         "@org_uber_go_zap//:go_default_library",
     ],
 )


### PR DESCRIPTION
**What this PR does / why we need it**:

- Fix the time to run the job to make it becomes more predictable.
- This also ensures that the job will be executed once per day even if the ops was restarted or deployed. 

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
