### PR TITLE
Send notification to users via Slack when it fails to trigger deployment

### DIFF
--- a/pkg/app/piped/notifier/BUILD.bazel
+++ b/pkg/app/piped/notifier/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/config:go_default_library",
+        "//pkg/git:go_default_library",
         "//pkg/model:go_default_library",
         "//pkg/version:go_default_library",
         "@org_golang_x_sync//errgroup:go_default_library",

--- a/pkg/app/piped/notifier/slack.go
+++ b/pkg/app/piped/notifier/slack.go
@@ -158,12 +158,21 @@ func (s *slack) buildSlackMessage(event model.NotificationEvent, webURL string) 
 		if err != nil {
 			s.logger.Error(fmt.Sprintf("failed to get the URL for the specified commit: %v", err))
 		}
-		fields = []slackField{
-			{"Project", truncateText(app.ProjectId, 8), true},
-			{"Application", makeSlackLink(app.Name, link), true},
-			{"Kind", strings.ToLower(app.Kind.String()), true},
-			{"Commit", makeSlackLink(truncateText(msg, 8), commitURL), true},
+		if commitURL == "" {
+			fields = []slackField{
+				{"Project", truncateText(app.ProjectId, 8), true},
+				{"Application", makeSlackLink(app.Name, link), true},
+				{"Kind", strings.ToLower(app.Kind.String()), true},
+			}
+		} else {
+			fields = []slackField{
+				{"Project", truncateText(app.ProjectId, 8), true},
+				{"Application", makeSlackLink(app.Name, link), true},
+				{"Kind", strings.ToLower(app.Kind.String()), true},
+				{"Commit", makeSlackLink(truncateText(msg, 8), commitURL), true},
+			}
 		}
+		
 	}
 	generatePipedEventData := func(id, name, version, project string) {
 		link = fmt.Sprintf("%s/settings/piped?project=%s", webURL, project)

--- a/pkg/app/piped/notifier/slack.go
+++ b/pkg/app/piped/notifier/slack.go
@@ -157,9 +157,10 @@ func (s *slack) buildSlackMessage(event model.NotificationEvent, webURL string) 
 		if err != nil {
 			s.logger.Error(fmt.Sprintf("failed to get the URL for the specified commit: %v", err))
 		}
+		link = makeSlackLink(app.Name, fmt.Sprintf("%s/applications/%s?project=%s", webURL, app.Id, app.PipedId))
 		fields = []slackField{
 			{"Project", truncateText(app.ProjectId, 8), true},
-			{"Application", makeSlackLink(app.Name, fmt.Sprintf("%s/applications/%s?project=%s", webURL, app.Id, app.PipedId)), true},
+			{"Application", link, true},
 			{"Kind", strings.ToLower(app.Kind.String()), true},
 			{"Commit", makeSlackLink(truncateText(msg, 8), commitURL), true},
 		}

--- a/pkg/app/piped/notifier/slack.go
+++ b/pkg/app/piped/notifier/slack.go
@@ -215,7 +215,7 @@ func (s *slack) buildSlackMessage(event model.NotificationEvent, webURL string) 
 
 	case model.NotificationEventType_EVENT_DEPLOYMENT_TRIGGER_FAILED:
 		md := event.Metadata.(*model.NotificationEventDeploymentTriggerFailed)
-		title = "Deployment Trigger was failed"
+		title = fmt.Sprintf("Failed to trigger a new deployment for %s", md.Application.Name)
 		text = md.Reason
 		generateDeploymentEventDataForTriggerFailed(md.Application, md.Hash, md.Message)
 

--- a/pkg/app/piped/notifier/slack.go
+++ b/pkg/app/piped/notifier/slack.go
@@ -153,8 +153,7 @@ func (s *slack) buildSlackMessage(event model.NotificationEvent, webURL string) 
 		}
 	}
 	generateDeploymentEventDataForTriggerFailed := func(app *model.Application, hash, msg string) {
-		var err error
-		link, err = git.MakeCommitURL(app.GitPath.Repo.Remote, hash)
+		commitURL, err := git.MakeCommitURL(app.GitPath.Repo.Remote, hash)
 		if err != nil {
 			s.logger.Error(fmt.Sprintf("failed to get the URL for the specified commit: %v", err))
 		}
@@ -162,7 +161,7 @@ func (s *slack) buildSlackMessage(event model.NotificationEvent, webURL string) 
 			{"Project", truncateText(app.ProjectId, 8), true},
 			{"Application", makeSlackLink(app.Name, fmt.Sprintf("%s/applications/%s?project=%s", webURL, app.Id, app.PipedId)), true},
 			{"Kind", strings.ToLower(app.Kind.String()), true},
-			{"Commit", makeSlackLink(truncateText(msg, 8), link), true},
+			{"Commit", makeSlackLink(truncateText(msg, 8), commitURL), true},
 		}
 	}
 	generatePipedEventData := func(id, name, version, project string) {

--- a/pkg/app/piped/notifier/slack.go
+++ b/pkg/app/piped/notifier/slack.go
@@ -158,19 +158,13 @@ func (s *slack) buildSlackMessage(event model.NotificationEvent, webURL string) 
 		if err != nil {
 			s.logger.Error(fmt.Sprintf("failed to get the URL for the specified commit: %v", err))
 		}
-		if commitURL == "" {
-			fields = []slackField{
-				{"Project", truncateText(app.ProjectId, 8), true},
-				{"Application", makeSlackLink(app.Name, link), true},
-				{"Kind", strings.ToLower(app.Kind.String()), true},
-			}
-		} else {
-			fields = []slackField{
-				{"Project", truncateText(app.ProjectId, 8), true},
-				{"Application", makeSlackLink(app.Name, link), true},
-				{"Kind", strings.ToLower(app.Kind.String()), true},
-				{"Commit", makeSlackLink(truncateText(msg, 8), commitURL), true},
-			}
+		fields = []slackField{
+			{"Project", truncateText(app.ProjectId, 8), true},
+			{"Application", makeSlackLink(app.Name, link), true},
+			{"Kind", strings.ToLower(app.Kind.String()), true},
+		}
+		if commitURL != "" {
+			fields = append(fields, slackField{"Commit", makeSlackLink(truncateText(msg, 8), commitURL), true})
 		}
 
 	}

--- a/pkg/app/piped/notifier/slack.go
+++ b/pkg/app/piped/notifier/slack.go
@@ -151,13 +151,13 @@ func (s *slack) buildSlackMessage(event model.NotificationEvent, webURL string) 
 			{"Started At", makeSlackDate(d.CreatedAt), true},
 		}
 	}
