### PR TITLE
Support loading Piped config data from a Git repository

### DIFF
--- a/pkg/app/launcher/cmd/launcher/BUILD.bazel
+++ b/pkg/app/launcher/cmd/launcher/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//pkg/app/api/service/pipedservice:go_default_library",
         "//pkg/cli:go_default_library",
         "//pkg/config:go_default_library",
+        "//pkg/git:go_default_library",
         "//pkg/rpc/rpcauth:go_default_library",
         "//pkg/rpc/rpcclient:go_default_library",
         "//pkg/version:go_default_library",

--- a/pkg/app/launcher/cmd/launcher/launcher.go
+++ b/pkg/app/launcher/cmd/launcher/launcher.go
@@ -68,8 +68,8 @@ type launcher struct {
 	runningConfigData []byte
 
 	configRepo git.Repo
-	clientKey string
-	client    pipedservice.Client
+	clientKey  string
+	client     pipedservice.Client
 }
 
 func NewCommand() *cobra.Command {


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #2564

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Support loading Piped config data from a Git repository
```
