### PR TITLE
Change the default interval for Eventwatcher to 1m

### DIFF
--- a/pkg/app/piped/eventwatcher/eventwatcher.go
+++ b/pkg/app/piped/eventwatcher/eventwatcher.go
@@ -41,7 +41,7 @@ import (
 const (
 	// The latest value and Event name are supposed.
 	defaultCommitMessageFormat = "Replace values with %q set by Event %q"
-	defaultCheckInterval       = 5 * time.Minute
+	defaultCheckInterval       = time.Minute
 )
 
 type Watcher interface {


### PR DESCRIPTION
**What this PR does / why we need it**:
I'll make a change on the docs along with https://github.com/pipe-cd/pipe/pull/2452 because both are breaking changes.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Change the default interval for Eventwatcher to 1m
```
