### PR TITLE
Update memory size used to run Piped on CloudRun

### DIFF
--- a/docs/content/en/docs/operator-manual/piped/installation/installing-on-cloudrun.md
+++ b/docs/content/en/docs/operator-manual/piped/installation/installing-on-cloudrun.md
@@ -103,7 +103,7 @@ description: >
             resources:
               limits:
                 cpu: 1000m
-                memory: 512Mi
+                memory: 2Gi
         volumes:
           - name: piped-config
             secret:


### PR DESCRIPTION
**What this PR does / why we need it**:

At least that value is required by CloudRun.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
