### PR TITLE
Enable to render variant args along with app args

### DIFF
--- a/pkg/app/piped/executor/analysis/analysis.go
+++ b/pkg/app/piped/executor/analysis/analysis.go
@@ -292,22 +292,22 @@ func (e *Executor) getHTTPConfig(templatableCfg *config.TemplatableAnalysisHTTP,
 	return &cfg, nil
 }
 
-func (e *Executor) buildAppArgs(customArgs map[string]string) appArgs {
-	args := appArgs{
-		BuiltIn: appBuiltInArgs{
+func (e *Executor) buildAppArgs(customArgs map[string]string) argsTemplate {
+	args := argsTemplate{
+		App: appArgs{
 			Name: e.Application.Name,
 			// TODO: Populate Env
 			Env: "",
 		},
-		Custom: customArgs,
+		AppCustomArgs: customArgs,
 	}
-	if e.config.Kind == config.KindKubernetesApp {
+	if e.config.Kind != config.KindKubernetesApp {
 		return args
 	}
 	namespace := "default"
 	if n := e.config.KubernetesDeploymentSpec.Input.Namespace; n != "" {
 		namespace = n
 	}
-	args.BuiltIn.K8s = struct{ Namespace string }{Namespace: namespace}
+	args.K8s.Namespace = namespace
 	return args
 }

--- a/pkg/app/piped/executor/analysis/metrics_analyzer.go
+++ b/pkg/app/piped/executor/analysis/metrics_analyzer.go
@@ -43,17 +43,20 @@ type metricsAnalyzer struct {
 	stageStartTime      time.Time
 	provider            metrics.Provider
 	analysisResultStore executor.AnalysisResultStore
-	logger              *zap.Logger
-	logPersister        executor.LogPersister
+	// Application-specific arguments using when rendering the query.
+	appTemplateArgs appArgs
+	logger          *zap.Logger
+	logPersister    executor.LogPersister
 }
 
-func newMetricsAnalyzer(id string, cfg config.AnalysisMetrics, stageStartTime time.Time, provider metrics.Provider, analysisResultStore executor.AnalysisResultStore, logger *zap.Logger, logPersister executor.LogPersister) *metricsAnalyzer {
+func newMetricsAnalyzer(id string, cfg config.AnalysisMetrics, stageStartTime time.Time, provider metrics.Provider, analysisResultStore executor.AnalysisResultStore, appTemplateArgs appArgs, logger *zap.Logger, logPersister executor.LogPersister) *metricsAnalyzer {
 	return &metricsAnalyzer{
 		id:                  id,
 		cfg:                 cfg,
 		stageStartTime:      stageStartTime,
 		provider:            provider,
 		analysisResultStore: analysisResultStore,
+		appTemplateArgs:     appTemplateArgs,
 		logPersister:        logPersister,
 		logger: logger.With(
 			zap.String("analyzer-id", id),
@@ -97,14 +100,14 @@ func (a *metricsAnalyzer) run(ctx context.Context) error {
 				return nil
 			}
 			if errors.Is(err, metrics.ErrNoDataFound) && a.cfg.SkipOnNoData {
-				a.logPersister.Infof("[%s] The query result evaluation was skipped because \"skipOnNoData\" is true even though no data returned. Reason: %v. Performed query: %q", a.id, err, a.cfg.Query)
+				a.logPersister.Infof("[%s] The query result evaluation was skipped because \"skipOnNoData\" is true though no data returned. Reason: %v", a.id, err)
 				continue
 			}
 			if err != nil {
-				a.logPersister.Errorf("[%s] Unexpected error: %v. Performed query: %q", a.id, err, a.cfg.Query)
+				a.logPersister.Errorf("[%s] Unexpected error: %v", a.id, err)
 			}
 			if expected {
-				a.logPersister.Successf("[%s] The query result is expected one. Performed query: %q", a.id, a.cfg.Query)
+				a.logPersister.Successf("[%s] The query result is expected one", a.id)
 				continue
 			}
 			failureCount++
@@ -163,7 +166,7 @@ func (a *metricsAnalyzer) analyzeWithPrevious(ctx context.Context) (expected, fi
 	}
 	points, err := a.provider.QueryPoints(ctx, a.cfg.Query, queryRange)
 	if err != nil {
-		return false, false, fmt.Errorf("failed to run query: %w", err)
+		return false, false, fmt.Errorf("failed to run query: %w: performed query: %q", err, a.cfg.Query)
 	}
 	values := make([]float64, 0, len(points))
 	for i := range points {
@@ -187,7 +190,7 @@ func (a *metricsAnalyzer) analyzeWithPrevious(ctx context.Context) (expected, fi
 	}
 	prevPoints, err := a.provider.QueryPoints(ctx, a.cfg.Query, prevQueryRange)
 	if err != nil {
-		return false, false, fmt.Errorf("failed to run query to fetch metrics for the previous deployment: %w", err)
+		return false, false, fmt.Errorf("failed to run query to fetch metrics for the previous deployment: %w: performed query: %q", err, a.cfg.Query)
 	}
 	prevValues := make([]float64, 0, len(prevPoints))
 	for i := range prevPoints {
@@ -219,7 +222,7 @@ func (a *metricsAnalyzer) analyzeWithCanaryBaseline(ctx context.Context) (bool, 
 
 	canaryPoints, err := a.provider.QueryPoints(ctx, canaryQuery, queryRange)
 	if err != nil {
-		return false, fmt.Errorf("failed to run query to fetch metrics for the Canary variant: %w", err)
+		return false, fmt.Errorf("failed to run query to fetch metrics for the Canary variant: %w: performed query: %q", err, canaryQuery)
 	}
 	canaryValues := make([]float64, 0, len(canaryPoints))
 	for i := range canaryPoints {
@@ -227,7 +230,7 @@ func (a *metricsAnalyzer) analyzeWithCanaryBaseline(ctx context.Context) (bool, 
 	}
 	baselinePoints, err := a.provider.QueryPoints(ctx, baselineQuery, queryRange)
 	if err != nil {
-		return false, fmt.Errorf("failed to run query to fetch metrics for the Baseline variant: %w", err)
+		return false, fmt.Errorf("failed to run query to fetch metrics for the Baseline variant: %w: performed query: %q", err, baselineQuery)
 	}
 	baselineValues := make([]float64, 0, len(baselinePoints))
 	for i := range baselinePoints {
@@ -260,7 +263,7 @@ func (a *metricsAnalyzer) analyzeWithCanaryPrimary(ctx context.Context) (bool, e
 
 	canaryPoints, err := a.provider.QueryPoints(ctx, canaryQuery, queryRange)
 	if err != nil {
-		return false, fmt.Errorf("failed to run query to fetch metrics for the Canary variant: %w", err)
+		return false, fmt.Errorf("failed to run query to fetch metrics for the Canary variant: %w: performed query: %q", err, canaryQuery)
 	}
 	canaryValues := make([]float64, 0, len(canaryPoints))
 	for i := range canaryPoints {
@@ -268,7 +271,7 @@ func (a *metricsAnalyzer) analyzeWithCanaryPrimary(ctx context.Context) (bool, e
 	}
 	primaryPoints, err := a.provider.QueryPoints(ctx, primaryQuery, queryRange)
 	if err != nil {
-		return false, fmt.Errorf("failed to run query to fetch metrics for the Primary variant: %w", err)
+		return false, fmt.Errorf("failed to run query to fetch metrics for the Primary variant: %w: performed query: %q", err, primaryQuery)
 	}
 	primaryValues := make([]float64, 0, len(primaryPoints))
 	for i := range primaryPoints {
@@ -279,37 +282,6 @@ func (a *metricsAnalyzer) analyzeWithCanaryPrimary(ctx context.Context) (bool, e
 		return false, nil
 	}
 	return true, nil
-}
-
-type argsForTemplate struct {
-	BuiltInArgs builtInArgs
-	// User-defined custom args.
-	VariantArgs map[string]string
-}
-
-type builtInArgs struct {
-	Variant struct {
-		Name string
-	}
-}
-
-// renderQuery applies the given variant args to the query template.
-func (a *metricsAnalyzer) renderQuery(queryTemplate string, variantArgs map[string]string, variant string) (string, error) {
-	args := argsForTemplate{
-		BuiltInArgs: builtInArgs{Variant: struct{ Name string }{Name: variant}},
-		VariantArgs: variantArgs,
-	}
-
-	t, err := template.New("AnalysisVariantTemplate").Parse(queryTemplate)
-	if err != nil {
-		return "", fmt.Errorf("failed to parse query template: %w", err)
-	}
-
-	b := new(bytes.Buffer)
-	if err := t.Execute(b, args); err != nil {
-		return "", fmt.Errorf("failed to apply template: %w", err)
-	}
-	return b.String(), err
 }
 
 // compare compares the given two samples using Mann-Whitney U test.
@@ -334,6 +306,9 @@ func compare(experiment, control []float64, deviation string) (err error) {
 		return fmt.Errorf("unknown deviation %q given", deviation)
 	}
 	res, err := mannwhitney.MannWhitneyUTest(experiment, control, alternativeHypothesis)
+	if errors.Is(err, mannwhitney.ErrSamplesEqual) {
+		return nil
+	}
 	if err != nil {
 		return fmt.Errorf("failed to perform the Mann-Whitney U test: %w", err)
 	}
@@ -347,4 +322,66 @@ func compare(experiment, control []float64, deviation string) (err error) {
 		return nil
 	}
 	return fmt.Errorf("the difference between the medians is statistically significant")
+}
+
+type argsTemplate struct {
+	VariantArgs variantArgs
+	AppArgs     appArgs
+}
+
+// appArgs allows variant-specific data to be embedded in the query.
+// NOTE: Changing its fields will force users to change the template definition.
+type variantArgs struct {
+	// The args that is automatically populated.
+	// This can be referred as {{ .VariantArgs.BuiltInArgs }}
+	BuiltIn variantBuiltInArgs
+	// User-defined custom args.
+	// This can be referred as {{ .VariantArgs.Custom }}
+	Custom map[string]string
+}
+
+type variantBuiltInArgs struct {
+	// One of "primary", "canary", or "baseline" will be populated.
+	Variant string
+}
+
+// appArgs allows application-specific data to be embedded in the query.
+// NOTE: Changing its fields will force users to change the template definition.
+type appArgs struct {
+	// The args that is automatically populated.
+	// This can be referred as {{ .AppArgs.BuiltInArgs }}
+	BuiltIn appBuiltInArgs
+	// User-defined custom args.
+	// This can be referred as {{ .AppArgs.Custom }}
+	Custom map[string]string
+}
+
+type appBuiltInArgs struct {
+	Name string
+	Env  string
+	K8s  struct {
+		Namespace string
+	}
+}
+
+// renderQuery applies the given variant args to the query template.
+func (a *metricsAnalyzer) renderQuery(queryTemplate string, variantCustomArgs map[string]string, variant string) (string, error) {
+	args := argsTemplate{
+		VariantArgs: variantArgs{
+			BuiltIn: struct{ Variant string }{Variant: variant},
+			Custom:  variantCustomArgs,
+		},
+		AppArgs: a.appTemplateArgs,
+	}
+
+	t, err := template.New("AnalysisTemplate").Parse(queryTemplate)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse query template: %w", err)
+	}
+
+	b := new(bytes.Buffer)
+	if err := t.Execute(b, args); err != nil {
+		return "", fmt.Errorf("failed to apply template: %w", err)
+	}
+	return b.String(), err
 }

--- a/pkg/app/piped/executor/analysis/metrics_analyzer_test.go
+++ b/pkg/app/piped/executor/analysis/metrics_analyzer_test.go
@@ -226,7 +226,7 @@ func Test_metricsAnalyzer_renderQuery(t *testing.T) {
 		{
 			name: "using only variant built in args",
 			args: args{
-				queryTemplate: `variant="{{ .VariantArgs.BuiltIn.Variant }}"`,
+				queryTemplate: `variant="{{ .Variant.Name }}"`,
 				variant:       "canary",
 			},
 			metricsAnalyzer: &metricsAnalyzer{},
@@ -236,12 +236,12 @@ func Test_metricsAnalyzer_renderQuery(t *testing.T) {
 		{
 			name: "using variant and app built in args",
 			args: args{
-				queryTemplate: `variant="{{ .VariantArgs.BuiltIn.Variant }}", app="{{ .AppArgs.BuiltIn.Name }}"`,
+				queryTemplate: `variant="{{ .Variant.Name }}", app="{{ .App.Name }}"`,
 				variant:       "canary",
 			},
 			metricsAnalyzer: &metricsAnalyzer{
-				appTemplateArgs: appArgs{
-					BuiltIn: appBuiltInArgs{
+				argsTemplate: argsTemplate{
+					App: appArgs{
 						Name: "app-1",
 					},
 				},
@@ -252,16 +252,16 @@ func Test_metricsAnalyzer_renderQuery(t *testing.T) {
 		{
 			name: "using variant and app built in and custom args",
 			args: args{
-				queryTemplate:     `variant="{{ .VariantArgs.BuiltIn.Variant }}", app="{{ .AppArgs.BuiltIn.Name }}", pod="{{ .VariantArgs.Custom.pod }}", id="{{ .AppArgs.Custom.id }}"`,
+				queryTemplate:     `variant="{{ .Variant.Name }}", app="{{ .App.Name }}", pod="{{ .VariantCustomArgs.pod }}", id="{{ .AppCustomArgs.id }}"`,
 				variantCustomArgs: map[string]string{"pod": "1234"},
 				variant:           "canary",
 			},
 			metricsAnalyzer: &metricsAnalyzer{
-				appTemplateArgs: appArgs{
-					BuiltIn: appBuiltInArgs{
+				argsTemplate: argsTemplate{
+					App: appArgs{
 						Name: "app-1",
 					},
-					Custom: map[string]string{"id": "xxxx"},
+					AppCustomArgs: map[string]string{"id": "xxxx"},
 				},
 			},
 			want:    `variant="canary", app="app-1", pod="1234", id="xxxx"`,

--- a/pkg/app/piped/executor/analysis/metrics_analyzer_test.go
+++ b/pkg/app/piped/executor/analysis/metrics_analyzer_test.go
@@ -209,3 +209,70 @@ func Test_compare(t *testing.T) {
 		})
 	}
 }
+
+func Test_metricsAnalyzer_renderQuery(t *testing.T) {
+	type args struct {
+		queryTemplate     string
+		variantCustomArgs map[string]string
+		variant           string
+	}
+	testcases := []struct {
+		name            string
+		metricsAnalyzer *metricsAnalyzer
+		args            args
+		want            string
+		wantErr         bool
+	}{
+		{
+			name: "using only variant built in args",
+			args: args{
+				queryTemplate: `variant="{{ .VariantArgs.BuiltIn.Variant }}"`,
+				variant:       "canary",
+			},
+			metricsAnalyzer: &metricsAnalyzer{},
+			want:            `variant="canary"`,
+			wantErr:         false,
+		},
+		{
+			name: "using variant and app built in args",
+			args: args{
+				queryTemplate: `variant="{{ .VariantArgs.BuiltIn.Variant }}", app="{{ .AppArgs.BuiltIn.Name }}"`,
+				variant:       "canary",
+			},
+			metricsAnalyzer: &metricsAnalyzer{
+				appTemplateArgs: appArgs{
+					BuiltIn: appBuiltInArgs{
+						Name: "app-1",
+					},
+				},
+			},
+			want:    `variant="canary", app="app-1"`,
+			wantErr: false,
+		},
+		{
+			name: "using variant and app built in and custom args",
+			args: args{
+				queryTemplate:     `variant="{{ .VariantArgs.BuiltIn.Variant }}", app="{{ .AppArgs.BuiltIn.Name }}", pod="{{ .VariantArgs.Custom.pod }}", id="{{ .AppArgs.Custom.id }}"`,
+				variantCustomArgs: map[string]string{"pod": "1234"},
+				variant:           "canary",
+			},
+			metricsAnalyzer: &metricsAnalyzer{
+				appTemplateArgs: appArgs{
+					BuiltIn: appBuiltInArgs{
+						Name: "app-1",
+					},
+					Custom: map[string]string{"id": "xxxx"},
+				},
+			},
+			want:    `variant="canary", app="app-1", pod="1234", id="xxxx"`,
+			wantErr: false,
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := tc.metricsAnalyzer.renderQuery(tc.args.queryTemplate, tc.args.variantCustomArgs, tc.args.variant)
+			assert.Equal(t, tc.wantErr, err != nil)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/pkg/app/piped/executor/executor.go
+++ b/pkg/app/piped/executor/executor.go
@@ -73,10 +73,12 @@ type Input struct {
 	Stage       *model.PipelineStage
 	StageConfig config.PipelineStage
 	// Readonly deployment model.
-	Deployment            *model.Deployment
-	Application           *model.Application
-	PipedConfig           *config.PipedSpec
-	TargetDSP             deploysource.Provider
+	Deployment  *model.Deployment
+	Application *model.Application
+	PipedConfig *config.PipedSpec
+	// Deploy source at target commit
+	TargetDSP deploysource.Provider
+	// Deploy source at running commit
 	RunningDSP            deploysource.Provider
 	CommandLister         CommandLister
 	LogPersister          LogPersister

--- a/pkg/config/analysis_template.go
+++ b/pkg/config/analysis_template.go
@@ -49,6 +49,7 @@ func LoadAnalysisTemplate(repoRoot string) (*AnalysisTemplateSpec, error) {
 			return nil, fmt.Errorf("failed to load config file %s: %w", path, err)
 		}
 		if cfg.Kind == KindAnalysisTemplate {
+			// TODO: Populate default values here because creasty/defaults seems not to set into maps
 			return cfg.AnalysisTemplateSpec, nil
 		}
 	}

--- a/pkg/config/deployment.go
+++ b/pkg/config/deployment.go
@@ -367,9 +367,8 @@ func (a *AnalysisStageOptions) Validate() error {
 }
 
 type AnalysisTemplateRef struct {
-	Name string `json:"name"`
-	// TODO: Rename args to appArgs
-	Args map[string]string `json:"args"`
+	Name    string            `json:"name"`
+	AppArgs map[string]string `json:"appArgs"`
 }
 
 func (a *AnalysisTemplateRef) Validate() error {


### PR DESCRIPTION
**What this PR does / why we need it**:
By this PR, we can render variant args for ADA in the strategies like `CANARY_BASELINE`, `CANARY_PRIMARY`.
`(*metricsAnalyzer).renderQuery()` is in charge of that. See the test cases of `Test_metricsAnalyzer_renderQuery` to see how it goes.

Originally, we settled on putting [three variable group](https://github.com/pipe-cd/pipe/blob/master/docs/rfcs/0006-ada-dynamic.md#args): `{{ .BuiltInArgs }}`, `{{ .VariantArgs }}`, and `{{ .AppArgs }}`. But if you think about it, it turned out just being two groups `{{ .VariantArgs }}` and `{{ .AppArgs }}` is easier to understand. See also the above test cases for how to access each variable.

**Breaking changes**

This PR contains a couple of breaking changes around AnalysisTemplate.
~Args reference names have been changed according to [the RFC](https://github.com/pipe-cd/pipe/blob/master/docs/rfcs/0006-ada-dynamic.md#examples).~
- ~`{{ .App.Name }}` will be `{{ .AppArgs.BuiltIn.Name }}`~
- ~`{{ .K8s.Namespace }}` will be `{{ .AppArgs.BuiltIn.K8s.Namespace }}`~

The name of the configuration field that specifies args will be changed as:

```yaml
- template: 
     name: http_error_rate
     appArgs: # former "args"
       foo: bar
```

The dynamic ADA feature can be considered Alpha by this PR. I'll update the documentation and examples right before releasing the new version including this.

**Which issue(s) this PR fixes**:

Fixes https://github.com/pipe-cd/pipe/issues/2509
Fixes https://github.com/pipe-cd/pipe/issues/2507

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Add an ability to perform ADA using dynamic data
```
