### PR TITLE
Ensure Eventwatcher to encode comments at the same line as value

### DIFF
--- a/pkg/yamlprocessor/yamlprocessor.go
+++ b/pkg/yamlprocessor/yamlprocessor.go
@@ -96,6 +96,10 @@ func (p *Processor) ReplaceString(path, value string) error {
 		Value:    value,
 	}
 
+	if c := oldNode.GetComment(); c != nil {
+		newNode.SetComment(c)
+	}
+
 	return yamlPath.ReplaceWithNode(p.file, newNode)
 }
 

--- a/pkg/yamlprocessor/yamlprocessor_test.go
+++ b/pkg/yamlprocessor/yamlprocessor_test.go
@@ -212,6 +212,15 @@ foo: new-text`),
 			wantErr: false,
 		},
 		{
+			name: "valid value with comment at the same line",
+			yml: `foo: bar # comments
+			`,
+			path:    "$.foo",
+			value:   "new-text",
+			want:    []byte("foo: new-text # comments"),
+			wantErr: false,
+		},
+		{
 			name: "array in block style",
 			yml: `foo:
   - bar


### PR DESCRIPTION
**What this PR does / why we need it**:
Until now, Eventwatcher has deleted comments at the same line like:

```yaml
foo:
  bar: baz # comment
```

This PR fixes to not be deleted.

See more: https://github.com/goccy/go-yaml/issues/248#issuecomment-916606301

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Fix a bug that Eventwatcher deletes comments at the same line at the YAML value
```
