### PR TITLE
Revert "Change Eventwatcher to need to specify repos to be observed"

### DIFF
--- a/pkg/config/piped.go
+++ b/pkg/config/piped.go
@@ -676,8 +676,7 @@ func (s *SecretManagement) UnmarshalJSON(data []byte) error {
 type PipedEventWatcher struct {
 	// Interval to fetch the latest event and compare it with one defined in EventWatcher config files
 	CheckInterval Duration `json:"checkInterval"`
-	// The configuration list of git repositories to be observed.
-	// Only the repositories in this list will be observed by Piped.
+	// Settings for each git repository.
 	GitRepos []PipedEventWatcherGitRepo `json:"gitRepos"`
 }
 


### PR DESCRIPTION
This reverts commit 4aaf4770190f2a21f59f354f599077d2e094f88a.

**What this PR does / why we need it**:
After the new version got released, we will re-revert this commit.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
