### PR TITLE
Add make web-test command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,10 @@ web-dep:
 web-dev:
 	cd pkg/app/web; yarn dev
 
+.PHONY: web-test
+web-test:
+	cd pkg/app/web; yarn test:coverage --runInBand
+
 .PHONY: generate-test-tls
 generate-test-tls:
 	openssl req -x509 -nodes -days 3650 -newkey rsa:2048 \


### PR DESCRIPTION
**What this PR does / why we need it**:

Add `make web-test` to run web test on local for web development 👀 
The command line from here: https://github.com/pipe-cd/pipe/blob/master/.kapetanios/presubmit.yaml#L95

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
