### PR TITLE
Add authentication.k8s.io/* API to the default watcing list of Kubernetes

### DIFF
--- a/pkg/app/piped/livestatestore/kubernetes/reflector.go
+++ b/pkg/app/piped/livestatestore/kubernetes/reflector.go
@@ -48,6 +48,7 @@ var (
 		"apiextensions.k8s.io":      {},
 		"rbac.authorization.k8s.io": {},
 		"policy":                    {},
+		"authentication.k8s.io":     {},
 	}
 	versionWhitelist = map[string]struct{}{
 		"v1":      {},
@@ -81,6 +82,7 @@ var (
 		"CustomResourceDefinition": {},
 		"PodDisruptionBudget":      {},
 		"PodSecurityPolicy":        {},
+		"TokenReview":              {},
 	}
 	ignoreResourceKeys = map[string]struct{}{
 		"v1:Service:default:kubernetes":               {},


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes part of #2436

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
