### PR TITLE
Make sync stable docs command works without the specified version input

### DIFF
--- a/hack/sync-stable-docs.sh
+++ b/hack/sync-stable-docs.sh
@@ -14,19 +14,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# parse params
-while [[ -z "$1" ]]
-do
-    echo "Missing docs version..."
-    exit 1
-done
+# get version from the release/RELEASE file and create the version docs string
+# for example, with the release file content:
+# version: v0.21.0
+# the version docs string will be v0.21.x
+LATEST_DOCS_VERSION="$(cut -d ' ' -f 2 release/RELEASE | cut -d '.' -f -2).x"
 
-echo "Sync stable docs with docs at version $1"
+# parse params
+if [[ -z "$1" ]]
+then
+  STABLE_DOCS_VERSION=$LATEST_DOCS_VERSION
+else
+  STABLE_DOCS_VERSION=$1
+fi
+
+echo "Sync stable docs with docs at version $STABLE_DOCS_VERSION"
 
 CONTENT_DIR=docs/content/en
 
 rm -rf $CONTENT_DIR/docs
-cp -rf $CONTENT_DIR/docs-$1 $CONTENT_DIR/docs
+cp -rf $CONTENT_DIR/docs-$STABLE_DOCS_VERSION $CONTENT_DIR/docs
 cat <<EOT > $CONTENT_DIR/docs/_index.md
 ---
 title: "Welcome to PipeCD"
@@ -38,4 +45,4 @@ menu:
 ---
 EOT
 
-echo "Stable version docs has been synced successfully with docs at version $1"
+echo "Stable version docs has been synced successfully with docs at version $STABLE_DOCS_VERSION"


### PR DESCRIPTION
**What this PR does / why we need it**:

From this comment https://github.com/pipe-cd/pipe/pull/2724#issuecomment-957059664, this PR makes the `sync-stable-docs` command more usable. We're now can use this command in two ways for different use-cases:
- `make sync-stable-docs` will sync the content under `/docs` with the latest released version docs
- `make sync-stable-docs version=xx` will sync the content under `/docs` with the version docs specified via the version parameter.

The latest released version docs (in (1)) decided by using the release version number from `release/RELEASE` (basically remove the last minor number and replace it with `x` character). Docs for the latest released version are expected to be prepared before we run this command at any time, so using that value to decide would be okay.

**Which issue(s) this PR fixes**:

Follow PR #2724 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
