### PR TITLE
Ensure fetch livestate whenever application kind is available

### DIFF
--- a/pkg/app/web/src/components/application-detail-page/application-state-view/index.tsx
+++ b/pkg/app/web/src/components/application-detail-page/application-state-view/index.tsx
@@ -6,7 +6,7 @@ import {
   makeStyles,
   Typography,
 } from "@material-ui/core";
-import { FC, memo } from "react";
+import { FC, memo, useEffect } from "react";
 import { UI_TEXT_REFRESH } from "~/constants/ui-text";
 import { useAppDispatch, useAppSelector } from "~/hooks/redux";
 import { useInterval } from "~/hooks/use-interval";
@@ -59,6 +59,12 @@ export const ApplicationStateView: FC<ApplicationStateViewProps> = memo(
       selectLiveStateById(state.applicationLiveState, applicationId),
       selectAppById(state.applications, applicationId),
     ]);
+
+    useEffect(() => {
+      if (app?.kind === ApplicationKind.KUBERNETES) {
+        dispatch(fetchApplicationStateById(app.id));
+      }
+    }, [app, dispatch]);
 
     useInterval(
       () => {


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, the livestate fetching request is triggered by `useInterval` hook which always delays before fetching the first time. This change ensures we will fetch the application livestate whenever the application detail (with ApplicationKind value) is available.

**Which issue(s) this PR fixes**:

Follow PR #2488 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
