### PR TITLE
Add sync stable docs command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,6 +119,10 @@ prepare-release:
 prepare-version-docs:
 	./hack/prepare-version-docs.sh $(version)
 
+.PHONY: sync-stable-docs
+sync-stable-docs:
+	./hack/sync-stable-docs.sh $(version)
+
 .PHONY: update-docsy
 update-docsy:
 	rm -rf docs/themes/docsy

--- a/hack/sync-stable-docs.sh
+++ b/hack/sync-stable-docs.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 The PipeCD Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# parse params
+while [[ -z "$1" ]]
+do
+    echo "Missing docs version..."
+    exit 1
+done
+
+echo "Sync stable docs with docs at version $1"
+
+CONTENT_DIR=docs/content/en
+
+rm -rf $CONTENT_DIR/docs
+cp -rf $CONTENT_DIR/docs-$1 $CONTENT_DIR/docs
+cat <<EOT > $CONTENT_DIR/docs/_index.md
+---
+title: "Welcome to PipeCD"
+linkTitle: "Documentation"
+weight: 1
+menu:
+  main:
+    weight: 20
+---
+EOT
+
+echo "Stable version docs has been synced successfully with docs at version $1"


### PR DESCRIPTION
**What this PR does / why we need it**:

To reduce manual steps while updating docs of the latest released version, lets add a command to sync the change on the latest version docs to the stable docs. A typical use-case is: Make changes on specified released version docs (usually the latest version), run command to sync all the changes of that version docs as stable latest docs.

The command is: `make sync-stable-docs version=v0.21.x`

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
