### PR TITLE
Add the explanation to the document to add bazelisk to user's PATH

### DIFF
--- a/docs/content/en/docs/contribution-guidelines/development.md
+++ b/docs/content/en/docs/contribution-guidelines/development.md
@@ -16,6 +16,11 @@ You can install `bazelisk` by `go get` as the following:
 go get github.com/bazelbuild/bazelisk
 ```
 
+Then Add it to your PATH
+```
+export PATH=$PATH:$(go env GOPATH)/bin
+```
+
 or directly install its [binary](https://github.com/bazelbuild/bazelisk/releases) from the release page.
 
 ## Repositories


### PR DESCRIPTION
**What this PR does / why we need it**:

When I setup my environment for pipe-cd with the document, the error is occurred as follows.
```shell
s15236@CA-20014576 pipe % bazelisk version
zsh: command not found: bazelisk
```

The reason of this was that bazelisk had not been added to my PATH. So, I added the explanation to the document.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
```release-note
NONE
```
