### PR TITLE
Mask secret value rendered as planpreview results

### DIFF
--- a/pkg/app/piped/cloudprovider/kubernetes/diff.go
+++ b/pkg/app/piped/cloudprovider/kubernetes/diff.go
@@ -118,15 +118,19 @@ func (r *DiffListResult) Render(opt DiffRenderOptions) string {
 		index++
 		b.WriteString(fmt.Sprintf("# %d. %s\n\n", index, key.ReadableString()))
 
-		if opt.UseDiffCommand {
+		// Use our diff check in the following cases:
+		// - not explicit set useDiffCommand option.
+		// - requires masking secret or configmap value.
+		if !opt.UseDiffCommand || opt.MaskSecret || opt.MaskConfigMap {
+			b.WriteString(renderer.Render(change.Diff.Nodes()))
+		} else {
+			// TODO: Find a way to mask values in case of using unix `diff` command.
 			d, err := diffByCommand(diffCommand, change.Old, change.New)
 			if err != nil {
 				b.WriteString(fmt.Sprintf("An error occurred while rendering diff (%v)", err))
 			} else {
 				b.Write(d)
 			}
-		} else {
-			b.WriteString(renderer.Render(change.Diff.Nodes()))
 		}
 		b.WriteString("\n")
 

--- a/pkg/app/piped/cloudprovider/kubernetes/diff.go
+++ b/pkg/app/piped/cloudprovider/kubernetes/diff.go
@@ -118,7 +118,7 @@ func (r *DiffListResult) Render(opt DiffRenderOptions) string {
 		index++
 		b.WriteString(fmt.Sprintf("# %d. %s\n\n", index, key.ReadableString()))
 
-		// Use our diff check in the following cases:
+		// Use our diff check in one of the following cases:
 		// - not explicit set useDiffCommand option.
 		// - requires masking secret or configmap value.
 		if !opt.UseDiffCommand || opt.MaskSecret || opt.MaskConfigMap {

--- a/pkg/app/piped/cloudprovider/kubernetes/diff.go
+++ b/pkg/app/piped/cloudprovider/kubernetes/diff.go
@@ -108,10 +108,14 @@ func (r *DiffListResult) Render(opt DiffRenderOptions) string {
 		opts := []diff.RenderOption{
 			diff.WithLeftPadding(1),
 		}
+
+		needMaskValue := false
 		if opt.MaskSecret && key.IsSecret() {
 			opts = append(opts, diff.WithMaskPath("data"))
+			needMaskValue = true
 		} else if opt.MaskConfigMap && key.IsConfigMap() {
 			opts = append(opts, diff.WithMaskPath("data"))
+			needMaskValue = true
 		}
 		renderer := diff.NewRenderer(opts...)
 
@@ -121,7 +125,7 @@ func (r *DiffListResult) Render(opt DiffRenderOptions) string {
 		// Use our diff check in one of the following cases:
 		// - not explicit set useDiffCommand option.
 		// - requires masking secret or configmap value.
-		if !opt.UseDiffCommand || opt.MaskSecret || opt.MaskConfigMap {
+		if !opt.UseDiffCommand || needMaskValue {
 			b.WriteString(renderer.Render(change.Diff.Nodes()))
 		} else {
 			// TODO: Find a way to mask values in case of using unix `diff` command.


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Mask secret and configuration values rendered as plan-preview result
```
