### PR TITLE
Add placeholder to path field in Add Application form

### DIFF
--- a/docs/content/en/docs/user-guide/adding-an-application.md
+++ b/docs/content/en/docs/user-guide/adding-an-application.md
@@ -40,7 +40,7 @@ Here are the list of fields in the register form:
 | Env | The environment this application should belongs to. Select one of the registered environments at `Settings/Environment` page.  | Yes |
 | Piped | The piped that handles this application. Select one of the registered `piped`s at `Settings/Piped` page. | Yes |
 | Repository | The Git repository contains application configuration and deployment configuration. Select one of the registered repositories in `piped` configuration. | Yes |
-| Path | The relative path from the root of the Git repository to the directory containing application configuration and deployment configuration. | Yes |
+| Path | The relative path from the root of the Git repository to the directory containing application configuration and deployment configuration. Use `./` means repository root. | Yes |
 | Config Filename | The name of deployment configuration file. Default is `.pipe.yaml`. | No |
 | Cloud Provider | Where the application will be deployed to. Select one of the registered cloud providers in `piped` configuration. | Yes |
 

--- a/pkg/app/web/src/components/application-form/index.tsx
+++ b/pkg/app/web/src/components/application-form/index.tsx
@@ -290,6 +290,7 @@ export const ApplicationForm: FC<ApplicationFormProps> = memo(
             <TextField
               id="repoPath"
               label="Path"
+              placeholder="Path (use ./ as repo root)"
               variant="outlined"
               margin="dense"
               disabled={

--- a/pkg/app/web/src/components/application-form/index.tsx
+++ b/pkg/app/web/src/components/application-form/index.tsx
@@ -290,7 +290,7 @@ export const ApplicationForm: FC<ApplicationFormProps> = memo(
             <TextField
               id="repoPath"
               label="Path"
-              helperText="./ means repository root"
+              placeholder="Relative path to app directory"
               variant="outlined"
               margin="dense"
               disabled={

--- a/pkg/app/web/src/components/application-form/index.tsx
+++ b/pkg/app/web/src/components/application-form/index.tsx
@@ -290,7 +290,7 @@ export const ApplicationForm: FC<ApplicationFormProps> = memo(
             <TextField
               id="repoPath"
               label="Path"
-              placeholder="Path (use ./ as repo root)"
+              helperText="./ means repository root"
               variant="outlined"
               margin="dense"
               disabled={


### PR DESCRIPTION
**What this PR does / why we need it**:

The Path field in Add Application form would look like this

<img width="606" alt="Screen Shot 2021-09-02 at 13 13 16" src="https://user-images.githubusercontent.com/32532742/131780703-b494fea8-4227-46aa-8986-cb99269034e5.png">

**Which issue(s) this PR fixes**:

Fixes #2407 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
