### PR TITLE
Avoid to emit annoying error log for app live state

### DIFF
--- a/pkg/app/api/applicationlivestatestore/store.go
+++ b/pkg/app/api/applicationlivestatestore/store.go
@@ -63,7 +63,17 @@ func (s *store) GetStateSnapshot(ctx context.Context, applicationID string) (*mo
 
 	fileResp, err := s.backend.Get(ctx, applicationID)
 	if err != nil {
-		s.logger.Error("failed to get application live state from filestore", zap.Error(err))
+		if errors.Is(err, filestore.ErrNotFound) {
+			s.logger.Warn("application live state is not found",
+				zap.String("app-id", applicationID),
+				zap.Error(err),
+			)
+		} else {
+			s.logger.Error("failed to get application live state from filestore",
+				zap.String("app-id", applicationID),
+				zap.Error(err),
+			)
+		}
 		return nil, err
 	}
 

--- a/pkg/app/api/applicationlivestatestore/store.go
+++ b/pkg/app/api/applicationlivestatestore/store.go
@@ -63,14 +63,9 @@ func (s *store) GetStateSnapshot(ctx context.Context, applicationID string) (*mo
 
 	fileResp, err := s.backend.Get(ctx, applicationID)
 	if err != nil {
-		if errors.Is(err, filestore.ErrNotFound) {
-			s.logger.Warn("application live state is not found",
-				zap.String("app-id", applicationID),
-				zap.Error(err),
-			)
-		} else {
+		if !errors.Is(err, filestore.ErrNotFound) {
 			s.logger.Error("failed to get application live state from filestore",
-				zap.String("app-id", applicationID),
+				zap.String("application-id", applicationID),
 				zap.Error(err),
 			)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
Live state often doesn't exist in Filestore. It is annoying to emit logs for that.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
