### PR TITLE
Change Eventwatcher to need to specify repos to be observed

### DIFF
--- a/pkg/app/piped/eventwatcher/eventwatcher.go
+++ b/pkg/app/piped/eventwatcher/eventwatcher.go
@@ -132,6 +132,7 @@ func (w *watcher) run(ctx context.Context, repo git.Repo, repoCfg config.PipedRe
 		checkInterval = defaultCheckInterval
 	}
 
+	w.logger.Info("start watching events", zap.String("repo", repoCfg.RepoID))
 	ticker := time.NewTicker(checkInterval)
 	defer ticker.Stop()
 	for {

--- a/pkg/app/piped/eventwatcher/eventwatcher.go
+++ b/pkg/app/piped/eventwatcher/eventwatcher.go
@@ -93,7 +93,10 @@ func (w *watcher) Run(ctx context.Context) error {
 		repoCfgs[repo.RepoID] = repo
 	}
 	for _, r := range w.config.EventWatcher.GitRepos {
-		cfg := repoCfgs[r.RepoID]
+		cfg, ok := repoCfgs[r.RepoID]
+		if !ok {
+			return fmt.Errorf("repo id %q doesn't exist in the Piped repositories list", r.RepoID)
+		}
 		repo, err := w.cloneRepo(ctx, cfg)
 		if err != nil {
 			return err

--- a/pkg/app/piped/eventwatcher/eventwatcher.go
+++ b/pkg/app/piped/eventwatcher/eventwatcher.go
@@ -88,10 +88,7 @@ func (w *watcher) Run(ctx context.Context) error {
 	defer os.RemoveAll(workingDir)
 	w.workingDir = workingDir
 
-	repoCfgs := make(map[string]config.PipedRepository, len(w.config.Repositories))
-	for _, repo := range w.config.Repositories {
-		repoCfgs[repo.RepoID] = repo
-	}
+	repoCfgs := w.config.GetRepositoryMap()
 	for _, r := range w.config.EventWatcher.GitRepos {
 		cfg, ok := repoCfgs[r.RepoID]
 		if !ok {

--- a/pkg/config/piped.go
+++ b/pkg/config/piped.go
@@ -676,7 +676,8 @@ func (s *SecretManagement) UnmarshalJSON(data []byte) error {
 type PipedEventWatcher struct {
 	// Interval to fetch the latest event and compare it with one defined in EventWatcher config files
 	CheckInterval Duration `json:"checkInterval"`
-	// The list of git repositories to be observed.
+	// The configuration list of git repositories to be observed.
+	// Only the repositories in this list will be observed by Piped.
 	GitRepos []PipedEventWatcherGitRepo `json:"gitRepos"`
 }
 

--- a/pkg/config/piped.go
+++ b/pkg/config/piped.go
@@ -677,6 +677,8 @@ type PipedEventWatcher struct {
 	// Interval to fetch the latest event and compare it with one defined in EventWatcher config files
 	CheckInterval Duration `json:"checkInterval"`
 	// Settings for each git repository.
+	// Required field if you want to enable Event watcher
+	// because only the specified repos will be observed.
 	GitRepos []PipedEventWatcherGitRepo `json:"gitRepos"`
 }
 

--- a/pkg/config/piped.go
+++ b/pkg/config/piped.go
@@ -676,9 +676,7 @@ func (s *SecretManagement) UnmarshalJSON(data []byte) error {
 type PipedEventWatcher struct {
 	// Interval to fetch the latest event and compare it with one defined in EventWatcher config files
 	CheckInterval Duration `json:"checkInterval"`
-	// Settings for each git repository.
-	// Required field if you want to enable Event watcher
-	// because only the specified repos will be observed.
+	// The list of git repositories to be observed.
 	GitRepos []PipedEventWatcherGitRepo `json:"gitRepos"`
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR changes Eventwatcher spec to require specifying repositories where you want Piped to observe.

This is a breaking change and needs to add instruction to the documentation. I'm going to add them right before releasing a new version including this change because it could confuse users if I made the change right now.

**Which issue(s) this PR fixes**:

Fixes https://github.com/pipe-cd/pipe/issues/2406

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Change Eventwatcher to need to specify repos to be observed
```
