### PR TITLE
Fix canary-patch app to directly use envoy configuration file path

### DIFF
--- a/examples/kubernetes/canary-patch/.pipe.yaml
+++ b/examples/kubernetes/canary-patch/.pipe.yaml
@@ -13,7 +13,8 @@ spec:
           - target:
               kind: ConfigMap
               name: canary-patch-envoy-config
-              documentRoot: $.data.envoy-config
+              # Because '.' is a reserved character so we have to enclose the last path component in single quotes.
+              documentRoot: $.data.'envoy-config.yaml'
             ops:
             - op: yaml-replace
               path: $.static_resources.listeners[0].filter_chains[0].filters[0].typed_config.route_config.virtual_hosts[0].routes[0].route.weighted_clusters.clusters[0].weight

--- a/examples/kubernetes/canary-patch/configmap.yaml
+++ b/examples/kubernetes/canary-patch/configmap.yaml
@@ -3,7 +3,7 @@ kind: ConfigMap
 metadata:
   name: canary-patch-envoy-config
 data:
-  envoy-config: |-
+  envoy-config.yaml: |-
     admin:
       address:
         socket_address:

--- a/examples/kubernetes/canary-patch/deployment.yaml
+++ b/examples/kubernetes/canary-patch/deployment.yaml
@@ -28,10 +28,10 @@ spec:
         image: envoyproxy/envoy-alpine:v1.18.3
         imagePullPolicy: IfNotPresent
         command:
-          - /bin/sh
+          - envoy
         args:
           - -c
-          - envoy --config-yaml "$(cat /etc/envoy/envoy-config)"
+          - /etc/envoy/envoy-config.yaml
         ports:
           - containerPort: 9090
           - containerPort: 9095


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
