### PR TITLE
Make it possible to attach any data to the Secret manifest in Piped chart

### DIFF
--- a/manifests/piped/templates/secret.yaml
+++ b/manifests/piped/templates/secret.yaml
@@ -7,7 +7,13 @@ metadata:
     {{- include "piped.labels" . | nindent 4 }}
 type: Opaque
 data:
-  {{ .Values.secret.pipedKey.fileName }}: {{ required "piped key is required" .Values.secret.pipedKey.data | b64enc | quote }}
+{{- range $k, $v := .Values.secret.data }}
+  {{ $k }}: {{ $v | b64enc | quote }}
+{{- end }}
+# Below ones will be removed in the future.
+{{- if .Values.secret.pipedKey.data }}
+  {{ .Values.secret.pipedKey.fileName }}: {{ .Values.secret.pipedKey.data | b64enc | quote }}
+{{- end }}
 {{- if .Values.secret.sshKey.data }}
   {{ .Values.secret.sshKey.fileName }}: {{ .Values.secret.sshKey.data | b64enc | quote }}
 {{- end }}

--- a/manifests/piped/values.yaml
+++ b/manifests/piped/values.yaml
@@ -42,7 +42,6 @@ config:
   #         branch: master
   #     syncInterval: 1m
 
-# TODO: Allow adding arbitrary secret files instead of fixing them as currently.
 secret:
   # Specifies whether a Secret for storing sensitive data should be created.
   create: true
@@ -50,6 +49,9 @@ secret:
   name: ""
   # Where the secret files will be mounted to.
   mountPath: /etc/piped-secret
+  # Additional list of secret data will be added to the Secret resource.
+  # TODO: Remove the predefined secrets after data field because this data field is more flexible.
+  data: {}
   pipedKey:
     # The name of the piped key file.
     fileName: piped-key


### PR DESCRIPTION
**What this PR does / why we need it**:

The installation doc will be updated before releasing this.
https://pipecd.dev/docs/operator-manual/piped/installation/installing-on-kubernetes/

Basically, from now we should install by

``` diff
 helm upgrade -i dev-piped pipecd/piped --version=v0.18.0 --namespace={NAMESPACE} \
   --set-file config.data={PATH_TO_PIPED_CONFIG_FILE} \
-  --set-file secret.pipedKey.data={PATH_TO_PIPED_KEY_FILE} \
-  --set-file secret.sshKey.data={PATH_TO_PRIVATE_SSH_KEY_FILE}
+  --set-file secret.data.piped-key={PATH_TO_PIPED_KEY_FILE} \
+  --set-file secret.data.ssh-key={PATH_TO_PRIVATE_SSH_KEY_FILE}
```

**Which issue(s) this PR fixes**:

Fixes #2376

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
The way of attaching sensitive data to the Secret manifest while installing Piped via Helm chart was changed. This change makes it possible to specify any data to it instead of just predefined ones.
```