-	generateDeploymentEventDataForTriggerFailed := func(app *model.Application, commit *model.GitCommit) {
-		link = makeCommitLink(app.GitPath, commit.Hash)
+	generateDeploymentEventDataForTriggerFailed := func(app *model.Application, hash, msg string) {
+		link = makeCommitLink(app.GitPath, hash)
 		fields = []slackField{
 			{"Project", truncateText(app.ProjectId, 8), true},
 			{"Application", makeSlackLink(app.Name, fmt.Sprintf("%s/applications/%s?project=%s", webURL, app.Id, app.PipedId)), true},
 			{"Kind", strings.ToLower(app.Kind.String()), true},
-			{"Commit", makeSlackLink(truncateText(commit.Message, 8), link), true},
+			{"Commit", makeSlackLink(truncateText(msg, 8), link), true},
 		}
 	}
 	generatePipedEventData := func(id, name, version, project string) {
@@ -217,7 +217,7 @@ func (s *slack) buildSlackMessage(event model.NotificationEvent, webURL string) 
 		md := event.Metadata.(*model.NotificationEventDeploymentTriggerFailed)
 		title = "Deployment Trigger was failed"
 		text = md.Reason
-		generateDeploymentEventDataForTriggerFailed(md.Application, md.Commit)
+		generateDeploymentEventDataForTriggerFailed(md.Application, md.Hash, md.Message)
 
 	case model.NotificationEventType_EVENT_PIPED_STARTED:
 		md := event.Metadata.(*model.NotificationEventPipedStarted)

--- a/pkg/app/piped/notifier/slack.go
+++ b/pkg/app/piped/notifier/slack.go
@@ -213,7 +213,7 @@ func (s *slack) buildSlackMessage(event model.NotificationEvent, webURL string) 
 		md := event.Metadata.(*model.NotificationEventPipedStopped)
 		title = "A piped has been stopped"
 		generatePipedEventData(md.Id, md.Name, md.Version, md.ProjectId)
-	
+
 	case model.NotificationEventType_EVENT_PIPED_FAILED:
 		md := event.Metadata.(*model.NotificationEventPipedFailed)
 		title = "A piped failed to start"

--- a/pkg/app/piped/notifier/slack.go
+++ b/pkg/app/piped/notifier/slack.go
@@ -213,6 +213,12 @@ func (s *slack) buildSlackMessage(event model.NotificationEvent, webURL string) 
 		md := event.Metadata.(*model.NotificationEventPipedStopped)
 		title = "A piped has been stopped"
 		generatePipedEventData(md.Id, md.Name, md.Version, md.ProjectId)
+	
+	case model.NotificationEventType_EVENT_PIPED_FAILED:
+		md := event.Metadata.(*model.NotificationEventPipedFailed)
+		title = "A piped failed to start"
+		text = md.Reason
+		generatePipedEventData(md.Id, md.Name, md.Version, md.ProjectId)
 
 	// TODO: Support application type of notification event.
 	default:

--- a/pkg/app/piped/notifier/slack.go
+++ b/pkg/app/piped/notifier/slack.go
@@ -153,14 +153,14 @@ func (s *slack) buildSlackMessage(event model.NotificationEvent, webURL string) 
 		}
 	}
 	generateDeploymentEventDataForTriggerFailed := func(app *model.Application, hash, msg string) {
+		link = fmt.Sprintf("%s/applications/%s?project=%s", webURL, app.Id, app.PipedId)
 		commitURL, err := git.MakeCommitURL(app.GitPath.Repo.Remote, hash)
 		if err != nil {
 			s.logger.Error(fmt.Sprintf("failed to get the URL for the specified commit: %v", err))
 		}
-		link = makeSlackLink(app.Name, fmt.Sprintf("%s/applications/%s?project=%s", webURL, app.Id, app.PipedId))
 		fields = []slackField{
 			{"Project", truncateText(app.ProjectId, 8), true},
-			{"Application", link, true},
+			{"Application", makeSlackLink(app.Name, link), true},
 			{"Kind", strings.ToLower(app.Kind.String()), true},
 			{"Commit", makeSlackLink(truncateText(msg, 8), commitURL), true},
 		}

--- a/pkg/app/piped/notifier/slack.go
+++ b/pkg/app/piped/notifier/slack.go
@@ -217,7 +217,7 @@ func (s *slack) buildSlackMessage(event model.NotificationEvent, webURL string) 
 		md := event.Metadata.(*model.NotificationEventDeploymentTriggerFailed)
 		title = fmt.Sprintf("Failed to trigger a new deployment for %s", md.Application.Name)
 		text = md.Reason
-		generateDeploymentEventDataForTriggerFailed(md.Application, md.Hash, md.Message)
+		generateDeploymentEventDataForTriggerFailed(md.Application, md.CommitHash, md.CommitMessage)
 
 	case model.NotificationEventType_EVENT_PIPED_STARTED:
 		md := event.Metadata.(*model.NotificationEventPipedStarted)

--- a/pkg/app/piped/notifier/slack.go
+++ b/pkg/app/piped/notifier/slack.go
@@ -153,7 +153,7 @@ func (s *slack) buildSlackMessage(event model.NotificationEvent, webURL string) 
 		}
 	}
 	generateDeploymentEventDataForTriggerFailed := func(app *model.Application, hash, msg string) {
-		link = fmt.Sprintf("%s/applications/%s?project=%s", webURL, app.Id, app.PipedId)
+		link = fmt.Sprintf("%s/applications/%s?project=%s", webURL, app.Id, app.ProjectId)
 		commitURL, err := git.MakeCommitURL(app.GitPath.Repo.Remote, hash)
 		if err != nil {
 			s.logger.Error(fmt.Sprintf("failed to get the URL for the specified commit: %v", err))

--- a/pkg/app/piped/notifier/slack.go
+++ b/pkg/app/piped/notifier/slack.go
@@ -204,6 +204,12 @@ func (s *slack) buildSlackMessage(event model.NotificationEvent, webURL string) 
 		color = slackWarnColor
 		generateDeploymentEventData(md.Deployment, md.EnvName, getAccountsAsString(md.MentionedAccounts))
 
+	case model.NotificationEventType_EVENT_DEPLOYMENT_TRIGGER_FAILED:
+		md := event.Metadata.(*model.NotificationEventDeploymentTriggerFailed)
+		title = "Deployment Trigger was failed"
+		text = md.Reason
+		generatePipedEventData(md.Id, md.Name, md.Version, md.ProjectId)
+
 	case model.NotificationEventType_EVENT_PIPED_STARTED:
 		md := event.Metadata.(*model.NotificationEventPipedStarted)
 		title = "A piped has been started"
@@ -212,12 +218,6 @@ func (s *slack) buildSlackMessage(event model.NotificationEvent, webURL string) 
 	case model.NotificationEventType_EVENT_PIPED_STOPPED:
 		md := event.Metadata.(*model.NotificationEventPipedStopped)
 		title = "A piped has been stopped"
-		generatePipedEventData(md.Id, md.Name, md.Version, md.ProjectId)
-
-	case model.NotificationEventType_EVENT_PIPED_FAILED:
-		md := event.Metadata.(*model.NotificationEventPipedFailed)
-		title = "A piped failed to start"
-		text = md.Reason
 		generatePipedEventData(md.Id, md.Name, md.Version, md.ProjectId)
 
 	// TODO: Support application type of notification event.

--- a/pkg/app/piped/notifier/slack.go
+++ b/pkg/app/piped/notifier/slack.go
@@ -172,7 +172,7 @@ func (s *slack) buildSlackMessage(event model.NotificationEvent, webURL string) 
 				{"Commit", makeSlackLink(truncateText(msg, 8), commitURL), true},
 			}
 		}
