### PR TITLE
Fix no line break in terraform v1 log

### DIFF
--- a/pkg/app/web/src/components/deployments-detail-page/log-viewer/log-line/index.tsx
+++ b/pkg/app/web/src/components/deployments-detail-page/log-viewer/log-line/index.tsx
@@ -76,10 +76,10 @@ export const LogLine: FC<LogLineProps> = ({
               backgroundColor: cell.bg !== 0 ? TERM_COLORS[cell.bg] : undefined,
               fontWeight: cell.bold ? "bold" : undefined,
               textDecoration: cell.underline ? "underline" : undefined,
-              whiteSpace: "pre-wrap",
+              whiteSpace: i !== 0 ? "pre-wrap" : "normal",
             }}
           >
-            {cell.content.split("\\n").join("<br/>")}
+            {cell.content.split("\\n").join("\n")}
           </span>
         ))}
       </Box>

--- a/pkg/app/web/src/utils/__snapshots__/parse-log.test.ts.snap
+++ b/pkg/app/web/src/utils/__snapshots__/parse-log.test.ts.snap
@@ -1,5 +1,38 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`multi line contained in same log block 1`] = `
+Array [
+  Object {
+    "bg": 0,
+    "bold": false,
+    "content": "\\\\n",
+    "fg": 7,
+    "underline": false,
+  },
+  Object {
+    "bg": 0,
+    "bold": true,
+    "content": " BOLD ",
+    "fg": 7,
+    "underline": false,
+  },
+  Object {
+    "bg": 0,
+    "bold": false,
+    "content": " Underline \\\\n",
+    "fg": 7,
+    "underline": true,
+  },
+  Object {
+    "bg": 7,
+    "bold": false,
+    "content": " Reversed ",
+    "fg": 0,
+    "underline": false,
+  },
+]
+`;
+
 exports[`parse bright colors 1`] = `
 Array [
   Object {

--- a/pkg/app/web/src/utils/__snapshots__/parse-log.test.ts.snap
+++ b/pkg/app/web/src/utils/__snapshots__/parse-log.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`multi line contained in same log block 1`] = `
+exports[`multi lines contained in a single log block 1`] = `
 Array [
   Object {
     "bg": 0,

--- a/pkg/app/web/src/utils/parse-log.test.ts
+++ b/pkg/app/web/src/utils/parse-log.test.ts
@@ -38,3 +38,11 @@ test("parse bright colors", () => {
     expect(parseLog(str)).toMatchSnapshot();
   });
 });
+
+test("multi lines contained in a single log block", () => {
+  [
+    "\n\u001b[1m BOLD \u001b[0m\u001b[4m Underline \n\u001b[0m\u001b[7m Reversed \u001b[0m",
+  ].forEach((str) => {
+    expect(parseLog(str)).toMatchSnapshot();
+  });
+});

--- a/pkg/app/web/src/utils/parse-log.ts
+++ b/pkg/app/web/src/utils/parse-log.ts
@@ -90,7 +90,7 @@ export function parseLog(logStr: string): Cell[] {
   const pushToCells = (content: string): void => {
     if (content.length > 0) {
       cells.push({
-        content: content.replace(/\s/g, NON_BREAK_SPACE),
+        content: content.replace(/\n/g, '\\n').replace(/\s/g, NON_BREAK_SPACE),
         fg,
         bg,
         bold,


### PR DESCRIPTION
**What this PR does / why we need it**:

It would look like this

<img width="1769" alt="Screen Shot 2021-09-07 at 17 59 30" src="https://user-images.githubusercontent.com/32532742/132317372-cb9126d9-c2b0-477e-82b9-62ceaf8c4d89.png">

**Which issue(s) this PR fixes**:

Follow PR #2416 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Fix no line break in Terraform V1 log on the deployment detail page
```
