### PR TITLE
Disable call insights get data on insight page

### DIFF
--- a/pkg/app/web/src/components/insight-page/insight-header/index.tsx
+++ b/pkg/app/web/src/components/insight-page/insight-header/index.tsx
@@ -11,11 +11,10 @@ import {
   MuiPickersUtilsProvider,
 } from "@material-ui/pickers";
 import { MaterialUiPickersDate } from "@material-ui/pickers/typings/date";
-import { FC, memo, useCallback, useEffect } from "react";
+import { FC, memo, useCallback } from "react";
 import { INSIGHT_STEP_TEXT } from "~/constants/insight-step-text";
 import { useAppDispatch, useAppSelector } from "~/hooks/redux";
 import { Application, selectAll, selectById } from "~/modules/applications";
-import { fetchDeploymentFrequency } from "~/modules/deployment-frequency";
 import {
   changeApplication,
   changeRangeFrom,
@@ -102,9 +101,10 @@ export const InsightHeader: FC = memo(function InsightHeader() {
     [dispatch]
   );
 
-  useEffect(() => {
-    dispatch(fetchDeploymentFrequency());
-  }, [dispatch, applicationId, step, rangeFrom, rangeTo]);
+  // TODO: Enable fetch chart data on insight filter changes.
+  // useEffect(() => {
+  //   dispatch(fetchDeploymentFrequency());
+  // }, [dispatch, applicationId, step, rangeFrom, rangeTo]);
 
   return (
     <Box display="flex" alignItems="center" justifyContent="flex-end">


### PR DESCRIPTION
**What this PR does / why we need it**:

Disable the GetInsightData requests on the insights page, the current insights page only for early access, shouldn't let its failed requests affect our monitoring board.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
