### PR TITLE
Fix flaky launcher test

### DIFF
--- a/pkg/app/launcher/cmd/launcher/binary.go
+++ b/pkg/app/launcher/cmd/launcher/binary.go
@@ -50,7 +50,7 @@ func (c *command) GracefulStop(period time.Duration) error {
 	select {
 	case <-timer.C:
 		c.cmd.Process.Kill()
-		return nil
+		return <-c.stoppedCh
 	case err := <-c.stoppedCh:
 		return err
 	}

--- a/pkg/app/launcher/cmd/launcher/binary_test.go
+++ b/pkg/app/launcher/cmd/launcher/binary_test.go
@@ -28,6 +28,10 @@ func TestCommand(t *testing.T) {
 	require.NotNil(t, cmd)
 
 	assert.True(t, cmd.IsRunning())
-	cmd.GracefulStop(time.Millisecond)
+
+	stopAfter := time.Millisecond
+	cmd.GracefulStop(stopAfter)
+	time.Sleep(stopAfter)
+
 	assert.False(t, cmd.IsRunning())
 }

--- a/pkg/app/launcher/cmd/launcher/binary_test.go
+++ b/pkg/app/launcher/cmd/launcher/binary_test.go
@@ -22,16 +22,30 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCommand(t *testing.T) {
-	cmd, err := runBinary("sh", []string{"sleep", "1m"})
-	require.NoError(t, err)
-	require.NotNil(t, cmd)
+func TestGracefulStopCommand(t *testing.T) {
+	testcases := []struct {
+		name      string
+		stopAfter time.Duration
+	}{
+		{
+			name:      "graceful stop after very short time",
+			stopAfter: time.Nanosecond,
+		},
+		{
+			name:      "graceful stop after second",
+			stopAfter: time.Second,
+		},
+	}
 
-	assert.True(t, cmd.IsRunning())
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd, err := runBinary("sh", []string{"sleep", "1m"})
+			require.NoError(t, err)
+			require.NotNil(t, cmd)
 
-	stopAfter := time.Millisecond
-	cmd.GracefulStop(stopAfter)
-	time.Sleep(stopAfter)
-
-	assert.False(t, cmd.IsRunning())
+			assert.True(t, cmd.IsRunning())
+			cmd.GracefulStop(tc.stopAfter)
+			assert.False(t, cmd.IsRunning())
+		})
+	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Suspend below flaky test
```console
(12:45:17) FAIL: //pkg/app/launcher/cmd/launcher:go_default_test (see /private/var/tmp/_bazel_/2d45f513ea3114123209fc663da944fe/execroot/pipe/bazel-out/darwin-fastbuild/testlogs/pkg/app/launcher/cmd/launcher/go_default_test/test.log)
(12:45:17) INFO: From Testing //pkg/app/launcher/cmd/launcher:go_default_test:
==================== Test output for //pkg/app/launcher/cmd/launcher:go_default_test:
--- FAIL: TestCommand (0.00s)
    binary_test.go:32: 
                Error Trace:    binary_test.go:32
                Error:          Should be false
                Test:           TestCommand
FAIL
================================================================================
```

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
