### PR TITLE
Bump terraform version to v1.0.10 in terraform examples

### DIFF
--- a/examples/terraform/simple/.pipe.yaml
+++ b/examples/terraform/simple/.pipe.yaml
@@ -3,7 +3,7 @@ apiVersion: pipecd.dev/v1beta1
 kind: TerraformApp
 spec:
   input:
-    terraformVersion: 0.12.26
+    terraformVersion: 1.0.10
   encryption:
     encryptedSecrets:
       serviceAccount: {ENCRYPTED_DATA_GENERATED_FROM_WEB}

--- a/examples/terraform/wait-approval/.pipe.yaml
+++ b/examples/terraform/wait-approval/.pipe.yaml
@@ -4,7 +4,7 @@ kind: TerraformApp
 spec:
   input:
     workspace: dev
-    terraformVersion: 0.12.26
+    terraformVersion: 1.0.10
   pipeline:
     stages:
       - name: TERRAFORM_PLAN


### PR DESCRIPTION
**What this PR does / why we need it**:

the latest version is v1.0.10
https://github.com/hashicorp/terraform/tags

I've confirmed it works expectedly.

(this is internal site)
- pipecd: https://dev.pipecd.dev/deployments/39a04705-7a14-49b4-b277-bef86b6a49d5?project=pipecd
- repository: https://github.com/pipe-cd/chaspy-dev/commit/b45538abba3a080f0355441d51e7c3859ed462e6

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
