### PR TITLE
Fix datasource not found for provisioned dashboards

### DIFF
--- a/manifests/pipecd/grafana-dashboards/cluster/node.json
+++ b/manifests/pipecd/grafana-dashboards/cluster/node.json
@@ -720,7 +720,18 @@
   "style": "dark",
   "tags": [],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "hide": 0,
+        "label": "datasource",
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      }
+    ]
   },
   "time": {
     "from": "now-6h",

--- a/manifests/pipecd/grafana-dashboards/cluster/pod.json
+++ b/manifests/pipecd/grafana-dashboards/cluster/pod.json
@@ -687,6 +687,16 @@
   "templating": {
     "list": [
       {
+        "hide": 0,
+        "label": "datasource",
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
+      {
         "allValue": null,
         "current": {},
         "datasource": "${DS_PROMETHEUS}",

--- a/manifests/pipecd/grafana-dashboards/cluster/prometheus.json
+++ b/manifests/pipecd/grafana-dashboards/cluster/prometheus.json
@@ -1155,7 +1155,18 @@
   "style": "dark",
   "tags": [],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "hide": 0,
+        "label": "datasource",
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      }
+    ]
   },
   "time": {
     "from": "now-6h",

--- a/manifests/pipecd/grafana-dashboards/control-plane/go.json
+++ b/manifests/pipecd/grafana-dashboards/control-plane/go.json
@@ -496,6 +496,16 @@
   "templating": {
     "list": [
       {
+        "hide": 0,
+        "label": "datasource",
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
+      {
         "allValue": null,
         "current": {
           "selected": true,

--- a/manifests/pipecd/grafana-dashboards/control-plane/incoming-request.json
+++ b/manifests/pipecd/grafana-dashboards/control-plane/incoming-request.json
@@ -753,6 +753,16 @@
   "templating": {
     "list": [
       {
+        "hide": 0,
+        "label": "datasource",
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
+      {
         "allValue": null,
         "current": {},
         "datasource": "${DS_PROMETHEUS}",

--- a/manifests/pipecd/grafana-dashboards/control-plane/overview.json
+++ b/manifests/pipecd/grafana-dashboards/control-plane/overview.json
@@ -456,6 +456,16 @@
   "templating": {
     "list": [
       {
+        "hide": 0,
+        "label": "datasource",
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
+      {
         "allValue": null,
         "current": {},
         "datasource": "${DS_PROMETHEUS}",

--- a/manifests/pipecd/grafana-dashboards/piped/go.json
+++ b/manifests/pipecd/grafana-dashboards/piped/go.json
@@ -473,6 +473,16 @@
   "templating": {
     "list": [
       {
+        "hide": 0,
+        "label": "datasource",
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
+      {
         "allValue": null,
         "current": {},
         "datasource": "${DS_PROMETHEUS}",

--- a/manifests/pipecd/grafana-dashboards/piped/process.json
+++ b/manifests/pipecd/grafana-dashboards/piped/process.json
@@ -265,6 +265,16 @@
   "templating": {
     "list": [
       {
+        "hide": 0,
+        "label": "datasource",
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
+      {
         "allValue": null,
         "current": {},
         "datasource": "${DS_PROMETHEUS}",


### PR DESCRIPTION
**What this PR does / why we need it**:

While initializing provisioned dashboards from exported JSON configurations, all fields such as `"__input"` which contains defined variable `$DS_PROMETHEUS` is omitted that cause `$DS_PROMETHEUS datasource not found` errors. This should be counted as a Grafana issue but currently, patches for this are not available and we have this workaround (addressed by this PR) for this.

ref: https://github.com/grafana/grafana/issues/10786

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
