### PR TITLE
Upgrade Prometheus and Grafana charts

### DIFF
--- a/manifests/pipecd/Chart.yaml
+++ b/manifests/pipecd/Chart.yaml
@@ -20,10 +20,10 @@ appVersion: {{ .VERSION }}
 # If you want to update the version of any child charts, bump the version to an arbitrary one.
 dependencies:
 - name: prometheus
-  version: "v13.7.0"
+  version: "v14.6.0"
   repository: "https://prometheus-community.github.io/helm-charts"
   condition: monitoring.enabled
 - name: grafana
-  version: "6.7.4"
+  version: "6.16.2"
   repository: "https://grafana.github.io/helm-charts"
   condition: monitoring.enabled


### PR DESCRIPTION
**What this PR does / why we need it**:
Bumps Prometheus and Grafana to the latest stable version. I checked it works well on my personal cluster.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
