### PR TITLE
Delay readiness check for server containers to avoid early server pod kill

### DIFF
--- a/manifests/pipecd/templates/deployment.yaml
+++ b/manifests/pipecd/templates/deployment.yaml
@@ -138,6 +138,7 @@ spec:
               path: /healthz
               port: admin
           readinessProbe:
+            initialDelaySeconds: 30
             httpGet:
               path: /healthz
               port: admin


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