-		
+
 	}
 	generatePipedEventData := func(id, name, version, project string) {
 		link = fmt.Sprintf("%s/settings/piped?project=%s", webURL, project)

--- a/pkg/app/piped/trigger/BUILD.bazel
+++ b/pkg/app/piped/trigger/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//pkg/filematcher:go_default_library",
         "//pkg/git:go_default_library",
         "//pkg/model:go_default_library",
+        "//pkg/version:go_default_library",
         "@com_github_google_uuid//:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//codes:go_default_library",

--- a/pkg/app/piped/trigger/deployment.go
+++ b/pkg/app/piped/trigger/deployment.go
@@ -189,11 +189,9 @@ func (t *Trigger) reportDeploymentFailed(app *model.Application, reason string, 
 		Type: model.NotificationEventType_EVENT_DEPLOYMENT_TRIGGER_FAILED,
 		Metadata: &model.NotificationEventDeploymentTriggerFailed{
 			Application: app,
-			Commit: &model.GitCommit{
-				Hash:    commit.Hash,
-				Message: commit.Message,
-			},
-			Reason: reason,
+			Hash:        commit.Hash,
+			Message:     commit.Message,
+			Reason:      reason,
 		},
 	})
 }

--- a/pkg/app/piped/trigger/deployment.go
+++ b/pkg/app/piped/trigger/deployment.go
@@ -190,7 +190,7 @@ func (t *Trigger) reportDeploymentFailed(app *model.Application, reason string, 
 		Metadata: &model.NotificationEventDeploymentTriggerFailed{
 			Application: app,
 			Commit: &model.GitCommit{
-				Hash: commit.Hash,
+				Hash:    commit.Hash,
 				Message: commit.Message,
 			},
 			Reason: reason,

--- a/pkg/app/piped/trigger/deployment.go
+++ b/pkg/app/piped/trigger/deployment.go
@@ -44,7 +44,7 @@ func (t *Trigger) triggerDeployment(
 	n, err := t.getNotification(app.GitPath)
 	if err != nil {
 		t.logger.Error("failed to get the list of mentions", zap.Error(err))
-		t.reportDeploymentFailed(app, fmt.Sprintf("failed to get the list of mentions %v", err), commit)
+		t.reportDeploymentFailed(app, fmt.Sprintf("failed to find the list of mentions from %s: %v", app.GitPath.GetDeploymentConfigFilePath(), err), commit)
 		return
 	}
 

--- a/pkg/app/piped/trigger/deployment.go
+++ b/pkg/app/piped/trigger/deployment.go
@@ -45,7 +45,7 @@ func (t *Trigger) triggerDeployment(
 	n, err := t.getNotification(app.GitPath)
 	if err != nil {
 		t.logger.Error("failed to get the list of mentions", zap.Error(err))
-		t.reportDeploymentFailed(ctx, fmt.Sprintf("failed to get the list of mentions %v", err))
+		t.reportDeploymentFailed(fmt.Sprintf("failed to get the list of mentions %v", err))
 		return
 	}
 
@@ -185,7 +185,7 @@ func buildDeployment(
 	return deployment, nil
 }
 
-func (t *Trigger) reportDeploymentFailed(ctx context.Context, reason string) {
+func (t *Trigger) reportDeploymentFailed(reason string) {
 	defer func() {
 		t.notifier.Notify(model.NotificationEvent{
 			Type: model.NotificationEventType_EVENT_PIPED_FAILED,

--- a/pkg/app/piped/trigger/deployment.go
+++ b/pkg/app/piped/trigger/deployment.go
@@ -51,7 +51,7 @@ func (t *Trigger) triggerDeployment(
 	deployment, err = buildDeployment(app, branch, commit, commander, syncStrategy, time.Now(), n)
 	if err != nil {
 		t.logger.Error("failed to build the deployment", zap.Error(err))
-		t.reportDeploymentFailed(app, fmt.Sprintf("failed to build the deployment %v", err), commit)
+		t.reportDeploymentFailed(app, fmt.Sprintf("failed to build the deployment: %v", err), commit)
 		return
 	}
 
@@ -88,7 +88,7 @@ func (t *Trigger) triggerDeployment(
 	}
 	if _, err = t.apiClient.CreateDeployment(ctx, req); err != nil {
 		t.logger.Error("failed to create deployment", zap.Error(err))
-		t.reportDeploymentFailed(app, fmt.Sprintf("failed to create deployment %v", err), commit)
+		t.reportDeploymentFailed(app, fmt.Sprintf("failed to create deployment: %v", err), commit)
 		return
 	}
 

--- a/pkg/app/piped/trigger/deployment.go
+++ b/pkg/app/piped/trigger/deployment.go
@@ -188,10 +188,10 @@ func (t *Trigger) reportDeploymentFailed(app *model.Application, reason string, 
 	t.notifier.Notify(model.NotificationEvent{
 		Type: model.NotificationEventType_EVENT_DEPLOYMENT_TRIGGER_FAILED,
 		Metadata: &model.NotificationEventDeploymentTriggerFailed{
-			Application: app,
-			Hash:        commit.Hash,
-			Message:     commit.Message,
-			Reason:      reason,
+			Application:   app,
+			CommitHash:    commit.Hash,
+			CommitMessage: commit.Message,
+			Reason:        reason,
 		},
 	})
 }

--- a/pkg/app/piped/trigger/deployment.go
+++ b/pkg/app/piped/trigger/deployment.go
@@ -186,18 +186,16 @@ func buildDeployment(
 }
 
 func (t *Trigger) reportDeploymentFailed(reason string) {
-	defer func() {
-		t.notifier.Notify(model.NotificationEvent{
-			Type: model.NotificationEventType_EVENT_DEPLOYMENT_TRIGGER_FAILED,
-			Metadata: &model.NotificationEventDeploymentTriggerFailed{
-				Id:        t.config.PipedID,
-				Name:      t.config.Name,
-				Version:   version.Get().Version,
-				ProjectId: t.config.ProjectID,
-				Reason:    reason,
-			},
-		})
-	}()
+	t.notifier.Notify(model.NotificationEvent{
+		Type: model.NotificationEventType_EVENT_DEPLOYMENT_TRIGGER_FAILED,
+		Metadata: &model.NotificationEventDeploymentTriggerFailed{
+			Id:        t.config.PipedID,
+			Name:      t.config.Name,
+			Version:   version.Get().Version,
+			ProjectId: t.config.ProjectID,
+			Reason:    reason,
+		},
+	})
 }
 
 func (t *Trigger) getNotification(p *model.ApplicationGitPath) (*config.DeploymentNotification, error) {

--- a/pkg/app/piped/trigger/deployment.go
+++ b/pkg/app/piped/trigger/deployment.go
@@ -188,8 +188,8 @@ func buildDeployment(
 func (t *Trigger) reportDeploymentFailed(reason string) {
 	defer func() {
 		t.notifier.Notify(model.NotificationEvent{
-			Type: model.NotificationEventType_EVENT_PIPED_FAILED,
-			Metadata: &model.NotificationEventPipedFailed{
+			Type: model.NotificationEventType_EVENT_DEPLOYMENT_TRIGGER_FAILED,
+			Metadata: &model.NotificationEventDeploymentTriggerFailed{
 				Id:        t.config.PipedID,
 				Name:      t.config.Name,
 				Version:   version.Get().Version,

--- a/pkg/app/piped/trigger/deployment.go
+++ b/pkg/app/piped/trigger/deployment.go
@@ -29,6 +29,7 @@ import (
 	"github.com/pipe-cd/pipe/pkg/config"
 	"github.com/pipe-cd/pipe/pkg/git"
 	"github.com/pipe-cd/pipe/pkg/model"
+	"github.com/pipe-cd/pipe/pkg/version"
 )
 
 const notificationsKey = "DeploymentNotification"
@@ -44,6 +45,7 @@ func (t *Trigger) triggerDeployment(
 	n, err := t.getNotification(app.GitPath)
 	if err != nil {
 		t.logger.Error("failed to get the list of mentions", zap.Error(err))
+		t.reportDeploymentFailed(ctx, fmt.Sprintf("failed to get the list of mentions %v", err))
 		return
 	}
 
@@ -181,6 +183,21 @@ func buildDeployment(
 	}
 
 	return deployment, nil
+}
+
+func (t *Trigger) reportDeploymentFailed(ctx context.Context, reason string) {
+	defer func() {
+		t.notifier.Notify(model.NotificationEvent{
+			Type: model.NotificationEventType_EVENT_PIPED_FAILED,
+			Metadata: &model.NotificationEventPipedFailed{
+				Id:        t.config.PipedID,
+				Name:      t.config.Name,
+				Version:   version.Get().Version,
+				ProjectId: t.config.ProjectID,
+				Reason:    reason,
+			},
+		})
+	}()
 }
 
 func (t *Trigger) getNotification(p *model.ApplicationGitPath) (*config.DeploymentNotification, error) {

--- a/pkg/app/piped/trigger/trigger.go
+++ b/pkg/app/piped/trigger/trigger.go
@@ -81,8 +81,6 @@ type Trigger struct {
 	gitRepos          map[string]git.Repo
 	gracePeriod       time.Duration
 	logger            *zap.Logger
-
-	nowFunc func() time.Time
 }
 
 // NewTrigger creates a new instance for Trigger.
@@ -119,7 +117,6 @@ func NewTrigger(
 		gitRepos:          make(map[string]git.Repo, len(cfg.Repositories)),
 		gracePeriod:       gracePeriod,
 		logger:            logger.Named("trigger"),
-		nowFunc:           time.Now,
 	}
 
 	return t, nil

--- a/pkg/app/piped/trigger/trigger.go
+++ b/pkg/app/piped/trigger/trigger.go
@@ -234,7 +234,7 @@ func (t *Trigger) checkNewCommits(ctx context.Context) error {
 			shouldTrigger, err := d.ShouldTrigger(ctx, app)
 			if err != nil {
 				t.logger.Error(fmt.Sprintf("failed to check application: %s", app.Id), zap.Error(err))
-				t.reportDeploymentFailed(ctx, fmt.Sprintf("failed to get the list of mentions %v", err))
+				t.reportDeploymentFailed(fmt.Sprintf("failed to get the list of mentions %v", err))
 				continue
 			}
 

--- a/pkg/app/piped/trigger/trigger.go
+++ b/pkg/app/piped/trigger/trigger.go
@@ -234,7 +234,7 @@ func (t *Trigger) checkNewCommits(ctx context.Context) error {
 			shouldTrigger, err := d.ShouldTrigger(ctx, app)
 			if err != nil {
 				t.logger.Error(fmt.Sprintf("failed to check application: %s", app.Id), zap.Error(err))
-				t.reportDeploymentFailed(fmt.Sprintf("failed to get the list of mentions %v", err))
+				t.reportDeploymentFailed(app, fmt.Sprintf("failed to get the list of mentions %v", err), headCommit)
 				continue
 			}
 

--- a/pkg/app/piped/trigger/trigger.go
+++ b/pkg/app/piped/trigger/trigger.go
@@ -45,7 +45,6 @@ type apiClient interface {
 	GetApplicationMostRecentDeployment(ctx context.Context, req *pipedservice.GetApplicationMostRecentDeploymentRequest, opts ...grpc.CallOption) (*pipedservice.GetApplicationMostRecentDeploymentResponse, error)
 	CreateDeployment(ctx context.Context, in *pipedservice.CreateDeploymentRequest, opts ...grpc.CallOption) (*pipedservice.CreateDeploymentResponse, error)
 	ReportApplicationMostRecentDeployment(ctx context.Context, req *pipedservice.ReportApplicationMostRecentDeploymentRequest, opts ...grpc.CallOption) (*pipedservice.ReportApplicationMostRecentDeploymentResponse, error)
-	ReportDeploymentCompleted(ctx context.Context, req *pipedservice.ReportDeploymentCompletedRequest, opts ...grpc.CallOption) (*pipedservice.ReportDeploymentCompletedResponse, error)
 }
 
 type gitClient interface {

--- a/pkg/app/piped/trigger/trigger.go
+++ b/pkg/app/piped/trigger/trigger.go
@@ -233,7 +233,7 @@ func (t *Trigger) checkNewCommits(ctx context.Context) error {
 			shouldTrigger, err := d.ShouldTrigger(ctx, app)
 			if err != nil {
 				t.logger.Error(fmt.Sprintf("failed to check application: %s", app.Id), zap.Error(err))
-				t.reportDeploymentFailed(app, fmt.Sprintf("failed to get the list of mentions %v", err), headCommit)
+				t.reportDeploymentFailed(app, fmt.Sprintf("failed to find the list of mentions from %s: %v", app.GitPath.GetDeploymentConfigFilePath(), err), headCommit)
 				continue
 			}
 

--- a/pkg/model/notificationevent.proto
+++ b/pkg/model/notificationevent.proto
@@ -103,8 +103,9 @@ message NotificationEventDeploymentWaitApproval {
 
 message NotificationEventDeploymentTriggerFailed {
     Application application = 1 [(validate.rules).message.required = true];
-    GitCommit commit = 2 [(validate.rules).message.required = true];
-    string reason = 3 [(validate.rules).string.min_len = 1];
+    string hash = 2 [(validate.rules).string.min_len = 1];
+    string message = 3 [(validate.rules).string.min_len = 1];
+    string reason = 4 [(validate.rules).string.min_len = 1];
 }
 
 message NotificationEventApplicationSynced {
@@ -131,9 +132,4 @@ message NotificationEventPipedStopped {
     string name = 2 [(validate.rules).string.min_len = 1];
     string version = 3;
     string project_id = 4 [(validate.rules).string.min_len = 1];
-}
-
-message GitCommit {
-    string hash = 4 [(validate.rules).string.min_len = 1];
-    string message = 7 [(validate.rules).string.min_len = 1];
 }

--- a/pkg/model/notificationevent.proto
+++ b/pkg/model/notificationevent.proto
@@ -30,6 +30,7 @@ enum NotificationEventType {
     EVENT_DEPLOYMENT_FAILED = 5;
     EVENT_DEPLOYMENT_CANCELLED = 6;
     EVENT_DEPLOYMENT_WAIT_APPROVAL = 7;
+    EVENT_DEPLOYMENT_TRIGGER_FAILED = 8;
 
     EVENT_APPLICATION_SYNCED = 100;
     EVENT_APPLICATION_OUT_OF_SYNC = 101;
@@ -39,8 +40,6 @@ enum NotificationEventType {
 
     EVENT_PIPED_STARTED = 300;
     EVENT_PIPED_STOPPED = 301;
-    EVENT_PIPED_FAILED = 302;
-
 }
 
 enum NotificationEventGroup {
@@ -102,6 +101,14 @@ message NotificationEventDeploymentWaitApproval {
     repeated string mentioned_accounts = 3;
 }
 
+message NotificationEventDeploymentTriggerFailed {
+    string id = 1 [(validate.rules).string.min_len = 1];
+    string name = 2 [(validate.rules).string.min_len = 1];
+    string version = 3;
+    string project_id = 4 [(validate.rules).string.min_len = 1];
+    string reason = 5;
+}
+
 message NotificationEventApplicationSynced {
     Application application = 1 [(validate.rules).message.required = true];
     string env_name = 2 [(validate.rules).string.min_len = 1];
@@ -126,12 +133,4 @@ message NotificationEventPipedStopped {
     string name = 2 [(validate.rules).string.min_len = 1];
     string version = 3;
     string project_id = 4 [(validate.rules).string.min_len = 1];
-}
-
-message NotificationEventPipedFailed {
-    string id = 1 [(validate.rules).string.min_len = 1];
-    string name = 2 [(validate.rules).string.min_len = 1];
-    string version = 3;
-    string project_id = 4 [(validate.rules).string.min_len = 1];
-    string reason = 5;
 }

--- a/pkg/model/notificationevent.proto
+++ b/pkg/model/notificationevent.proto
@@ -39,6 +39,7 @@ enum NotificationEventType {
 
     EVENT_PIPED_STARTED = 300;
     EVENT_PIPED_STOPPED = 301;
+    EVENT_PIPED_FAILED = 302;
 
 }
 
@@ -125,4 +126,12 @@ message NotificationEventPipedStopped {
     string name = 2 [(validate.rules).string.min_len = 1];
     string version = 3;
     string project_id = 4 [(validate.rules).string.min_len = 1];
+}
+
+message NotificationEventPipedFailed {
+    string id = 1 [(validate.rules).string.min_len = 1];
+    string name = 2 [(validate.rules).string.min_len = 1];
+    string version = 3;
+    string project_id = 4 [(validate.rules).string.min_len = 1];
+    string reason = 5;
 }

--- a/pkg/model/notificationevent.proto
+++ b/pkg/model/notificationevent.proto
@@ -103,8 +103,8 @@ message NotificationEventDeploymentWaitApproval {
 
 message NotificationEventDeploymentTriggerFailed {
     Application application = 1 [(validate.rules).message.required = true];
-    string hash = 2 [(validate.rules).string.min_len = 1];
-    string message = 3 [(validate.rules).string.min_len = 1];
+    string commit_hash = 2 [(validate.rules).string.min_len = 1];
+    string commit_message = 3 [(validate.rules).string.min_len = 1];
     string reason = 4 [(validate.rules).string.min_len = 1];
 }
 

--- a/pkg/model/notificationevent.proto
+++ b/pkg/model/notificationevent.proto
@@ -102,11 +102,9 @@ message NotificationEventDeploymentWaitApproval {
 }
 
 message NotificationEventDeploymentTriggerFailed {
-    string id = 1 [(validate.rules).string.min_len = 1];
-    string name = 2 [(validate.rules).string.min_len = 1];
-    string version = 3;
-    string project_id = 4 [(validate.rules).string.min_len = 1];
-    string reason = 5;
+    Application application = 1 [(validate.rules).message.required = true];
+    GitCommit commit = 2 [(validate.rules).message.required = true];
+    string reason = 3 [(validate.rules).string.min_len = 1];
 }
 
 message NotificationEventApplicationSynced {
@@ -133,4 +131,9 @@ message NotificationEventPipedStopped {
     string name = 2 [(validate.rules).string.min_len = 1];
     string version = 3;
     string project_id = 4 [(validate.rules).string.min_len = 1];
+}
+
+message GitCommit {
+    string hash = 4 [(validate.rules).string.min_len = 1];
+    string message = 7 [(validate.rules).string.min_len = 1];
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is related to #2742, but doesn't fix it. The following picture is an example.

![Screen Shot 2021-11-10 at 16 36 35](https://user-images.githubusercontent.com/59436572/141069897-84d5c70d-a724-494b-8d75-c0a1ae9b1601.png)

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Send notification events when it fails to trigger deployment
```
