### PR TITLE
Update planner to use pipeline even for the first deployment when alwaysUsePipeline was configured

### DIFF
--- a/pkg/app/piped/planner/cloudrun/cloudrun.go
+++ b/pkg/app/piped/planner/cloudrun/cloudrun.go
@@ -81,8 +81,16 @@ func (p *Planner) Plan(ctx context.Context, in planner.Input) (out planner.Outpu
 		return
 	}
 
+	// When no pipeline was configured, do the quick sync.
+	if cfg.Pipeline == nil || len(cfg.Pipeline.Stages) == 0 {
+		out.SyncStrategy = model.SyncStrategy_QUICK_SYNC
+		out.Stages = buildQuickSyncPipeline(cfg.Input.AutoRollback, time.Now())
+		out.Summary = fmt.Sprintf("Quick sync to deploy image %s and configure all traffic to it (pipeline was not configured)", out.Version)
+		return
+	}
+
 	// Force to use pipeline when the alwaysUsePipeline field was configured.
-	if cfg.Planner.AlwaysUsePipeline && cfg.Pipeline != nil {
+	if cfg.Planner.AlwaysUsePipeline {
 		out.SyncStrategy = model.SyncStrategy_PIPELINE
 		out.Stages = buildProgressivePipeline(cfg.Pipeline, cfg.Input.AutoRollback, time.Now())
 		out.Summary = "Sync with the specified pipeline (alwaysUsePipeline was set)"
@@ -95,14 +103,6 @@ func (p *Planner) Plan(ctx context.Context, in planner.Input) (out planner.Outpu
 		out.SyncStrategy = model.SyncStrategy_QUICK_SYNC
 		out.Stages = buildQuickSyncPipeline(cfg.Input.AutoRollback, time.Now())
 		out.Summary = fmt.Sprintf("Quick sync to deploy image %s and configure all traffic to it (it seems this is the first deployment)", out.Version)
-		return
-	}
-
-	// When no pipeline was configured, do the quick sync.
-	if cfg.Pipeline == nil || len(cfg.Pipeline.Stages) == 0 {
-		out.SyncStrategy = model.SyncStrategy_QUICK_SYNC
-		out.Stages = buildQuickSyncPipeline(cfg.Input.AutoRollback, time.Now())
-		out.Summary = fmt.Sprintf("Quick sync to deploy image %s and configure all traffic to it (pipeline was not configured)", out.Version)
 		return
 	}
 

--- a/pkg/app/piped/planner/cloudrun/cloudrun.go
+++ b/pkg/app/piped/planner/cloudrun/cloudrun.go
@@ -82,7 +82,7 @@ func (p *Planner) Plan(ctx context.Context, in planner.Input) (out planner.Outpu
 	}
 
 	// Force to use pipeline when the alwaysUsePipeline field was configured.
-	if cfg.Planner.AlwaysUsePipeline && cfg.Pipeline == nil {
+	if cfg.Planner.AlwaysUsePipeline && cfg.Pipeline != nil {
 		out.SyncStrategy = model.SyncStrategy_PIPELINE
 		out.Stages = buildProgressivePipeline(cfg.Pipeline, cfg.Input.AutoRollback, time.Now())
 		out.Summary = "Sync with the specified pipeline (alwaysUsePipeline was set)"

--- a/pkg/app/piped/planner/ecs/ecs.go
+++ b/pkg/app/piped/planner/ecs/ecs.go
@@ -81,6 +81,14 @@ func (p *Planner) Plan(ctx context.Context, in planner.Input) (out planner.Outpu
 		return
 	}
 
+	// Force to use pipeline when the alwaysUsePipeline field was configured.
+	if cfg.Planner.AlwaysUsePipeline && cfg.Pipeline != nil {
+		out.SyncStrategy = model.SyncStrategy_PIPELINE
+		out.Stages = buildProgressivePipeline(cfg.Pipeline, cfg.Input.AutoRollback, time.Now())
+		out.Summary = "Sync with the specified pipeline (alwaysUsePipeline was set)"
+		return
+	}
+
 	// If this is the first time to deploy this application or it was unable to retrieve last successful commit,
 	// we perform the quick sync strategy.
 	if in.MostRecentSuccessfulCommitHash == "" {
@@ -95,14 +103,6 @@ func (p *Planner) Plan(ctx context.Context, in planner.Input) (out planner.Outpu
 		out.SyncStrategy = model.SyncStrategy_QUICK_SYNC
 		out.Stages = buildQuickSyncPipeline(cfg.Input.AutoRollback, time.Now())
 		out.Summary = fmt.Sprintf("Quick sync to deploy image %s and configure all traffic to it (pipeline was not configured)", out.Version)
-		return
-	}
-
-	// Force to use pipeline when the alwaysUsePipeline field was configured.
-	if cfg.Planner.AlwaysUsePipeline {
-		out.SyncStrategy = model.SyncStrategy_PIPELINE
-		out.Stages = buildProgressivePipeline(cfg.Pipeline, cfg.Input.AutoRollback, time.Now())
-		out.Summary = "Sync with the specified pipeline (alwaysUsePipeline was set)"
 		return
 	}
 

--- a/pkg/app/piped/planner/lambda/lambda.go
+++ b/pkg/app/piped/planner/lambda/lambda.go
@@ -81,6 +81,14 @@ func (p *Planner) Plan(ctx context.Context, in planner.Input) (out planner.Outpu
 		return
 	}
 
+	// Force to use pipeline when the alwaysUsePipeline field was configured.
+	if cfg.Planner.AlwaysUsePipeline && cfg.Pipeline != nil {
+		out.SyncStrategy = model.SyncStrategy_PIPELINE
+		out.Stages = buildProgressivePipeline(cfg.Pipeline, cfg.Input.AutoRollback, time.Now())
+		out.Summary = "Sync with the specified pipeline (alwaysUsePipeline was set)"
+		return
+	}
+
 	// If this is the first time to deploy this application or it was unable to retrieve last successful commit,
 	// we perform the quick sync strategy.
 	if in.MostRecentSuccessfulCommitHash == "" {
@@ -95,14 +103,6 @@ func (p *Planner) Plan(ctx context.Context, in planner.Input) (out planner.Outpu
 		out.SyncStrategy = model.SyncStrategy_QUICK_SYNC
 		out.Stages = buildQuickSyncPipeline(cfg.Input.AutoRollback, time.Now())
 		out.Summary = fmt.Sprintf("Quick sync to deploy image %s and configure all traffic to it (pipeline was not configured)", out.Version)
-		return
-	}
-
-	// Force to use pipeline when the alwaysUsePipeline field was configured.
-	if cfg.Planner.AlwaysUsePipeline {
-		out.SyncStrategy = model.SyncStrategy_PIPELINE
-		out.Stages = buildProgressivePipeline(cfg.Pipeline, cfg.Input.AutoRollback, time.Now())
-		out.Summary = "Sync with the specified pipeline (alwaysUsePipeline was set)"
 		return
 	}
 


### PR DESCRIPTION

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
