### PR TITLE
Update Eventwatcher docs to mention gitRepos have to be specified

### DIFF
--- a/docs/content/en/docs/operator-manual/piped/configuration-reference.md
+++ b/docs/content/en/docs/operator-manual/piped/configuration-reference.md
@@ -164,8 +164,8 @@ Must be one of the following structs:
 
 | Field | Type | Description | Required |
 |-|-|-|-|
-| checkInterval | duration | Interval to fetch the latest event and compare it with one defined in EventWatcher config files. Defaults to `5m`. | No |
-| gitRepos | [][EventWatcherGitRepo](/docs/operator-manual/piped/configuration-reference/#eventwatchergitrepo) | List of settings for each git repository | No |
+| checkInterval | duration | Interval to fetch the latest event and compare it with one defined in EventWatcher config files. Defaults to `1m`. | No |
+| gitRepos | [][EventWatcherGitRepo](/docs/operator-manual/piped/configuration-reference/#eventwatchergitrepo) | The configuration list of git repositories to be observed. Only the repositories in this list will be observed by Piped. | No |
 
 ### EventWatcherGitRepo
 

--- a/docs/content/en/docs/operator-manual/piped/configuring-event-watcher.md
+++ b/docs/content/en/docs/operator-manual/piped/configuring-event-watcher.md
@@ -11,24 +11,38 @@ To enable [EventWatcher](/docs/user-guide/event-watcher/), you have to configure
 ### [required] Grant write permission
 The [SSH key used by Piped](/docs/operator-manual/piped/configuration-reference/#git) must be a key with write-access because piped needs to commit and push to your git repository when any incoming event matches.
 
-### [optional] Settings for watcher
-The Piped's behavior can be finely controlled by setting the `eventWatcher` field.
+### [required] Specify Git repositories to be observed
+Piped watches events only for the Git repositories specified in the `gitRepos` list.
+You need to add all repositories you want to enable Eventwatcher.
 
 ```yaml
 apiVersion: pipecd.dev/v1beta1
 kind: Piped
 spec:
   eventWatcher:
-    checkInterval: 5m
+    gitRepos:
+      - repoId: repo-1
+      - repoId: repo-2
+      - repoId: repo-3
+```
+
+### [optional] Specify Eventwatcher files Piped will use
+If multiple Pipeds handle a single repository, you can prevent conflicts by splitting into the multiple EventWatcher files and setting `includes/excludes` to specify the files that should be monitored by this Piped.
+
+Say for instance, if you only want the Piped to use the Eventwatcher files under `.pipe/dev/`:
+
+```yaml
+apiVersion: pipecd.dev/v1beta1
+kind: Piped
+spec:
+  eventWatcher:
     gitRepos:
       - repoId: repo-1
         commitMessage: Update values by Event watcher
         includes:
-          - event-watcher-dev.yaml
-          - event-watcher-stg.yaml
+          - dev/*.yaml
 ```
 
-If multiple Pipeds handle a single repository, you can prevent conflicts by splitting into the multiple EventWatcher files and setting `includes/excludes` to specify the files that should be monitored by this Piped.
 `excludes` is prioritized if both `includes` and `excludes` are given.
 
 The full list of configurable fields are [here](/docs/operator-manual/piped/configuration-reference/#eventwatcher).

--- a/docs/content/en/docs/operator-manual/piped/configuring-event-watcher.md
+++ b/docs/content/en/docs/operator-manual/piped/configuring-event-watcher.md
@@ -8,10 +8,10 @@ description: >
 
 To enable [EventWatcher](/docs/user-guide/event-watcher/), you have to configure your piped at first.
 
-### [required] Grant write permission
+### Grant write permission
 The [SSH key used by Piped](/docs/operator-manual/piped/configuration-reference/#git) must be a key with write-access because piped needs to commit and push to your git repository when any incoming event matches.
 
-### [required] Specify Git repositories to be observed
+### Specify Git repositories to be observed
 Piped watches events only for the Git repositories specified in the `gitRepos` list.
 You need to add all repositories you want to enable Eventwatcher.
 

--- a/docs/content/en/docs/user-guide/event-watcher.md
+++ b/docs/content/en/docs/user-guide/event-watcher.md
@@ -20,7 +20,7 @@ While it empowers you to build pretty versatile workflows, the canonical use cas
 This guide walks you through configuring Event watcher and how to push an Event.
 
 ## Prerequisites
-Before we get into configuring EventWatcher, be sure to grant write permission to the SSH key used by Piped. See [here](/docs/operator-manual/piped/configuring-event-watcher/) for more details.
+Before we get into configuring EventWatcher, be sure to configure Piped. See [here](/docs/operator-manual/piped/configuring-event-watcher/) for more details.
 
 ## Usage
 File updating can be done by registering the latest value corresponding to the Event in the control-plane and comparing it with the current value.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds descriptions on https://github.com/pipe-cd/pipe/pull/2452 and https://github.com/pipe-cd/pipe/pull/2454.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
