### PR TITLE
Remove unneeded flag to specify tag from pipectl

### DIFF
--- a/pkg/app/pipectl/cmd/application/add.go
+++ b/pkg/app/pipectl/cmd/application/add.go
@@ -62,8 +62,6 @@ func newAddCommand(root *command) *cobra.Command {
 	cmd.Flags().StringVar(&c.appDir, "app-dir", c.appDir, "The relative path from the root of repository to the application directory.")
 	cmd.Flags().StringVar(&c.configFileName, "config-file-name", c.configFileName, "The configuration file name. Default is .pipe.yaml")
 	cmd.Flags().StringVar(&c.description, "description", c.description, "The description of the application.")
-	// TODO: Re-enabled pipectl to specify tags after we settled on using tags
-	//cmd.Flags().StringSliceVar(&c.tags, "tags", c.tags, "The comma-separated custom attributes of the application.")
 
 	cmd.MarkFlagRequired("app-name")
 	cmd.MarkFlagRequired("app-kind")
@@ -102,7 +100,6 @@ func (c *add) run(ctx context.Context, input cli.Input) error {
 		Kind:          model.ApplicationKind(appKind),
 		CloudProvider: c.cloudProvider,
 		Description:   c.description,
-		//Tags:          c.tags,
 	}
 
 	resp, err := cli.AddApplication(ctx, req)


### PR DESCRIPTION
**What this PR does / why we need it**:
We currently attempt to register labels via configuration declaratively.

**Which issue(s) this PR fixes**:

Closes https://github.com/pipe-cd/pipe/issues/2741

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
