### PR TITLE
Ensure that each CloudRun revision should be registered once

### DIFF
--- a/pkg/app/piped/cloudprovider/cloudrun/cloudrun.go
+++ b/pkg/app/piped/cloudprovider/cloudrun/cloudrun.go
@@ -32,14 +32,19 @@ const (
 )
 
 var (
-	ErrServiceNotFound = errors.New("not found")
+	ErrServiceNotFound  = errors.New("not found")
+	ErrRevisionNotFound = errors.New("not found")
 )
 
-type Service run.Service
+type (
+	Service  run.Service
+	Revision run.Revision
+)
 
 type Client interface {
 	Create(ctx context.Context, sm ServiceManifest) (*Service, error)
 	Update(ctx context.Context, sm ServiceManifest) (*Service, error)
+	GetRevision(ctx context.Context, name string) (*Revision, error)
 }
 
 type Registry interface {

--- a/pkg/app/piped/executor/cloudrun/cloudrun.go
+++ b/pkg/app/piped/executor/cloudrun/cloudrun.go
@@ -145,6 +145,6 @@ func revisionExists(ctx context.Context, in *executor.Input, client provider.Cli
 		return false, nil
 	}
 
-	in.LogPersister.Errorf("Failed while checking the existence of revision %s", revisionName)
+	in.LogPersister.Errorf("Failed while checking the existence of revision %s (%v)", revisionName, err)
 	return false, err
 }

--- a/pkg/app/piped/executor/cloudrun/deploy.go
+++ b/pkg/app/piped/executor/cloudrun/deploy.go
@@ -32,10 +32,9 @@ const promotePercentageMetadataKey = "promote-percentage"
 type deployExecutor struct {
 	executor.Input
 
-	deploySource      *deploysource.DeploySource
-	deployCfg         *config.CloudRunDeploymentSpec
-	cloudProviderName string
-	cloudProviderCfg  *config.CloudProviderCloudRunConfig
+	deploySource *deploysource.DeploySource
+	deployCfg    *config.CloudRunDeploymentSpec
+	client       provider.Client
 }
 
 func (e *deployExecutor) Execute(sig executor.StopSignal) model.StageStatus {
@@ -53,9 +52,14 @@ func (e *deployExecutor) Execute(sig executor.StopSignal) model.StageStatus {
 		return model.StageStatus_STAGE_FAILURE
 	}
 
-	var found bool
-	e.cloudProviderName, e.cloudProviderCfg, found = findCloudProvider(&e.Input)
+	cpName, cpCfg, found := findCloudProvider(&e.Input)
 	if !found {
+		return model.StageStatus_STAGE_FAILURE
+	}
+
+	e.client, err = provider.DefaultRegistry().Client(ctx, cpName, cpCfg, e.Logger)
+	if err != nil {
+		e.LogPersister.Errorf("Unable to create ClourRun client for the provider (%v)", err)
 		return model.StageStatus_STAGE_FAILURE
 	}
 
@@ -100,7 +104,7 @@ func (e *deployExecutor) ensureSync(ctx context.Context) model.StageStatus {
 		return model.StageStatus_STAGE_FAILURE
 	}
 
-	if !apply(ctx, &e.Input, e.cloudProviderName, e.cloudProviderCfg, sm) {
+	if !apply(ctx, &e.Input, e.client, sm) {
 		return model.StageStatus_STAGE_FAILURE
 	}
 
@@ -169,11 +173,23 @@ func (e *deployExecutor) ensurePromote(ctx context.Context) model.StageStatus {
 			Percent:      100 - options.Percent.Int(),
 		},
 	}
-	if !configureServiceManifest(&e.Input, sm, revision, traffics) {
+
+	exist, err := revisionExists(ctx, &e.Input, e.client, revision)
+	if err != nil {
 		return model.StageStatus_STAGE_FAILURE
 	}
 
-	if !apply(ctx, &e.Input, e.cloudProviderName, e.cloudProviderCfg, sm) {
+	newRevision := revision
+	if exist {
+		newRevision = ""
+		e.LogPersister.Infof("Revision %s was already registered", revision)
+	}
+
+	if !configureServiceManifest(&e.Input, sm, newRevision, traffics) {
+		return model.StageStatus_STAGE_FAILURE
+	}
+
+	if !apply(ctx, &e.Input, e.client, sm) {
 		return model.StageStatus_STAGE_FAILURE
 	}
 

--- a/pkg/app/piped/executor/cloudrun/rollback.go
+++ b/pkg/app/piped/executor/cloudrun/rollback.go
@@ -24,6 +24,7 @@ import (
 
 type rollbackExecutor struct {
 	executor.Input
+	client provider.Client
 }
 
 func (e *rollbackExecutor) Execute(sig executor.StopSignal) model.StageStatus {
@@ -32,6 +33,18 @@ func (e *rollbackExecutor) Execute(sig executor.StopSignal) model.StageStatus {
 		originalStatus = e.Stage.Status
 		status         model.StageStatus
 	)
+
+	cpName, cpCfg, found := findCloudProvider(&e.Input)
+	if !found {
+		return model.StageStatus_STAGE_FAILURE
+	}
+
+	var err error
+	e.client, err = provider.DefaultRegistry().Client(ctx, cpName, cpCfg, e.Logger)
+	if err != nil {
+		e.LogPersister.Errorf("Unable to create ClourRun client for the provider (%v)", err)
+		return model.StageStatus_STAGE_FAILURE
+	}
 
 	switch model.Stage(e.Stage.Name) {
 	case model.StageRollback:
@@ -64,11 +77,6 @@ func (e *rollbackExecutor) ensureRollback(ctx context.Context) model.StageStatus
 		return model.StageStatus_STAGE_FAILURE
 	}
 
-	cloudProviderName, cloudProviderCfg, found := findCloudProvider(&e.Input)
-	if !found {
-		return model.StageStatus_STAGE_FAILURE
-	}
-
 	sm, ok := loadServiceManifest(&e.Input, deployCfg.Input.ServiceManifestFile, runningDS)
 	if !ok {
 		return model.StageStatus_STAGE_FAILURE
@@ -89,7 +97,7 @@ func (e *rollbackExecutor) ensureRollback(ctx context.Context) model.StageStatus
 		return model.StageStatus_STAGE_FAILURE
 	}
 
-	if !apply(ctx, &e.Input, cloudProviderName, cloudProviderCfg, sm) {
+	if !apply(ctx, &e.Input, e.client, sm) {
 		return model.StageStatus_STAGE_FAILURE
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

CloudRun has started validating the immutability of each revision against its name while applying the Service manifest.
It means that updating the revision configuration for the same name will not be allowed.
Until now, we are updating the traffic percentage in the revision configuration and that caused our recent deployment failures.
This PR adds a check the existence of each revision in Promote stage before creating a new one.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Fix CloudRun bug that blocks deployment with multiple promotion stages
```
