### PR TITLE
Add Application Name filter for deployments

### DIFF
--- a/pkg/app/web/src/api/deployments.ts
+++ b/pkg/app/web/src/api/deployments.ts
@@ -32,6 +32,7 @@ export const getDeployments = ({
     opts.setApplicationIdsList(options.applicationIdsList);
     opts.setKindsList(options.kindsList);
     opts.setStatusesList(options.statusesList);
+    opts.setApplicationName(options.applicationName);
     req.setOptions(opts);
     req.setPageSize(pageSize);
     req.setCursor(cursor);

--- a/pkg/app/web/src/components/applications-page/application-filter/application-autocomplete.tsx
+++ b/pkg/app/web/src/components/applications-page/application-filter/application-autocomplete.tsx
@@ -27,7 +27,7 @@ export const ApplicationAutocomplete: FC<Props> = ({ value, onChange }) => {
         onChange(value || "");
       }}
       renderInput={(params) => (
-        <TextField {...params} label="Name" variant="outlined" />
+        <TextField {...params} label="Application Name" variant="outlined" />
       )}
     />
   );

--- a/pkg/app/web/src/components/applications-page/application-filter/index.test.tsx
+++ b/pkg/app/web/src/components/applications-page/application-filter/index.test.tsx
@@ -27,7 +27,7 @@ test("Change filter values", () => {
   );
 
   userEvent.type(
-    screen.getByRole("textbox", { name: "Name" }),
+    screen.getByRole("textbox", { name: "Application Name" }),
     dummyApplication.name
   );
   userEvent.click(screen.getByRole("option", { name: dummyApplication.name }));

--- a/pkg/app/web/src/components/deployments-page/deployment-filter/index.test.tsx
+++ b/pkg/app/web/src/components/deployments-page/deployment-filter/index.test.tsx
@@ -31,7 +31,7 @@ test("Change filter values", () => {
     screen.getByRole("textbox", { name: /application id/i }),
     dummyApplication.id
   );
-  userEvent.click(screen.getByRole("option", { name: dummyApplication.id }));
+  userEvent.click(screen.getByRole("option", { name: `${dummyApplication.name} (${dummyApplication.id})` }));
 
   expect(onChange).toHaveBeenCalledWith({ applicationId: dummyApplication.id });
   onChange.mockClear();

--- a/pkg/app/web/src/components/deployments-page/deployment-filter/index.test.tsx
+++ b/pkg/app/web/src/components/deployments-page/deployment-filter/index.test.tsx
@@ -28,10 +28,10 @@ test("Change filter values", () => {
   );
 
   userEvent.type(
-    screen.getByRole("textbox", { name: /application/i }),
-    dummyApplication.name
+    screen.getByRole("textbox", { name: /application id/i }),
+    dummyApplication.id
   );
-  userEvent.click(screen.getByRole("option", { name: dummyApplication.name }));
+  userEvent.click(screen.getByRole("option", { name: dummyApplication.id }));
 
   expect(onChange).toHaveBeenCalledWith({ applicationId: dummyApplication.id });
   onChange.mockClear();

--- a/pkg/app/web/src/components/deployments-page/deployment-filter/index.tsx
+++ b/pkg/app/web/src/components/deployments-page/deployment-filter/index.tsx
@@ -7,7 +7,7 @@ import {
   TextField,
 } from "@material-ui/core";
 import Autocomplete from "@material-ui/lab/Autocomplete";
-import { FC, memo, useCallback } from "react";
+import { FC, memo, useCallback, useState, useEffect } from "react";
 import { FilterView } from "~/components/filter-view";
 import { APPLICATION_KIND_TEXT } from "~/constants/application-kind";
 import { DEPLOYMENT_STATE_TEXT } from "~/constants/deployment-status-text";
@@ -49,6 +49,7 @@ export const DeploymentFilter: FC<DeploymentFilterProps> = memo(
   function DeploymentFilter({ options, onChange, onClear }) {
     const classes = useStyles();
     const envs = useAppSelector(selectAllEnvs);
+    const [localApplications, setLocalApplications] = useState<Application.AsObject[]>([]);
     const applications = useAppSelector<Application.AsObject[]>((state) =>
       selectAllApplications(state.applications)
     );
@@ -64,6 +65,14 @@ export const DeploymentFilter: FC<DeploymentFilterProps> = memo(
       },
       [options, onChange]
     );
+
+    useEffect(() => {
+      if (options.applicationName) {
+        setLocalApplications(applications.filter(app => app.name === options.applicationName));
+      } else {
+        setLocalApplications(applications);
+      }
+    }, [applications, options]);
 
     return (
       <FilterView
@@ -145,9 +154,9 @@ export const DeploymentFilter: FC<DeploymentFilterProps> = memo(
         <div className={classes.formItem}>
           <Autocomplete
             id="application-select"
-            options={applications}
+            options={localApplications}
             getOptionLabel={(option) => option.id}
-            renderOption={(option) => <span>{option.id}</span>}
+            renderOption={(option) => <span>{option.name} ({option.id})</span>}
             value={selectedApp || null}
             onChange={(_, value) => {
               handleUpdateFilterValue({

--- a/pkg/app/web/src/components/deployments-page/deployment-filter/index.tsx
+++ b/pkg/app/web/src/components/deployments-page/deployment-filter/index.tsx
@@ -25,6 +25,7 @@ import {
   DeploymentStatusKey,
 } from "~/modules/deployments";
 import { selectAllEnvs } from "~/modules/environments";
+import { ApplicationAutocomplete } from "../../applications-page/application-filter/application-autocomplete";
 
 const useStyles = makeStyles((theme) => ({
   formItem: {
@@ -70,6 +71,13 @@ export const DeploymentFilter: FC<DeploymentFilterProps> = memo(
           onClear();
         }}
       >
+        <div className={classes.formItem}>
+          <ApplicationAutocomplete
+            value={options.applicationName ?? null}
+            onChange={(value) => handleUpdateFilterValue({ applicationName: value })}
+          />
+        </div>
+
         <FormControl className={classes.formItem} variant="outlined">
           <InputLabel id="filter-env">Environment</InputLabel>
           <Select
@@ -138,8 +146,8 @@ export const DeploymentFilter: FC<DeploymentFilterProps> = memo(
           <Autocomplete
             id="application-select"
             options={applications}
-            getOptionLabel={(option) => option.name}
-            renderOption={(option) => <span>{option.name}</span>}
+            getOptionLabel={(option) => option.id}
+            renderOption={(option) => <span>{option.id}</span>}
             value={selectedApp || null}
             onChange={(_, value) => {
               handleUpdateFilterValue({
@@ -149,7 +157,7 @@ export const DeploymentFilter: FC<DeploymentFilterProps> = memo(
             renderInput={(params) => (
               <TextField
                 {...params}
-                label="Application"
+                label="Application Id"
                 variant="outlined"
                 inputProps={{
                   ...params.inputProps,

--- a/pkg/app/web/src/modules/deployments/index.ts
+++ b/pkg/app/web/src/modules/deployments/index.ts
@@ -92,7 +92,7 @@ export const fetchDeploymentById = createAsyncThunk<
 const convertFilterOptions = (
   options: DeploymentFilterOptions
 ): ListDeploymentsRequest.Options.AsObject => {
-  return {
+  const ops = {
     applicationName: options.applicationName ?? "",
     applicationIdsList: options.applicationId ? [options.applicationId] : [],
     envIdsList: options.envId ? [options.envId] : [],
@@ -103,6 +103,8 @@ const convertFilterOptions = (
       ? [parseInt(options.status, 10) as DeploymentStatus]
       : [],
   };
+  console.warn("OPS", ops);
+  return ops;
 };
 
 /**

--- a/pkg/app/web/src/modules/deployments/index.ts
+++ b/pkg/app/web/src/modules/deployments/index.ts
@@ -92,7 +92,7 @@ export const fetchDeploymentById = createAsyncThunk<
 const convertFilterOptions = (
   options: DeploymentFilterOptions
 ): ListDeploymentsRequest.Options.AsObject => {
-  const ops = {
+  return {
     applicationName: options.applicationName ?? "",
     applicationIdsList: options.applicationId ? [options.applicationId] : [],
     envIdsList: options.envId ? [options.envId] : [],
@@ -103,8 +103,6 @@ const convertFilterOptions = (
       ? [parseInt(options.status, 10) as DeploymentStatus]
       : [],
   };
-  console.warn("OPS", ops);
-  return ops;
 };
 
 /**


### PR DESCRIPTION
**What this PR does / why we need it**:

It would work as below

https://user-images.githubusercontent.com/32532742/133885302-2b586185-7eda-4587-b5dd-35693f619473.mp4

- filter directly with application id => query for specified application's deployments.
- filter using application name => query for all deployments of applications named as same as input name.

Bonus
- filter using application name also reflect the result to the application id field selectable options, only applications named as same as input name are remained.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Add ApplicationName as a deployment filter on deployments list page
```
