### PR TITLE
Revert Eventwatcher to need to specify repos to be observed

### DIFF
--- a/pkg/app/piped/eventwatcher/eventwatcher.go
+++ b/pkg/app/piped/eventwatcher/eventwatcher.go
@@ -88,15 +88,20 @@ func (w *watcher) Run(ctx context.Context) error {
 	defer os.RemoveAll(workingDir)
 	w.workingDir = workingDir
 
-	for _, repoCfg := range w.config.Repositories {
-		repo, err := w.cloneRepo(ctx, repoCfg)
+	repoCfgs := w.config.GetRepositoryMap()
+	for _, r := range w.config.EventWatcher.GitRepos {
+		cfg, ok := repoCfgs[r.RepoID]
+		if !ok {
+			return fmt.Errorf("repo id %q doesn't exist in the Piped repositories list", r.RepoID)
+		}
+		repo, err := w.cloneRepo(ctx, cfg)
 		if err != nil {
 			return err
 		}
 		defer repo.Clean()
 
 		w.wg.Add(1)
-		go w.run(ctx, repo, repoCfg)
+		go w.run(ctx, repo, cfg)
 	}
 
 	w.wg.Wait()
@@ -127,6 +132,7 @@ func (w *watcher) run(ctx context.Context, repo git.Repo, repoCfg config.PipedRe
 		checkInterval = defaultCheckInterval
 	}
 
+	w.logger.Info("start watching events", zap.String("repo", repoCfg.RepoID))
 	ticker := time.NewTicker(checkInterval)
 	defer ticker.Stop()
 	for {

--- a/pkg/config/piped.go
+++ b/pkg/config/piped.go
@@ -676,7 +676,8 @@ func (s *SecretManagement) UnmarshalJSON(data []byte) error {
 type PipedEventWatcher struct {
 	// Interval to fetch the latest event and compare it with one defined in EventWatcher config files
 	CheckInterval Duration `json:"checkInterval"`
-	// Settings for each git repository.
+	// The configuration list of git repositories to be observed.
+	// Only the repositories in this list will be observed by Piped.
 	GitRepos []PipedEventWatcherGitRepo `json:"gitRepos"`
 }
 


### PR DESCRIPTION
This reverts commit 89bc645c226550afd553ff2af8803bccf74a8706.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Change Eventwatcher to need to specify repos to be observed
```
