### PR TITLE
Enable ADA stage to compare two samples using Mann-Whitney U test

### DIFF
--- a/pkg/app/piped/executor/analysis/BUILD.bazel
+++ b/pkg/app/piped/executor/analysis/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//pkg/app/piped/analysisprovider/metrics/factory:go_default_library",
         "//pkg/app/piped/apistore/analysisresultstore:go_default_library",
         "//pkg/app/piped/executor:go_default_library",
+        "//pkg/app/piped/executor/analysis/mannwhitney:go_default_library",
         "//pkg/config:go_default_library",
         "//pkg/model:go_default_library",
         "@org_golang_x_sync//errgroup:go_default_library",

--- a/pkg/app/piped/executor/analysis/metrics_analyzer_test.go
+++ b/pkg/app/piped/executor/analysis/metrics_analyzer_test.go
@@ -1,3 +1,17 @@
+// Copyright 2021 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package analysis
 
 import (
@@ -121,6 +135,80 @@ func Test_metricsAnalyzer_analyzeWithThreshold(t *testing.T) {
 			got, err := tc.metricsAnalyzer.analyzeWithThreshold(context.Background())
 			assert.Equal(t, tc.wantErr, err != nil)
 			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func Test_compare(t *testing.T) {
+	type args struct {
+		experiment []float64
+		control    []float64
+		deviation  string
+	}
+	testcases := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "no significance",
+			args: args{
+				experiment: []float64{0.1, 0.2, 0.3, 0.4, 0.5},
+				control:    []float64{0.1, 0.2, 0.3, 0.4, 0.5},
+				deviation:  "EITHER",
+			},
+			wantErr: false,
+		},
+		{
+			name: "deviation on high direction as expected",
+			args: args{
+				experiment: []float64{10.1, 10.2, 10.3, 10.4, 10.5},
+				control:    []float64{0.1, 0.2, 0.3, 0.4, 0.5},
+				deviation:  "LOW",
+			},
+			wantErr: false,
+		},
+		{
+			name: "deviation on low direction as expected",
+			args: args{
+				experiment: []float64{0.1, 0.2, 0.3, 0.4, 0.5},
+				control:    []float64{10.1, 10.2, 10.3, 10.4, 10.5},
+				deviation:  "HIGH",
+			},
+			wantErr: false,
+		},
+		{
+			name: "deviation on high direction as unexpected",
+			args: args{
+				experiment: []float64{10.1, 10.2, 10.3, 10.4, 10.5},
+				control:    []float64{0.1, 0.2, 0.3, 0.4, 0.5},
+				deviation:  "HIGH",
+			},
+			wantErr: true,
+		},
+		{
+			name: "deviation on low direction as unexpected",
+			args: args{
+				experiment: []float64{0.1, 0.2, 0.3, 0.4, 0.5},
+				control:    []float64{10.1, 10.2, 10.3, 10.4, 10.5},
+				deviation:  "LOW",
+			},
+			wantErr: true,
+		},
+		{
+			name: "deviation as unexpected",
+			args: args{
+				experiment: []float64{0.1, 0.2, 5.3, 0.2, 0.5},
+				control:    []float64{0.1, 0.1, 0.1, 0.1, 0.1},
+				deviation:  "EITHER",
+			},
+			wantErr: true,
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := compare(tc.args.experiment, tc.args.control, tc.args.deviation)
+			assert.Equal(t, tc.wantErr, err != nil)
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR enables to perform the Mann-Whitney U test for evaluating metrics in the `PREVIOUS`, `CANARY_BASELINE`, and `CANARY_PRIMARY` strategies.

See the test cases for more information on what results can be achieved in what cases.

**Which issue(s) this PR fixes**:

Fixes https://github.com/pipe-cd/pipe/issues/2508

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
