### PR TITLE
Add ability to notify `DEPLOYMENT_APPROVED` event to Slack

### DIFF
--- a/pkg/app/piped/notifier/slack.go
+++ b/pkg/app/piped/notifier/slack.go
@@ -177,6 +177,12 @@ func (s *slack) buildSlackMessage(event model.NotificationEvent, webURL string) 
 		title = fmt.Sprintf("Deployment for %q is waiting for an approval", md.Deployment.ApplicationName)
 		generateDeploymentEventData(md.Deployment, md.EnvName, getAccountsAsString(md.MentionedAccounts))
 
+	case model.NotificationEventType_EVENT_DEPLOYMENT_APPROVED:
+		md := event.Metadata.(*model.NotificationEventDeploymentApproved)
+		title = fmt.Sprintf("Deployment for %q was approved successfully", md.Deployment.ApplicationName)
+		text = fmt.Sprintf("Approved by %s", md.Approver)
+		generateDeploymentEventData(md.Deployment, md.EnvName, getAccountsAsString(md.MentionedAccounts))
+
 	case model.NotificationEventType_EVENT_DEPLOYMENT_SUCCEEDED:
 		md := event.Metadata.(*model.NotificationEventDeploymentSucceeded)
 		title = fmt.Sprintf("Deployment for %q was completed successfully", md.Deployment.ApplicationName)


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
