### PR TITLE
API add ability to filter deployments by application name

### DIFF
--- a/pkg/app/api/grpcapi/web_api.go
+++ b/pkg/app/api/grpcapi/web_api.go
@@ -1041,6 +1041,13 @@ func (a *WebAPI) ListDeployments(ctx context.Context, req *webservice.ListDeploy
 				Value:    o.EnvIds[0],
 			})
 		}
+		if o.ApplicationName != "" {
+			filters = append(filters, datastore.ListFilter{
+				Field:    "ApplicationName",
+				Operator: datastore.OperatorEqual,
+				Value:    o.ApplicationName,
+			})
+		}
 	}
 
 	deployments, cursor, err := a.deploymentStore.ListDeployments(ctx, datastore.ListOptions{

--- a/pkg/app/api/service/webservice/service.proto
+++ b/pkg/app/api/service/webservice/service.proto
@@ -317,6 +317,7 @@ message ListDeploymentsRequest {
         repeated model.ApplicationKind kinds = 2;
         repeated string application_ids = 3;
         repeated string env_ids = 4;
+        string application_name = 5;
     }
     Options options = 1;
     int32 page_size = 2;

--- a/pkg/app/ops/firestoreindexensurer/indexes.json
+++ b/pkg/app/ops/firestoreindexensurer/indexes.json
@@ -188,6 +188,27 @@
     "queryScope": "COLLECTION",
     "fields": [
       {
+        "fieldPath": "ApplicationName",
+        "order": "ASCENDING",
+        "arrayConfig": ""
+      },
+      {
+        "fieldPath": "UpdatedAt",
+        "order": "DESCENDING",
+        "arrayConfig": ""
+      },
+      {
+        "fieldPath": "Id",
+        "order": "ASCENDING",
+        "arrayConfig": ""
+      }
+    ]
+  },
+  {
+    "collectionGroup": "Deployment",
+    "queryScope": "COLLECTION",
+    "fields": [
+      {
         "fieldPath": "EnvId",
         "order": "ASCENDING",
         "arrayConfig": ""

--- a/pkg/app/ops/firestoreindexensurer/indexes_test.go
+++ b/pkg/app/ops/firestoreindexensurer/indexes_test.go
@@ -212,6 +212,27 @@ func TestParseIndexes(t *testing.T) {
 			QueryScope:      "COLLECTION",
 			Fields: []field{
 				{
+					FieldPath:   "ApplicationName",
+					Order:       "ASCENDING",
+					ArrayConfig: "",
+				},
+				{
+					FieldPath:   "UpdatedAt",
+					Order:       "DESCENDING",
+					ArrayConfig: "",
+				},
+				{
+					FieldPath:   "Id",
+					Order:       "ASCENDING",
+					ArrayConfig: "",
+				},
+			},
+		},
+		{
+			CollectionGroup: "Deployment",
+			QueryScope:      "COLLECTION",
+			Fields: []field{
+				{
 					FieldPath:   "EnvId",
 					Order:       "ASCENDING",
 					ArrayConfig: "",

--- a/pkg/app/web/src/modules/deployments/index.ts
+++ b/pkg/app/web/src/modules/deployments/index.ts
@@ -28,6 +28,7 @@ export interface DeploymentFilterOptions {
   kind?: string;
   applicationId?: string;
   envId?: string;
+  applicationName?: string;
 }
 
 export const isDeploymentRunning = (
@@ -92,6 +93,7 @@ const convertFilterOptions = (
   options: DeploymentFilterOptions
 ): ListDeploymentsRequest.Options.AsObject => {
   return {
+    applicationName: options.applicationName ?? "",
     applicationIdsList: options.applicationId ? [options.applicationId] : [],
     envIdsList: options.envId ? [options.envId] : [],
     kindsList: options.kind

--- a/pkg/datastore/mysql/ensurer/indexes.sql
+++ b/pkg/datastore/mysql/ensurer/indexes.sql
@@ -53,6 +53,10 @@ CREATE INDEX command_piped_id ON Command (PipedId);
 ALTER TABLE Deployment ADD COLUMN ApplicationId VARCHAR(36) GENERATED ALWAYS AS (data->>"$.application_id") VIRTUAL NOT NULL;
 CREATE INDEX deployment_application_id_updated_at_desc ON Deployment (ApplicationId, UpdatedAt DESC);
 
+-- index on `ApplicationName` ASC and `UpdatedAt` DESC
+ALTER TABLE Deployment ADD COLUMN ApplicationName VARCHAR(36) GENERATED ALWAYS AS (data->>"$.application_name") VIRTUAL NOT NULL;
+CREATE INDEX deployment_application_name_updated_at_desc ON Deployment (ApplicationName, UpdatedAt DESC);
+
 -- index on `ProjectId` ASC and `UpdatedAt` DESC
 CREATE INDEX deployment_project_id_updated_at_desc ON Deployment (ProjectId, UpdatedAt DESC);
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, we only have a way to filter deployments by Env, Kind, Status, and ApplicationId (display as application name on UI) which is hard to use in case there are many applications with the same name. This change adds ApplicationName as a filter, the change for the client will be addressed by another PR.

**Which issue(s) this PR fixes**:

Part of #2448

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
