### PR TITLE
Add ability to disable auto trigger deployment on git change

### DIFF
--- a/pkg/app/piped/planpreview/builder.go
+++ b/pkg/app/piped/planpreview/builder.go
@@ -305,9 +305,9 @@ func (b *builder) cloneHeadCommit(ctx context.Context, headBranch, headCommit st
 }
 
 func (b *builder) findTriggerApps(ctx context.Context, repo git.Repo, apps []*model.Application, headCommit string) (triggerApps []*model.Application, failedResults []*model.ApplicationPlanPreviewResult, err error) {
-	d := trigger.NewDeterminer(repo, headCommit, b.commitGetter, b.logger)
+	d := trigger.NewDeterminer(repo, headCommit, b.commitGetter, true, b.logger)
 	for _, app := range apps {
-		shouldTrigger, err := d.ShouldTrigger(ctx, app, true)
+		shouldTrigger, err := d.ShouldTrigger(ctx, app)
 		if err != nil {
 			// We only need the environment name
 			// so the returned error can be ignorable.

--- a/pkg/app/piped/planpreview/builder.go
+++ b/pkg/app/piped/planpreview/builder.go
@@ -307,7 +307,7 @@ func (b *builder) cloneHeadCommit(ctx context.Context, headBranch, headCommit st
 func (b *builder) findTriggerApps(ctx context.Context, repo git.Repo, apps []*model.Application, headCommit string) (triggerApps []*model.Application, failedResults []*model.ApplicationPlanPreviewResult, err error) {
 	d := trigger.NewDeterminer(repo, headCommit, b.commitGetter, b.logger)
 	for _, app := range apps {
-		shouldTrigger, err := d.ShouldTrigger(ctx, app, false)
+		shouldTrigger, err := d.ShouldTrigger(ctx, app, true)
 		if err != nil {
 			// We only need the environment name
 			// so the returned error can be ignorable.

--- a/pkg/app/piped/planpreview/builder.go
+++ b/pkg/app/piped/planpreview/builder.go
@@ -307,7 +307,7 @@ func (b *builder) cloneHeadCommit(ctx context.Context, headBranch, headCommit st
 func (b *builder) findTriggerApps(ctx context.Context, repo git.Repo, apps []*model.Application, headCommit string) (triggerApps []*model.Application, failedResults []*model.ApplicationPlanPreviewResult, err error) {
 	d := trigger.NewDeterminer(repo, headCommit, b.commitGetter, b.logger)
 	for _, app := range apps {
-		shouldTrigger, err := d.ShouldTrigger(ctx, app)
+		shouldTrigger, err := d.ShouldTrigger(ctx, app, false)
 		if err != nil {
 			// We only need the environment name
 			// so the returned error can be ignorable.

--- a/pkg/app/piped/trigger/determiner.go
+++ b/pkg/app/piped/trigger/determiner.go
@@ -65,7 +65,7 @@ func (d *Determiner) ShouldTrigger(ctx context.Context, app *model.Application, 
 	}
 
 	// Not trigger in case users disable auto trigger deploy on change and the change is ignorable.
-	if deployConfig.Trigger.DisableAutoDeployOnChange && ignorable {
+	if deployConfig.Trigger.OnCommit.Disable && ignorable {
 		logger.Info(fmt.Sprintf("auto trigger deployment disabled for application, hash: %s", d.targetCommit))
 		return false, nil
 	}
@@ -98,8 +98,8 @@ func (d *Determiner) ShouldTrigger(ctx context.Context, app *model.Application, 
 	}
 
 	// TODO: Remove deprecated `deployConfig.TriggerPaths` configuration.
-	checkingPaths := make([]string, len(deployConfig.Trigger.Paths)+len(deployConfig.TriggerPaths))
-	checkingPaths = append(checkingPaths, deployConfig.Trigger.Paths...)
+	checkingPaths := make([]string, len(deployConfig.Trigger.OnCommit.Paths)+len(deployConfig.TriggerPaths))
+	checkingPaths = append(checkingPaths, deployConfig.Trigger.OnCommit.Paths...)
 	checkingPaths = append(checkingPaths, deployConfig.TriggerPaths...)
 
 	touched, err := isTouchedByChangedFiles(app.GitPath.Path, checkingPaths, changedFiles)

--- a/pkg/app/piped/trigger/determiner.go
+++ b/pkg/app/piped/trigger/determiner.go
@@ -63,7 +63,7 @@ func (d *Determiner) ShouldTrigger(ctx context.Context, app *model.Application) 
 	}
 
 	logger.Info(fmt.Sprintf("trigger for application, trigger: %v", deployConfig.Trigger))
-	if !deployConfig.Trigger.AutoDeployOnChange {
+	if !deployConfig.Trigger.DisableAutoDeployOnChange {
 		logger.Info(fmt.Sprintf("auto trigger deployment disabled for application, hash: %s", d.targetCommit))
 		return false, nil
 	}

--- a/pkg/app/piped/trigger/determiner.go
+++ b/pkg/app/piped/trigger/determiner.go
@@ -120,8 +120,6 @@ func (d *Determiner) shouldTriggerOnCommit(ctx context.Context, app *model.Appli
 		}
 	}
 
-	logger.Info("CheckingPaths", zap.Any("checking", checkingPaths))
-	logger.Info("ChangedFiles", zap.Any("changes", changedFiles))
 	touched, err := isTouchedByChangedFiles(app.GitPath.Path, checkingPaths, changedFiles)
 	if err != nil {
 		return false, err

--- a/pkg/app/piped/trigger/determiner.go
+++ b/pkg/app/piped/trigger/determiner.go
@@ -97,7 +97,12 @@ func (d *Determiner) ShouldTrigger(ctx context.Context, app *model.Application, 
 		return false, err
 	}
 
-	touched, err := isTouchedByChangedFiles(app.GitPath.Path, deployConfig.Trigger.Paths, changedFiles)
+	// TODO: Remove deprecated `deployConfig.TriggerPaths` configuration.
+	checkingPaths := make([]string, len(deployConfig.Trigger.Paths)+len(deployConfig.TriggerPaths))
+	checkingPaths = append(checkingPaths, deployConfig.Trigger.Paths...)
+	checkingPaths = append(checkingPaths, deployConfig.TriggerPaths...)
+
+	touched, err := isTouchedByChangedFiles(app.GitPath.Path, checkingPaths, changedFiles)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/app/piped/trigger/determiner.go
+++ b/pkg/app/piped/trigger/determiner.go
@@ -50,7 +50,9 @@ func NewDeterminer(repo git.Repo, targetCommit string, cg LastTriggeredCommitGet
 }
 
 // ShouldTrigger decides whether a given application should be triggered or not.
-func (d *Determiner) ShouldTrigger(ctx context.Context, app *model.Application) (bool, error) {
+// Flag `ignorable` set to `false` will force check changes and use it to determine
+// the application deployment should be triggered or not, regardless of the user's configuration.
+func (d *Determiner) ShouldTrigger(ctx context.Context, app *model.Application, ignorable bool) (bool, error) {
 	logger := d.logger.With(
 		zap.String("app", app.Name),
 		zap.String("app-id", app.Id),
@@ -62,7 +64,8 @@ func (d *Determiner) ShouldTrigger(ctx context.Context, app *model.Application) 
 		return false, err
 	}
 
-	if !deployConfig.Trigger.DisableAutoDeployOnChange {
+	// Not trigger in case users disable auto trigger deploy on change and the change is ignorable.
+	if deployConfig.Trigger.DisableAutoDeployOnChange && ignorable {
 		logger.Info(fmt.Sprintf("auto trigger deployment disabled for application, hash: %s", d.targetCommit))
 		return false, nil
 	}

--- a/pkg/app/piped/trigger/determiner.go
+++ b/pkg/app/piped/trigger/determiner.go
@@ -62,7 +62,6 @@ func (d *Determiner) ShouldTrigger(ctx context.Context, app *model.Application) 
 		return false, err
 	}
 
-	logger.Info(fmt.Sprintf("trigger for application, trigger: %v", deployConfig.Trigger))
 	if !deployConfig.Trigger.DisableAutoDeployOnChange {
 		logger.Info(fmt.Sprintf("auto trigger deployment disabled for application, hash: %s", d.targetCommit))
 		return false, nil

--- a/pkg/app/piped/trigger/determiner.go
+++ b/pkg/app/piped/trigger/determiner.go
@@ -70,7 +70,7 @@ func (d *Determiner) shouldTriggerOnCommit(ctx context.Context, app *model.Appli
 	}
 
 	// Not trigger in case users disable auto trigger deploy on change and the user config is unignorable.
-	if deployConfig.Trigger.OnCommit.Disable && !ignoreUserConfig {
+	if deployConfig.Trigger.OnCommit.Disabled && !ignoreUserConfig {
 		logger.Info(fmt.Sprintf("auto trigger deployment disabled for application, hash: %s", d.targetCommit))
 		return false, nil
 	}

--- a/pkg/app/piped/trigger/trigger.go
+++ b/pkg/app/piped/trigger/trigger.go
@@ -230,7 +230,7 @@ func (t *Trigger) checkNewCommits(ctx context.Context) error {
 		d := NewDeterminer(gitRepo, headCommit.Hash, t.commitStore, t.logger)
 
 		for _, app := range apps {
-			shouldTrigger, err := d.ShouldTrigger(ctx, app, true)
+			shouldTrigger, err := d.ShouldTrigger(ctx, app, false)
 			if err != nil {
 				t.logger.Error(fmt.Sprintf("failed to check application: %s", app.Id), zap.Error(err))
 				continue

--- a/pkg/app/piped/trigger/trigger.go
+++ b/pkg/app/piped/trigger/trigger.go
@@ -227,10 +227,10 @@ func (t *Trigger) checkNewCommits(ctx context.Context) error {
 		if err != nil {
 			continue
 		}
-		d := NewDeterminer(gitRepo, headCommit.Hash, t.commitStore, t.logger)
+		d := NewDeterminer(gitRepo, headCommit.Hash, t.commitStore, false, t.logger)
 
 		for _, app := range apps {
-			shouldTrigger, err := d.ShouldTrigger(ctx, app, false)
+			shouldTrigger, err := d.ShouldTrigger(ctx, app)
 			if err != nil {
 				t.logger.Error(fmt.Sprintf("failed to check application: %s", app.Id), zap.Error(err))
 				continue

--- a/pkg/app/piped/trigger/trigger.go
+++ b/pkg/app/piped/trigger/trigger.go
@@ -230,7 +230,7 @@ func (t *Trigger) checkNewCommits(ctx context.Context) error {
 		d := NewDeterminer(gitRepo, headCommit.Hash, t.commitStore, t.logger)
 
 		for _, app := range apps {
-			shouldTrigger, err := d.ShouldTrigger(ctx, app)
+			shouldTrigger, err := d.ShouldTrigger(ctx, app, true)
 			if err != nil {
 				t.logger.Error(fmt.Sprintf("failed to check application: %s", app.Id), zap.Error(err))
 				continue

--- a/pkg/config/deployment.go
+++ b/pkg/config/deployment.go
@@ -59,7 +59,7 @@ type Trigger struct {
 	// Regular expression can be used.
 	Paths []string `json:"paths,omitempty"`
 	// Control trigger new deployment on Git change or not.
-	AutoDeployOnChange bool `json:"autoDeployOnChange,omitempty" default:"true"`
+	DisableAutoDeployOnChange bool `json:"disableAutoDeployOnChange,omitempty"`
 }
 
 func (s *GenericDeploymentSpec) Validate() error {

--- a/pkg/config/deployment.go
+++ b/pkg/config/deployment.go
@@ -37,9 +37,8 @@ type GenericDeploymentSpec struct {
 	Pipeline *DeploymentPipeline `json:"pipeline"`
 	// The list of sealed secrets that should be decrypted.
 	SealedSecrets []SealedSecretMapping `json:"sealedSecrets"`
-	// List of directories or files where their changes will trigger the deployment.
-	// Regular expression can be used.
-	TriggerPaths []string `json:"triggerPaths,omitempty"`
+	// The trigger configuration use to determine trigger logic.
+	Trigger Trigger `json:"trigger"`
 	// The maximum length of time to execute deployment before giving up.
 	// Default is 6h.
 	Timeout Duration `json:"timeout,omitempty" default:"6h"`
@@ -53,6 +52,14 @@ type DeploymentPlanner struct {
 	// Disable auto-detecting to use QUICK_SYNC or PROGRESSIVE_SYNC.
 	// Always use the speficied pipeline for all deployments.
 	AlwaysUsePipeline bool `json:"alwaysUsePipeline"`
+}
+
+type Trigger struct {
+	// List of directories or files where their changes will trigger the deployment.
+	// Regular expression can be used.
+	Paths []string `json:"paths,omitempty"`
+	// Control trigger new deployment on Git change or not.
+	AutoDeployOnChange bool `json:"autoDeployOnChange,omitempty" default:"true"`
 }
 
 func (s *GenericDeploymentSpec) Validate() error {

--- a/pkg/config/deployment.go
+++ b/pkg/config/deployment.go
@@ -59,11 +59,16 @@ type DeploymentPlanner struct {
 }
 
 type Trigger struct {
+	// Configuration in case changes on commit are found.
+	OnCommit OnCommitConfig `json:"onCommit"`
+}
+
+type OnCommitConfig struct {
+	// Control trigger new deployment on Git change or not.
+	Disable bool `json:"disable,omitempty"`
 	// List of directories or files where their changes will trigger the deployment.
 	// Regular expression can be used.
 	Paths []string `json:"paths,omitempty"`
-	// Control trigger new deployment on Git change or not.
-	DisableAutoDeployOnChange bool `json:"disableAutoDeployOnChange,omitempty"`
 }
 
 func (s *GenericDeploymentSpec) Validate() error {

--- a/pkg/config/deployment.go
+++ b/pkg/config/deployment.go
@@ -60,12 +60,12 @@ type DeploymentPlanner struct {
 
 type Trigger struct {
 	// Configuration in case changes on commit are found.
-	OnCommit OnCommitConfig `json:"onCommit"`
+	OnCommit OnCommit `json:"onCommit"`
 }
 
-type OnCommitConfig struct {
+type OnCommit struct {
 	// Control trigger new deployment on Git change or not.
-	Disable bool `json:"disable,omitempty"`
+	Disabled bool `json:"disabled,omitempty"`
 	// List of directories or files where their changes will trigger the deployment.
 	// Regular expression can be used.
 	Paths []string `json:"paths,omitempty"`

--- a/pkg/config/deployment.go
+++ b/pkg/config/deployment.go
@@ -37,6 +37,10 @@ type GenericDeploymentSpec struct {
 	Pipeline *DeploymentPipeline `json:"pipeline"`
 	// The list of sealed secrets that should be decrypted.
 	SealedSecrets []SealedSecretMapping `json:"sealedSecrets"`
+	// List of directories or files where their changes will trigger the deployment.
+	// Regular expression can be used.
+	// Deprecated: use Trigger.Paths instead.
+	TriggerPaths []string `json:"triggerPaths,omitempty"`
 	// The trigger configuration use to determine trigger logic.
 	Trigger Trigger `json:"trigger"`
 	// The maximum length of time to execute deployment before giving up.

--- a/pkg/config/deployment_cloudrun_test.go
+++ b/pkg/config/deployment_cloudrun_test.go
@@ -37,6 +37,11 @@ func TestCloudRunDeploymentConfig(t *testing.T) {
 			expectedSpec: &CloudRunDeploymentSpec{
 				GenericDeploymentSpec: GenericDeploymentSpec{
 					Timeout: Duration(6 * time.Hour),
+					Trigger: Trigger{
+						OnCommit: OnCommitConfig{
+							Disable: false,
+						},
+					},
 				},
 				Input: CloudRunDeploymentInput{
 					AutoRollback: true,

--- a/pkg/config/deployment_cloudrun_test.go
+++ b/pkg/config/deployment_cloudrun_test.go
@@ -37,6 +37,9 @@ func TestCloudRunDeploymentConfig(t *testing.T) {
 			expectedSpec: &CloudRunDeploymentSpec{
 				GenericDeploymentSpec: GenericDeploymentSpec{
 					Timeout: Duration(6 * time.Hour),
+					Trigger: Trigger{
+						AutoDeployOnChange: true,
+					},
 				},
 				Input: CloudRunDeploymentInput{
 					AutoRollback: true,

--- a/pkg/config/deployment_cloudrun_test.go
+++ b/pkg/config/deployment_cloudrun_test.go
@@ -37,9 +37,6 @@ func TestCloudRunDeploymentConfig(t *testing.T) {
 			expectedSpec: &CloudRunDeploymentSpec{
 				GenericDeploymentSpec: GenericDeploymentSpec{
 					Timeout: Duration(6 * time.Hour),
-					Trigger: Trigger{
-						AutoDeployOnChange: true,
-					},
 				},
 				Input: CloudRunDeploymentInput{
 					AutoRollback: true,

--- a/pkg/config/deployment_cloudrun_test.go
+++ b/pkg/config/deployment_cloudrun_test.go
@@ -38,8 +38,8 @@ func TestCloudRunDeploymentConfig(t *testing.T) {
 				GenericDeploymentSpec: GenericDeploymentSpec{
 					Timeout: Duration(6 * time.Hour),
 					Trigger: Trigger{
-						OnCommit: OnCommitConfig{
-							Disable: false,
+						OnCommit: OnCommit{
+							Disabled: false,
 						},
 					},
 				},

--- a/pkg/config/deployment_ecs_test.go
+++ b/pkg/config/deployment_ecs_test.go
@@ -38,9 +38,6 @@ func TestECSDeploymentConfig(t *testing.T) {
 			expectedSpec: &ECSDeploymentSpec{
 				GenericDeploymentSpec: GenericDeploymentSpec{
 					Timeout: Duration(6 * time.Hour),
-					Trigger: Trigger{
-						AutoDeployOnChange: true,
-					},
 				},
 				Input: ECSDeploymentInput{
 					ServiceDefinitionFile: "/path/to/servicedef.yaml",

--- a/pkg/config/deployment_ecs_test.go
+++ b/pkg/config/deployment_ecs_test.go
@@ -38,6 +38,9 @@ func TestECSDeploymentConfig(t *testing.T) {
 			expectedSpec: &ECSDeploymentSpec{
 				GenericDeploymentSpec: GenericDeploymentSpec{
 					Timeout: Duration(6 * time.Hour),
+					Trigger: Trigger{
+						AutoDeployOnChange: true,
+					},
 				},
 				Input: ECSDeploymentInput{
 					ServiceDefinitionFile: "/path/to/servicedef.yaml",

--- a/pkg/config/deployment_ecs_test.go
+++ b/pkg/config/deployment_ecs_test.go
@@ -38,6 +38,11 @@ func TestECSDeploymentConfig(t *testing.T) {
 			expectedSpec: &ECSDeploymentSpec{
 				GenericDeploymentSpec: GenericDeploymentSpec{
 					Timeout: Duration(6 * time.Hour),
+					Trigger: Trigger{
+						OnCommit: OnCommitConfig{
+							Disable: false,
+						},
+					},
 				},
 				Input: ECSDeploymentInput{
 					ServiceDefinitionFile: "/path/to/servicedef.yaml",

--- a/pkg/config/deployment_ecs_test.go
+++ b/pkg/config/deployment_ecs_test.go
@@ -39,8 +39,8 @@ func TestECSDeploymentConfig(t *testing.T) {
 				GenericDeploymentSpec: GenericDeploymentSpec{
 					Timeout: Duration(6 * time.Hour),
 					Trigger: Trigger{
-						OnCommit: OnCommitConfig{
-							Disable: false,
+						OnCommit: OnCommit{
+							Disabled: false,
 						},
 					},
 				},

--- a/pkg/config/deployment_kubernetes_test.go
+++ b/pkg/config/deployment_kubernetes_test.go
@@ -79,6 +79,9 @@ func TestKubernetesDeploymentConfig(t *testing.T) {
 						},
 					},
 					Timeout: Duration(6 * time.Hour),
+					Trigger: Trigger{
+						AutoDeployOnChange: true,
+					},
 				},
 				Input: KubernetesDeploymentInput{
 					AutoRollback: true,

--- a/pkg/config/deployment_kubernetes_test.go
+++ b/pkg/config/deployment_kubernetes_test.go
@@ -79,6 +79,11 @@ func TestKubernetesDeploymentConfig(t *testing.T) {
 						},
 					},
 					Timeout: Duration(6 * time.Hour),
+					Trigger: Trigger{
+						OnCommit: OnCommitConfig{
+							Disable: false,
+						},
+					},
 				},
 				Input: KubernetesDeploymentInput{
 					AutoRollback: true,

--- a/pkg/config/deployment_kubernetes_test.go
+++ b/pkg/config/deployment_kubernetes_test.go
@@ -79,9 +79,6 @@ func TestKubernetesDeploymentConfig(t *testing.T) {
 						},
 					},
 					Timeout: Duration(6 * time.Hour),
-					Trigger: Trigger{
-						AutoDeployOnChange: true,
-					},
 				},
 				Input: KubernetesDeploymentInput{
 					AutoRollback: true,

--- a/pkg/config/deployment_kubernetes_test.go
+++ b/pkg/config/deployment_kubernetes_test.go
@@ -80,8 +80,8 @@ func TestKubernetesDeploymentConfig(t *testing.T) {
 					},
 					Timeout: Duration(6 * time.Hour),
 					Trigger: Trigger{
-						OnCommit: OnCommitConfig{
-							Disable: false,
+						OnCommit: OnCommit{
+							Disabled: false,
 						},
 					},
 				},

--- a/pkg/config/deployment_lambda_test.go
+++ b/pkg/config/deployment_lambda_test.go
@@ -37,6 +37,9 @@ func TestLambdaDeploymentConfig(t *testing.T) {
 			expectedSpec: &LambdaDeploymentSpec{
 				GenericDeploymentSpec: GenericDeploymentSpec{
 					Timeout: Duration(6 * time.Hour),
+					Trigger: Trigger{
+						AutoDeployOnChange: true,
+					},
 				},
 				Input: LambdaDeploymentInput{
 					FunctionManifestFile: "function.yaml",

--- a/pkg/config/deployment_lambda_test.go
+++ b/pkg/config/deployment_lambda_test.go
@@ -37,9 +37,6 @@ func TestLambdaDeploymentConfig(t *testing.T) {
 			expectedSpec: &LambdaDeploymentSpec{
 				GenericDeploymentSpec: GenericDeploymentSpec{
 					Timeout: Duration(6 * time.Hour),
-					Trigger: Trigger{
-						AutoDeployOnChange: true,
-					},
 				},
 				Input: LambdaDeploymentInput{
 					FunctionManifestFile: "function.yaml",

--- a/pkg/config/deployment_lambda_test.go
+++ b/pkg/config/deployment_lambda_test.go
@@ -37,6 +37,11 @@ func TestLambdaDeploymentConfig(t *testing.T) {
 			expectedSpec: &LambdaDeploymentSpec{
 				GenericDeploymentSpec: GenericDeploymentSpec{
 					Timeout: Duration(6 * time.Hour),
+					Trigger: Trigger{
+						OnCommit: OnCommitConfig{
+							Disable: false,
+						},
+					},
 				},
 				Input: LambdaDeploymentInput{
 					FunctionManifestFile: "function.yaml",

--- a/pkg/config/deployment_lambda_test.go
+++ b/pkg/config/deployment_lambda_test.go
@@ -38,8 +38,8 @@ func TestLambdaDeploymentConfig(t *testing.T) {
 				GenericDeploymentSpec: GenericDeploymentSpec{
 					Timeout: Duration(6 * time.Hour),
 					Trigger: Trigger{
-						OnCommit: OnCommitConfig{
-							Disable: false,
+						OnCommit: OnCommit{
+							Disabled: false,
 						},
 					},
 				},

--- a/pkg/config/deployment_terraform_test.go
+++ b/pkg/config/deployment_terraform_test.go
@@ -39,9 +39,6 @@ func TestTerraformDeploymentConfig(t *testing.T) {
 			expectedSpec: &TerraformDeploymentSpec{
 				GenericDeploymentSpec: GenericDeploymentSpec{
 					Timeout: Duration(6 * time.Hour),
-					Trigger: Trigger{
-						AutoDeployOnChange: true,
-					},
 				},
 				Input: TerraformDeploymentInput{},
 			},
@@ -54,9 +51,6 @@ func TestTerraformDeploymentConfig(t *testing.T) {
 			expectedSpec: &TerraformDeploymentSpec{
 				GenericDeploymentSpec: GenericDeploymentSpec{
 					Timeout: Duration(6 * time.Hour),
-					Trigger: Trigger{
-						AutoDeployOnChange: true,
-					},
 				},
 				Input: TerraformDeploymentInput{
 					Workspace:        "dev",
@@ -79,9 +73,6 @@ func TestTerraformDeploymentConfig(t *testing.T) {
 						},
 					},
 					Timeout: Duration(6 * time.Hour),
-					Trigger: Trigger{
-						AutoDeployOnChange: true,
-					},
 				},
 				Input: TerraformDeploymentInput{
 					Workspace:        "dev",
@@ -117,9 +108,6 @@ func TestTerraformDeploymentConfig(t *testing.T) {
 						},
 					},
 					Timeout: Duration(6 * time.Hour),
-					Trigger: Trigger{
-						AutoDeployOnChange: true,
-					},
 				},
 				Input: TerraformDeploymentInput{
 					Workspace:        "dev",

--- a/pkg/config/deployment_terraform_test.go
+++ b/pkg/config/deployment_terraform_test.go
@@ -39,6 +39,9 @@ func TestTerraformDeploymentConfig(t *testing.T) {
 			expectedSpec: &TerraformDeploymentSpec{
 				GenericDeploymentSpec: GenericDeploymentSpec{
 					Timeout: Duration(6 * time.Hour),
+					Trigger: Trigger{
+						AutoDeployOnChange: true,
+					},
 				},
 				Input: TerraformDeploymentInput{},
 			},
@@ -51,6 +54,9 @@ func TestTerraformDeploymentConfig(t *testing.T) {
 			expectedSpec: &TerraformDeploymentSpec{
 				GenericDeploymentSpec: GenericDeploymentSpec{
 					Timeout: Duration(6 * time.Hour),
+					Trigger: Trigger{
+						AutoDeployOnChange: true,
+					},
 				},
 				Input: TerraformDeploymentInput{
 					Workspace:        "dev",
@@ -73,6 +79,9 @@ func TestTerraformDeploymentConfig(t *testing.T) {
 						},
 					},
 					Timeout: Duration(6 * time.Hour),
+					Trigger: Trigger{
+						AutoDeployOnChange: true,
+					},
 				},
 				Input: TerraformDeploymentInput{
 					Workspace:        "dev",
@@ -108,6 +117,9 @@ func TestTerraformDeploymentConfig(t *testing.T) {
 						},
 					},
 					Timeout: Duration(6 * time.Hour),
+					Trigger: Trigger{
+						AutoDeployOnChange: true,
+					},
 				},
 				Input: TerraformDeploymentInput{
 					Workspace:        "dev",

--- a/pkg/config/deployment_terraform_test.go
+++ b/pkg/config/deployment_terraform_test.go
@@ -40,8 +40,8 @@ func TestTerraformDeploymentConfig(t *testing.T) {
 				GenericDeploymentSpec: GenericDeploymentSpec{
 					Timeout: Duration(6 * time.Hour),
 					Trigger: Trigger{
-						OnCommit: OnCommitConfig{
-							Disable: false,
+						OnCommit: OnCommit{
+							Disabled: false,
 						},
 					},
 				},
@@ -57,8 +57,8 @@ func TestTerraformDeploymentConfig(t *testing.T) {
 				GenericDeploymentSpec: GenericDeploymentSpec{
 					Timeout: Duration(6 * time.Hour),
 					Trigger: Trigger{
-						OnCommit: OnCommitConfig{
-							Disable: false,
+						OnCommit: OnCommit{
+							Disabled: false,
 						},
 					},
 				},
@@ -84,8 +84,8 @@ func TestTerraformDeploymentConfig(t *testing.T) {
 					},
 					Timeout: Duration(6 * time.Hour),
 					Trigger: Trigger{
-						OnCommit: OnCommitConfig{
-							Disable: false,
+						OnCommit: OnCommit{
+							Disabled: false,
 						},
 					},
 				},
@@ -124,8 +124,8 @@ func TestTerraformDeploymentConfig(t *testing.T) {
 					},
 					Timeout: Duration(6 * time.Hour),
 					Trigger: Trigger{
-						OnCommit: OnCommitConfig{
-							Disable: false,
+						OnCommit: OnCommit{
+							Disabled: false,
 						},
 					},
 				},

--- a/pkg/config/deployment_terraform_test.go
+++ b/pkg/config/deployment_terraform_test.go
@@ -39,6 +39,11 @@ func TestTerraformDeploymentConfig(t *testing.T) {
 			expectedSpec: &TerraformDeploymentSpec{
 				GenericDeploymentSpec: GenericDeploymentSpec{
 					Timeout: Duration(6 * time.Hour),
+					Trigger: Trigger{
+						OnCommit: OnCommitConfig{
+							Disable: false,
+						},
+					},
 				},
 				Input: TerraformDeploymentInput{},
 			},
@@ -51,6 +56,11 @@ func TestTerraformDeploymentConfig(t *testing.T) {
 			expectedSpec: &TerraformDeploymentSpec{
 				GenericDeploymentSpec: GenericDeploymentSpec{
 					Timeout: Duration(6 * time.Hour),
+					Trigger: Trigger{
+						OnCommit: OnCommitConfig{
+							Disable: false,
+						},
+					},
 				},
 				Input: TerraformDeploymentInput{
 					Workspace:        "dev",
@@ -73,6 +83,11 @@ func TestTerraformDeploymentConfig(t *testing.T) {
 						},
 					},
 					Timeout: Duration(6 * time.Hour),
+					Trigger: Trigger{
+						OnCommit: OnCommitConfig{
+							Disable: false,
+						},
+					},
 				},
 				Input: TerraformDeploymentInput{
 					Workspace:        "dev",
@@ -108,6 +123,11 @@ func TestTerraformDeploymentConfig(t *testing.T) {
 						},
 					},
 					Timeout: Duration(6 * time.Hour),
+					Trigger: Trigger{
+						OnCommit: OnCommitConfig{
+							Disable: false,
+						},
+					},
 				},
 				Input: TerraformDeploymentInput{
 					Workspace:        "dev",

--- a/pkg/config/deployment_test.go
+++ b/pkg/config/deployment_test.go
@@ -45,9 +45,6 @@ func TestHasStage(t *testing.T) {
 						},
 					},
 				},
-				Trigger: Trigger{
-					AutoDeployOnChange: true,
-				},
 			},
 			stage: model.StageK8sPrimaryRollout,
 			want:  false,
@@ -61,9 +58,6 @@ func TestHasStage(t *testing.T) {
 							Name: model.StageK8sSync,
 						},
 					},
-				},
-				Trigger: Trigger{
-					AutoDeployOnChange: true,
 				},
 			},
 			stage: model.StageK8sSync,

--- a/pkg/config/deployment_test.go
+++ b/pkg/config/deployment_test.go
@@ -270,8 +270,8 @@ func TestGenericTriggerConfiguration(t *testing.T) {
 				GenericDeploymentSpec: GenericDeploymentSpec{
 					Timeout: Duration(6 * time.Hour),
 					Trigger: Trigger{
-						OnCommit: OnCommitConfig{
-							Disable: false,
+						OnCommit: OnCommit{
+							Disabled: false,
 							Paths: []string{
 								"deployment.yaml",
 							},

--- a/pkg/config/deployment_test.go
+++ b/pkg/config/deployment_test.go
@@ -45,6 +45,9 @@ func TestHasStage(t *testing.T) {
 						},
 					},
 				},
+				Trigger: Trigger{
+					AutoDeployOnChange: true,
+				},
 			},
 			stage: model.StageK8sPrimaryRollout,
 			want:  false,
@@ -58,6 +61,9 @@ func TestHasStage(t *testing.T) {
 							Name: model.StageK8sSync,
 						},
 					},
+				},
+				Trigger: Trigger{
+					AutoDeployOnChange: true,
 				},
 			},
 			stage: model.StageK8sSync,

--- a/pkg/config/testdata/application/generic-trigger.yaml
+++ b/pkg/config/testdata/application/generic-trigger.yaml
@@ -1,0 +1,7 @@
+apiVersion: pipecd.dev/v1beta1
+kind: KubernetesApp
+spec:
+  trigger:
+    onCommit:
+      paths:
+        - deployment.yaml


### PR DESCRIPTION
**What this PR does / why we need it**:

Sample configuration for this looks like
```yaml
apiVersion: pipecd.dev/v1beta1
kind: KubernetesApp
spec:
  trigger:
    onCommit:
       disable: true
  input:
    ...
```

Besides, we can also configure watching paths via `spec.trigger.onCommit.Paths` field, the previous `spec.triggerPaths` is marked as deprecated and will be removed later.

**Which issue(s) this PR fixes**:

Fixes #2245 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Add ability to disable auto-trigger deployment on Git changes
```
