### PR TITLE
Ensure Eventwatcher to mark event as handled

### DIFF
--- a/pkg/app/api/grpcapi/piped_api.go
+++ b/pkg/app/api/grpcapi/piped_api.go
@@ -857,6 +857,28 @@ func (a *PipedAPI) ListEvents(ctx context.Context, req *pipedservice.ListEventsR
 	}, nil
 }
 
+func (a *PipedAPI) ReportEventHandled(ctx context.Context, req *pipedservice.ReportEventHandledRequest) (*pipedservice.ReportEventHandledResponse, error) {
+	_, _, _, err := rpcauth.ExtractPipedToken(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	err = a.eventStore.MarkEventHandled(ctx, req.EventId)
+	if err != nil {
+		switch err {
+		case datastore.ErrNotFound:
+			return nil, status.Errorf(codes.NotFound, "event %q is not found", req.EventId)
+		default:
+			a.logger.Error("failed to mark event as handled",
+				zap.String("event-id", req.EventId),
+				zap.Error(err),
+			)
+			return nil, status.Errorf(codes.Internal, "failed to mark event %q as handled", req.EventId)
+		}
+	}
+	return &pipedservice.ReportEventHandledResponse{}, nil
+}
+
 func (a *PipedAPI) GetLatestAnalysisResult(ctx context.Context, req *pipedservice.GetLatestAnalysisResultRequest) (*pipedservice.GetLatestAnalysisResultResponse, error) {
 	_, pipedID, _, err := rpcauth.ExtractPipedToken(ctx)
 	if err != nil {

--- a/pkg/app/api/service/pipedservice/service.proto
+++ b/pkg/app/api/service/pipedservice/service.proto
@@ -415,7 +415,7 @@ message ListEventsResponse {
 }
 
 message ReportEventsHandledRequest {
-    repeated string event_ids = 1;
+    repeated string event_ids = 1 [(validate.rules).repeated.min_items = 1];
 }
 
 message ReportEventsHandledResponse {

--- a/pkg/app/api/service/pipedservice/service.proto
+++ b/pkg/app/api/service/pipedservice/service.proto
@@ -150,6 +150,8 @@ service PipedService {
 
     // ListEvents returns a list of Events inside the given range.
     rpc ListEvents(ListEventsRequest) returns (ListEventsResponse) {}
+    // ReportEventHandled marks the event as handled.
+    rpc ReportEventHandled(ReportEventHandledRequest) returns (ReportEventHandledResponse) {}
 
     // GetLatestAnalysisResult returns the most successful analysis result.
     rpc GetLatestAnalysisResult(GetLatestAnalysisResultRequest) returns (GetLatestAnalysisResultResponse) {}
@@ -410,6 +412,13 @@ message ListEventsRequest {
 
 message ListEventsResponse {
     repeated pipe.model.Event events = 1;
+}
+
+message ReportEventHandledRequest {
+    string event_id = 1 [(validate.rules).string.min_len = 1];
+}
+
+message ReportEventHandledResponse {
 }
 
 message GetLatestAnalysisResultRequest {

--- a/pkg/app/api/service/pipedservice/service.proto
+++ b/pkg/app/api/service/pipedservice/service.proto
@@ -150,8 +150,8 @@ service PipedService {
 
     // ListEvents returns a list of Events inside the given range.
     rpc ListEvents(ListEventsRequest) returns (ListEventsResponse) {}
-    // ReportEventHandled marks the event as handled.
-    rpc ReportEventHandled(ReportEventHandledRequest) returns (ReportEventHandledResponse) {}
+    // ReportEventHandled marks the given all events as handled.
+    rpc ReportEventsHandled(ReportEventsHandledRequest) returns (ReportEventsHandledResponse) {}
 
     // GetLatestAnalysisResult returns the most successful analysis result.
     rpc GetLatestAnalysisResult(GetLatestAnalysisResultRequest) returns (GetLatestAnalysisResultResponse) {}
@@ -414,11 +414,11 @@ message ListEventsResponse {
     repeated pipe.model.Event events = 1;
 }
 
-message ReportEventHandledRequest {
-    string event_id = 1 [(validate.rules).string.min_len = 1];
+message ReportEventsHandledRequest {
+    repeated string event_ids = 1;
 }
 
-message ReportEventHandledResponse {
+message ReportEventsHandledResponse {
 }
 
 message GetLatestAnalysisResultRequest {

--- a/pkg/app/piped/cmd/piped/piped.go
+++ b/pkg/app/piped/cmd/piped/piped.go
@@ -393,6 +393,7 @@ func (p *piped) run(ctx context.Context, input cli.Input) (runErr error) {
 			cfg,
 			eventGetter,
 			gitClient,
+			apiClient,
 			input.Logger,
 		)
 		group.Go(func() error {

--- a/pkg/app/piped/eventwatcher/BUILD.bazel
+++ b/pkg/app/piped/eventwatcher/BUILD.bazel
@@ -6,11 +6,13 @@ go_library(
     importpath = "github.com/pipe-cd/pipe/pkg/app/piped/eventwatcher",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/app/api/service/pipedservice:go_default_library",
         "//pkg/config:go_default_library",
         "//pkg/git:go_default_library",
         "//pkg/model:go_default_library",
         "//pkg/regexpool:go_default_library",
         "//pkg/yamlprocessor:go_default_library",
+        "@org_golang_google_grpc//:go_default_library",
         "@org_uber_go_zap//:go_default_library",
     ],
 )

--- a/pkg/datastore/eventstore.go
+++ b/pkg/datastore/eventstore.go
@@ -32,6 +32,7 @@ var (
 type EventStore interface {
 	AddEvent(ctx context.Context, e model.Event) error
 	ListEvents(ctx context.Context, opts ListOptions) ([]*model.Event, error)
+	MarkEventHandled(ctx context.Context, eventID string) error
 }
 
 type eventStore struct {
@@ -80,4 +81,13 @@ func (s *eventStore) ListEvents(ctx context.Context, opts ListOptions) ([]*model
 		es = append(es, &e)
 	}
 	return es, nil
+}
+
+func (s *eventStore) MarkEventHandled(ctx context.Context, eventID string) error {
+	return s.ds.Update(ctx, EventModelKind, eventID, eventFactory, func(e interface{}) error {
+		event := e.(*model.Event)
+		event.Handled = true
+		event.HandledAt = s.nowFunc().Unix()
+		return nil
+	})
 }

--- a/pkg/model/event.proto
+++ b/pkg/model/event.proto
@@ -36,10 +36,10 @@ message Event {
     // True if it have been handled.
     bool handled = 7;
 
+    // Unix time when the event was handled.
+    int64 handled_at = 13;
     // Unix time when the event was created.
     int64 created_at = 14 [(validate.rules).int64.gt = 0];
     // Unix time of the last time when the event was updated.
     int64 updated_at = 15 [(validate.rules).int64.gt = 0];
-    // Unix time when the event was handled.
-    int64 handled_at = 16;
 }

--- a/pkg/model/event.proto
+++ b/pkg/model/event.proto
@@ -33,9 +33,13 @@ message Event {
     map<string,string> labels = 5;
     // A fixed-length identifier consists of its own name and labels.
     string event_key = 6 [(validate.rules).string.min_len = 1];
+    // True if it have been handled.
+    bool handled = 7;
 
     // Unix time when the event was created.
     int64 created_at = 14 [(validate.rules).int64.gt = 0];
     // Unix time of the last time when the event was updated.
     int64 updated_at = 15 [(validate.rules).int64.gt = 0];
+    // Unix time when the event was handled.
+    int64 handled_at = 16;
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Eventwatcher will mark events as handled after pushing the changes. This PR contains exactly:
- Add `Handled` state to the Event model
- Add a new rpc `ReportEventHandled` to PipedAPI
- Update eventwatcher to report it to the above API: pkg/app/piped/eventwatcher/eventwatcher.go

**Which issue(s) this PR fixes**:

Fixes https://github.com/pipe-cd/pipe/issues/2475

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Prevent Eventwatcher from handling events already handled
```
