### PR TITLE
Add a piped component that watches app configs

### DIFF
--- a/pkg/app/api/grpcapi/piped_api.go
+++ b/pkg/app/api/grpcapi/piped_api.go
@@ -933,6 +933,16 @@ func (a *PipedAPI) GetDesiredVersion(ctx context.Context, _ *pipedservice.GetDes
 	}, nil
 }
 
+func (a *PipedAPI) UpdateApplicationConfigurations(ctx context.Context, req *pipedservice.UpdateApplicationConfigurationsRequest) (*pipedservice.UpdateApplicationConfigurationsResponse, error) {
+	// TODO: Update the given application configurations
+	return nil, status.Errorf(codes.Unimplemented, "UpdateApplicationConfigurations is not implemented yet")
+}
+
+func (a *PipedAPI) PutUnregisteredApplicationConfigurations(ctx context.Context, req *pipedservice.PutUnregisteredApplicationConfigurationsRequest) (*pipedservice.PutUnregisteredApplicationConfigurationsResponse, error) {
+	// TODO: Make the unused application configurations cache up-to-date
+	return nil, status.Errorf(codes.Unimplemented, "PutUnregisteredApplicationConfigurations is not implemented yet")
+}
+
 // validateAppBelongsToPiped checks if the given application belongs to the given piped.
 // It gives back an error unless the application belongs to the piped.
 func (a *PipedAPI) validateAppBelongsToPiped(ctx context.Context, appID, pipedID string) error {

--- a/pkg/app/api/grpcapi/piped_api.go
+++ b/pkg/app/api/grpcapi/piped_api.go
@@ -938,9 +938,9 @@ func (a *PipedAPI) UpdateApplicationConfigurations(ctx context.Context, req *pip
 	return nil, status.Errorf(codes.Unimplemented, "UpdateApplicationConfigurations is not implemented yet")
 }
 
-func (a *PipedAPI) PutUnregisteredApplicationConfigurations(ctx context.Context, req *pipedservice.PutUnregisteredApplicationConfigurationsRequest) (*pipedservice.PutUnregisteredApplicationConfigurationsResponse, error) {
+func (a *PipedAPI) ReportUnregisteredApplicationConfigurations(ctx context.Context, req *pipedservice.ReportUnregisteredApplicationConfigurationsRequest) (*pipedservice.ReportUnregisteredApplicationConfigurationsResponse, error) {
 	// TODO: Make the unused application configurations cache up-to-date
-	return nil, status.Errorf(codes.Unimplemented, "PutUnregisteredApplicationConfigurations is not implemented yet")
+	return nil, status.Errorf(codes.Unimplemented, "ReportUnregisteredApplicationConfigurations is not implemented yet")
 }
 
 // validateAppBelongsToPiped checks if the given application belongs to the given piped.

--- a/pkg/app/api/service/pipedservice/service.proto
+++ b/pkg/app/api/service/pipedservice/service.proto
@@ -164,8 +164,8 @@ service PipedService {
 
     // UpdateApplicationConfigurations updates application configurations.
     rpc UpdateApplicationConfigurations(UpdateApplicationConfigurationsRequest) returns (UpdateApplicationConfigurationsResponse) {}
-    // PutLatestUnusedApplicationConfigurations puts the latest configurations of applications that isn't registered yet.
-    rpc PutUnregisteredApplicationConfigurations(PutUnregisteredApplicationConfigurationsRequest) returns (PutUnregisteredApplicationConfigurationsResponse) {}
+    // ReportLatestUnusedApplicationConfigurations puts the latest configurations of applications that isn't registered yet.
+    rpc ReportUnregisteredApplicationConfigurations(ReportUnregisteredApplicationConfigurationsRequest) returns (ReportUnregisteredApplicationConfigurationsResponse) {}
 }
 
 enum ListOrder {
@@ -449,28 +449,20 @@ message GetDesiredVersionResponse {
     string version = 1;
 }
 
-message ApplicationConfiguration {
-    // TODO: Make it possible to update application configs via Piped
-    //   To do so, first we need to enable application configs to be defined in Git repository
-    //string name = 1 [(validate.rules).string.min_len = 1];
-    //string kind = 2 [(validate.rules).string.min_len = 1];
-    //string env_id = 3 [(validate.rules).string.min_len = 1];
-    map<string, string> labels = 4;
-}
 
 message UpdateApplicationConfigurationsRequest {
     // The application configurations that should be updated.
-    repeated ApplicationConfiguration applications = 1;
+    repeated pipe.model.ApplicationInfo applications = 1;
 }
 
 message UpdateApplicationConfigurationsResponse {
 }
 
-message PutUnregisteredApplicationConfigurationsRequest {
+message ReportUnregisteredApplicationConfigurationsRequest {
     // All the latest application configurations that isn't registered yet.
     // Note that ALL configs are always be contained every time.
-    repeated ApplicationConfiguration applications = 1;
+    repeated pipe.model.ApplicationInfo applications = 1;
 }
 
-message PutUnregisteredApplicationConfigurationsResponse {
+message ReportUnregisteredApplicationConfigurationsResponse {
 }

--- a/pkg/app/api/service/pipedservice/service.proto
+++ b/pkg/app/api/service/pipedservice/service.proto
@@ -162,7 +162,10 @@ service PipedService {
     // GetDesiredVersion returns the desired version of the given Piped.
     rpc GetDesiredVersion(GetDesiredVersionRequest) returns (GetDesiredVersionResponse) {}
 
-    // TODO: Add an rpc to update application info based on one defined in the application config
+    // UpdateApplicationConfigurations updates application configurations.
+    rpc UpdateApplicationConfigurations(UpdateApplicationConfigurationsRequest) returns (UpdateApplicationConfigurationsResponse) {}
+    // PutLatestUnusedApplicationConfigurations puts the latest configurations of applications that isn't registered yet.
+    rpc PutUnregisteredApplicationConfigurations(PutUnregisteredApplicationConfigurationsRequest) returns (PutUnregisteredApplicationConfigurationsResponse) {}
 }
 
 enum ListOrder {
@@ -444,4 +447,30 @@ message GetDesiredVersionRequest {
 
 message GetDesiredVersionResponse {
     string version = 1;
+}
+
+message ApplicationConfiguration {
+    // TODO: Make it possible to update application configs via Piped
+    //   To do so, first we need to enable application configs to be defined in Git repository
+    //string name = 1 [(validate.rules).string.min_len = 1];
+    //string kind = 2 [(validate.rules).string.min_len = 1];
+    //string env_id = 3 [(validate.rules).string.min_len = 1];
+    map<string, string> labels = 4;
+}
+
+message UpdateApplicationConfigurationsRequest {
+    // The application configurations that should be updated.
+    repeated ApplicationConfiguration applications = 1;
+}
+
+message UpdateApplicationConfigurationsResponse {
+}
+
+message PutUnregisteredApplicationConfigurationsRequest {
+    // All the latest application configurations that isn't registered yet.
+    // Note that ALL configs are always be contained every time.
+    repeated ApplicationConfiguration applications = 1;
+}
+
+message PutUnregisteredApplicationConfigurationsResponse {
 }

--- a/pkg/app/piped/apistore/environmentstore/store.go
+++ b/pkg/app/piped/apistore/environmentstore/store.go
@@ -34,27 +34,33 @@ const (
 
 type apiClient interface {
 	GetEnvironment(ctx context.Context, in *pipedservice.GetEnvironmentRequest, opts ...grpc.CallOption) (*pipedservice.GetEnvironmentResponse, error)
+	//GetEnvironmentByName(ctx context.Context, in *pipedservice.GetEnvironmentByNameRequest, opts ...grpc.CallOption) (*pipedservice.GetEnvironmentByNameResponse, error)
 }
 
 // Lister helps list and get Environment.
 // All objects returned here must be treated as read-only.
 type Lister interface {
 	Get(ctx context.Context, id string) (*model.Environment, error)
+	GetByName(ctx context.Context, name string) (*model.Environment, error)
 }
 
 type Store struct {
 	apiClient apiClient
-	cache     cache.Cache
-	callGroup *singleflight.Group
-	logger    *zap.Logger
+	// A goroutine-safe map from id to Environment.
+	cache cache.Cache
+	// A goroutine-safe map from name to Environment.
+	cacheByName cache.Cache
+	callGroup   *singleflight.Group
+	logger      *zap.Logger
 }
 
-func NewStore(apiClient apiClient, cache cache.Cache, logger *zap.Logger) *Store {
+func NewStore(apiClient apiClient, cache, cacheByName cache.Cache, logger *zap.Logger) *Store {
 	return &Store{
-		apiClient: apiClient,
-		cache:     cache,
-		callGroup: &singleflight.Group{},
-		logger:    logger.Named("environmentstore"),
+		apiClient:   apiClient,
+		cache:       cache,
+		cacheByName: cacheByName,
+		callGroup:   &singleflight.Group{},
+		logger:      logger.Named("environmentstore"),
 	}
 }
 
@@ -93,4 +99,46 @@ func (s *Store) Get(ctx context.Context, id string) (*model.Environment, error) 
 		return nil, err
 	}
 	return data.(*model.Environment), nil
+}
+
+// TODO: Implement environmentstore.GetByName
+func (s *Store) GetByName(ctx context.Context, name string) (*model.Environment, error) {
+	/*
+		env, err := s.cacheByName.Get(name)
+		if err == nil {
+			return env.(*model.Environment), nil
+		}
+
+		// Ensure that timeout is configured.
+		ctx, cancel := context.WithTimeout(ctx, defaultAPITimeout)
+		defer cancel()
+
+		// Ensure that only one RPC call is executed for the given key at a time
+		// and the newest data is stored in the cache.
+		data, err, _ := s.callGroup.Do(name, func() (interface{}, error) {
+			req := &pipedservice.GetEnvironmentByNameRequest{
+				Name: name,
+			}
+			resp, err := s.apiClient.GetEnvironmentByName(ctx, req)
+			if err != nil {
+				s.logger.Warn("failed to get environment from control plane",
+					zap.String("name", name),
+					zap.Error(err),
+				)
+				return nil, fmt.Errorf("failed to get environment %s, %w", name, err)
+			}
+
+			if err := s.cacheByName.Put(id, resp.Environment); err != nil {
+				s.logger.Warn("failed to put environment to cache", zap.Error(err))
+			}
+			return resp.Environment, nil
+		})
+
+		if err != nil {
+			return nil, err
+		}
+		return data.(*model.Environment), nil
+	*/
+
+	return nil, fmt.Errorf("not implemented")
 }

--- a/pkg/app/piped/appconfigreporter/BUILD.bazel
+++ b/pkg/app/piped/appconfigreporter/BUILD.bazel
@@ -1,0 +1,18 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["appconfigreporter.go"],
+    importpath = "github.com/pipe-cd/pipe/pkg/app/piped/appconfigreporter",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/app/api/service/pipedservice:go_default_library",
+        "//pkg/cache:go_default_library",
+        "//pkg/cache/memorycache:go_default_library",
+        "//pkg/config:go_default_library",
+        "//pkg/git:go_default_library",
+        "//pkg/model:go_default_library",
+        "@org_golang_google_grpc//:go_default_library",
+        "@org_uber_go_zap//:go_default_library",
+    ],
+)

--- a/pkg/app/piped/appconfigreporter/BUILD.bazel
+++ b/pkg/app/piped/appconfigreporter/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -7,12 +7,22 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/app/api/service/pipedservice:go_default_library",
-        "//pkg/cache:go_default_library",
-        "//pkg/cache/memorycache:go_default_library",
         "//pkg/config:go_default_library",
         "//pkg/git:go_default_library",
         "//pkg/model:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
+        "@org_uber_go_zap//:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    size = "small",
+    srcs = ["appconfigreporter_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//pkg/model:go_default_library",
+        "@com_github_stretchr_testify//assert:go_default_library",
         "@org_uber_go_zap//:go_default_library",
     ],
 )

--- a/pkg/app/piped/appconfigreporter/appconfigreporter.go
+++ b/pkg/app/piped/appconfigreporter/appconfigreporter.go
@@ -1,0 +1,220 @@
+// Copyright 2021 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package appconfigreporter
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"time"
+
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+
+	"github.com/pipe-cd/pipe/pkg/app/api/service/pipedservice"
+	"github.com/pipe-cd/pipe/pkg/cache"
+	"github.com/pipe-cd/pipe/pkg/cache/memorycache"
+	"github.com/pipe-cd/pipe/pkg/config"
+	"github.com/pipe-cd/pipe/pkg/git"
+	"github.com/pipe-cd/pipe/pkg/model"
+)
+
+const (
+	defaultLastFetchedCommitCacheSize = 500
+)
+
+type apiClient interface {
+	UpdateApplicationConfigurations(ctx context.Context, in *pipedservice.UpdateApplicationConfigurationsRequest, opts ...grpc.CallOption) (*pipedservice.UpdateApplicationConfigurationsResponse, error)
+	PutUnregisteredApplicationConfigurations(ctx context.Context, in *pipedservice.PutUnregisteredApplicationConfigurationsRequest, opts ...grpc.CallOption) (*pipedservice.PutUnregisteredApplicationConfigurationsResponse, error)
+}
+
+type gitClient interface {
+	Clone(ctx context.Context, repoID, remote, branch, destination string) (git.Repo, error)
+}
+
+type applicationLister interface {
+	List() []*model.Application
+}
+
+type Reporter struct {
+	apiClient         apiClient
+	gitClient         gitClient
+	applicationLister applicationLister
+	config            *config.PipedSpec
+	gitRepos          map[string]git.Repo
+	gracePeriod       time.Duration
+	// Cache for the last fetched commit for each repository.
+	lastFetchedCommitCache cache.Cache
+	logger                 *zap.Logger
+}
+
+func NewReporter(
+	apiClient apiClient,
+	gitClient gitClient,
+	appLister applicationLister,
+	cfg *config.PipedSpec,
+	gracePeriod time.Duration,
+	logger *zap.Logger,
+) (*Reporter, error) {
+	cache, err := memorycache.NewLRUCache(defaultLastFetchedCommitCacheSize)
+	if err != nil {
+		return nil, err
+	}
+	return &Reporter{
+		apiClient:              apiClient,
+		gitClient:              gitClient,
+		applicationLister:      appLister,
+		config:                 cfg,
+		gracePeriod:            gracePeriod,
+		lastFetchedCommitCache: cache,
+		logger:                 logger.Named("app-config-reporter"),
+	}, nil
+}
+
+func (r *Reporter) Run(ctx context.Context) error {
+	r.logger.Info("start running app-config-reporter")
+
+	// Pre-clone to cache the registered git repositories.
+	r.gitRepos = make(map[string]git.Repo, len(r.config.Repositories))
+	for _, repoCfg := range r.config.Repositories {
+		repo, err := r.gitClient.Clone(ctx, repoCfg.RepoID, repoCfg.Remote, repoCfg.Branch, "")
+		if err != nil {
+			r.logger.Error("failed to clone repository",
+				zap.String("repo-id", repoCfg.RepoID),
+				zap.Error(err),
+			)
+			return err
+		}
+		r.gitRepos[repoCfg.RepoID] = repo
+	}
+
+	// FIXME: Think about sync interval of app config reporter
+	ticker := time.NewTicker(r.config.SyncInterval.Duration())
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			if err := r.checkApps(ctx); err != nil {
+				r.logger.Error("failed to check application configurations defined in Git", zap.Error(err))
+			}
+		case <-ctx.Done():
+			r.logger.Info("app-config-reporter has been stopped")
+			return nil
+		}
+	}
+}
+
+// checkApps checks and reports two types of applications.
+// One is applications registered in Control-plane already, and another is ones that aren't registered yet.
+func (r *Reporter) checkApps(ctx context.Context) (err error) {
+	if len(r.gitRepos) == 0 {
+		r.logger.Info("no repositories were configured for this piped")
+		return
+	}
+
+	var (
+		unusedApps      = make([]*pipedservice.ApplicationConfiguration, 0)
+		appsToBeUpdated = make([]*pipedservice.ApplicationConfiguration, 0)
+		appsMap         = r.listApplications()
+	)
+	for repoID, repo := range r.gitRepos {
+		if err = repo.Pull(ctx, repo.GetClonedBranch()); err != nil {
+			r.logger.Error("failed to update repo to latest",
+				zap.String("repo-id", repoID),
+				zap.Error(err),
+			)
+			return
+		}
+
+		// TODO: Collect unused application configurations that aren't used yet
+		//   Currently, it could be thought the best to open files that suffixed by .pipe.yaml
+
+		var headCommit git.Commit
+		// Get the head commit of the repository.
+		headCommit, err = repo.GetLatestCommit(ctx)
+		if err != nil {
+			return
+		}
+		var lastFetchedCommit interface{}
+		lastFetchedCommit, err = r.lastFetchedCommitCache.Get(repoID)
+		if err != nil && !errors.Is(err, cache.ErrNotFound) {
+			r.logger.Error("failed to get the last fetched commit from cache", zap.Error(err))
+		}
+		if headCommit.Hash == lastFetchedCommit.(string) {
+			continue
+		}
+		apps, ok := appsMap[repoID]
+		if !ok {
+			continue
+		}
+		for _, app := range apps {
+			gitPath := app.GetGitPath()
+			_ = filepath.Join(repo.GetPath(), gitPath.Path, gitPath.ConfigFilename)
+			// TODO: Collect applications that need to be updated
+		}
+
+		defer func() {
+			if err == nil {
+				r.lastFetchedCommitCache.Put(repoID, headCommit)
+			}
+		}()
+	}
+	if len(unusedApps) > 0 {
+		_, err = r.apiClient.PutUnregisteredApplicationConfigurations(
+			ctx,
+			&pipedservice.PutUnregisteredApplicationConfigurationsRequest{
+				Applications: unusedApps,
+			},
+		)
+		if err != nil {
+			return fmt.Errorf("failed to put the latest unregistered application configurations: %w", err)
+		}
+	}
+
+	if len(appsToBeUpdated) == 0 {
+		return nil
+	}
+	_, err = r.apiClient.UpdateApplicationConfigurations(
+		ctx,
+		&pipedservice.UpdateApplicationConfigurationsRequest{
+			Applications: appsToBeUpdated,
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("failed to update application configurations: %w", err)
+	}
+
+	return
+}
+
+// listApplications retrieves all applications that should be handled by this piped
+// and then groups them by repoID.
+func (r *Reporter) listApplications() map[string][]*model.Application {
+	var (
+		apps       = r.applicationLister.List()
+		repoToApps = make(map[string][]*model.Application)
+	)
+	for _, app := range apps {
+		repoId := app.GitPath.Repo.Id
+		if _, ok := repoToApps[repoId]; !ok {
+			repoToApps[repoId] = []*model.Application{app}
+		} else {
+			repoToApps[repoId] = append(repoToApps[repoId], app)
+		}
+	}
+	return repoToApps
+}

--- a/pkg/app/piped/appconfigreporter/appconfigreporter.go
+++ b/pkg/app/piped/appconfigreporter/appconfigreporter.go
@@ -226,7 +226,8 @@ func (r *Reporter) updateRegisteredApps(ctx context.Context, registeredAppPaths 
 		if err != nil {
 			return fmt.Errorf("failed to get the latest commit of %s: %w", repoID, err)
 		}
-		as, err := r.findRegisteredApps(ctx, repoID, repo, headCommit.Hash, registeredAppPaths)
+		var as []*model.ApplicationInfo
+		as, err = r.findRegisteredApps(ctx, repoID, repo, headCommit.Hash, registeredAppPaths)
 		if err != nil {
 			return err
 		}
@@ -305,7 +306,7 @@ func shouldSkip(repoID, path, cfgFilename string, registeredAppPaths map[string]
 	return false
 }
 
-func (r *Reporter) readApplicationInfo(ctx context.Context, path, cfgFilePath string) (appInfo *model.ApplicationInfo, err error) {
+func (r *Reporter) readApplicationInfo(ctx context.Context, path, cfgFilePath string) (*model.ApplicationInfo, error) {
 	b, err := fs.ReadFile(r.fsys, cfgFilePath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open the configuration file: %w", err)

--- a/pkg/app/piped/appconfigreporter/appconfigreporter.go
+++ b/pkg/app/piped/appconfigreporter/appconfigreporter.go
@@ -130,8 +130,9 @@ func (r *Reporter) scanAppConfigs(ctx context.Context) error {
 	}
 
 	// Create a map to determine from GitPath if the application is registered.
-	registeredAppPaths := make(map[string]struct{})
-	for _, app := range r.applicationLister.List() {
+	apps := r.applicationLister.List()
+	registeredAppPaths := make(map[string]struct{}, len(apps))
+	for _, app := range apps {
 		id := model.BuildGitPathID(app.GitPath.Repo.Id, app.GitPath.Path, app.GitPath.ConfigFilename)
 		registeredAppPaths[id] = struct{}{}
 	}

--- a/pkg/app/piped/appconfigreporter/appconfigreporter.go
+++ b/pkg/app/piped/appconfigreporter/appconfigreporter.go
@@ -46,7 +46,6 @@ type applicationLister interface {
 }
 
 type environmentGetter interface {
-	Get(ctx context.Context, id string) (*model.Environment, error)
 	GetByName(ctx context.Context, name string) (*model.Environment, error)
 }
 

--- a/pkg/app/piped/appconfigreporter/appconfigreporter.go
+++ b/pkg/app/piped/appconfigreporter/appconfigreporter.go
@@ -357,6 +357,7 @@ func (r *Reporter) readApplicationInfo(ctx context.Context, cfgFilePath string) 
 		return nil, fmt.Errorf("failed to get env by name: %w", err)
 	}
 
+	// TODO: Return an error if any one of required field of Application is empty
 	return &model.ApplicationInfo{
 		Name: spec.Name,
 		// TODO: Convert Kind string into dedicated type

--- a/pkg/app/piped/appconfigreporter/appconfigreporter.go
+++ b/pkg/app/piped/appconfigreporter/appconfigreporter.go
@@ -67,13 +67,11 @@ type Reporter struct {
 	gitRepos          map[string]git.Repo
 	gracePeriod       time.Duration
 	// Cache for the last scanned commit for each repository.
-	// Not goroutine safe.
 	lastScannedCommits map[string]string
 	fileSystem         fs.FS
 	logger             *zap.Logger
 
 	// Whether it already swept all unregistered apps from control-plane.
-	// Not goroutine safe.
 	sweptUnregisteredApps bool
 }
 
@@ -301,15 +299,15 @@ func (r *Reporter) scanAllFiles(ctx context.Context, repoRoot, repoID string, re
 		if d.IsDir() {
 			return nil
 		}
+		if !strings.HasSuffix(path, model.DefaultDeploymentConfigFileExtension) {
+			return nil
+		}
 
 		cfgRelPath, err := filepath.Rel(repoRoot, path)
 		if err != nil {
 			return err
 		}
 
-		if !strings.HasSuffix(cfgRelPath, model.DefaultDeploymentConfigFileExtension) {
-			return nil
-		}
 		gitPathKey := makeGitPathKey(repoID, cfgRelPath)
 		if _, registered := registeredAppPaths[gitPathKey]; registered != wantRegistered {
 			return nil

--- a/pkg/app/piped/appconfigreporter/appconfigreporter_test.go
+++ b/pkg/app/piped/appconfigreporter/appconfigreporter_test.go
@@ -1,0 +1,116 @@
+// Copyright 2021 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package appconfigreporter
+
+import (
+	"io/fs"
+	"testing"
+	"testing/fstest"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+
+	"github.com/pipe-cd/pipe/pkg/model"
+)
+
+func Test_findUnregisteredApps(t *testing.T) {
+	type args struct {
+		registeredAppPaths map[string]struct{}
+		fileSystem         fs.FS
+		repoPath, repoID   string
+	}
+	testcases := []struct {
+		name     string
+		reporter *Reporter
+		args     args
+		want     []*model.ApplicationInfo
+		wantErr  bool
+	}{
+		{
+			name: "file not found",
+			args: args{
+				fileSystem: fstest.MapFS{
+					"path/to/repo-1/app-1/app.pipecd.yaml": &fstest.MapFile{Data: []byte("")},
+				},
+				repoPath:           "invalid",
+				repoID:             "repo-1",
+				registeredAppPaths: map[string]struct{}{},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "all are registered",
+			args: args{
+				fileSystem: fstest.MapFS{
+					"path/to/repo-1/app-1/app.pipecd.yaml": &fstest.MapFile{Data: []byte("")},
+				},
+				repoPath: "path/to/repo-1",
+				repoID:   "repo-1",
+				registeredAppPaths: map[string]struct{}{
+					"repo-1:path/to/repo-1/app.pipecd.yaml": {},
+				},
+			},
+			want:    []*model.ApplicationInfo{},
+			wantErr: false,
+		},
+		{
+			name: "invalid app config is contained",
+			args: args{
+				fileSystem: fstest.MapFS{
+					"path/to/repo-1/app-1/app.pipecd.yaml": &fstest.MapFile{Data: []byte("invalid-text")},
+				},
+				repoPath:           "path/to/repo-1",
+				repoID:             "repo-1",
+				registeredAppPaths: map[string]struct{}{},
+			},
+			want:    []*model.ApplicationInfo{},
+			wantErr: false,
+		},
+		{
+			name: "valid app config that is unregistered",
+			args: args{
+				fileSystem: fstest.MapFS{
+					"path/to/repo-1/app-1/app.pipecd.yaml": &fstest.MapFile{Data: []byte(`
+apiVersion: pipecd.dev/v1beta1
+kind: KubernetesApp
+spec:
+  name: app-1
+  labels:
+    key-1: value-1`)},
+				},
+				repoPath:           "path/to/repo-1",
+				repoID:             "repo-1",
+				registeredAppPaths: map[string]struct{}{},
+			},
+			want: []*model.ApplicationInfo{
+				{
+					Name:           "app-1",
+					Labels:         map[string]string{"key-1": "value-1"},
+					Path:           "path/to/repo-1",
+					ConfigFilename: "app.pipecd.yaml",
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := findUnregisteredApps(tc.args.fileSystem, tc.args.repoPath, tc.args.repoID, tc.args.registeredAppPaths, zap.NewNop())
+			assert.Equal(t, tc.wantErr, err != nil)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/pkg/app/piped/cmd/piped/BUILD.bazel
+++ b/pkg/app/piped/cmd/piped/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//pkg/app/piped/apistore/deploymentstore:go_default_library",
         "//pkg/app/piped/apistore/environmentstore:go_default_library",
         "//pkg/app/piped/apistore/eventstore:go_default_library",
+        "//pkg/app/piped/appconfigreporter:go_default_library",
         "//pkg/app/piped/chartrepo:go_default_library",
         "//pkg/app/piped/cloudprovider/kubernetes/kubernetesmetrics:go_default_library",
         "//pkg/app/piped/controller:go_default_library",

--- a/pkg/app/piped/cmd/piped/piped.go
+++ b/pkg/app/piped/cmd/piped/piped.go
@@ -442,7 +442,7 @@ func (p *piped) run(ctx context.Context, input cli.Input) (runErr error) {
 
 	// Start running app-config-reporter.
 	{
-		r, err := appconfigreporter.NewReporter(
+		r := appconfigreporter.NewReporter(
 			apiClient,
 			gitClient,
 			applicationLister,
@@ -450,10 +450,6 @@ func (p *piped) run(ctx context.Context, input cli.Input) (runErr error) {
 			p.gracePeriod,
 			input.Logger,
 		)
-		if err != nil {
-			input.Logger.Error("failed to initialize app-config-reporter", zap.Error(err))
-			return err
-		}
 
 		group.Go(func() error {
 			return r.Run(ctx)

--- a/pkg/app/piped/cmd/piped/piped.go
+++ b/pkg/app/piped/cmd/piped/piped.go
@@ -250,6 +250,7 @@ func (p *piped) run(ctx context.Context, input cli.Input) (runErr error) {
 	environmentStore := environmentstore.NewStore(
 		apiClient,
 		memorycache.NewTTLCache(ctx, 10*time.Minute, time.Minute),
+		memorycache.NewTTLCache(ctx, 10*time.Minute, time.Minute),
 		input.Logger,
 	)
 
@@ -446,6 +447,7 @@ func (p *piped) run(ctx context.Context, input cli.Input) (runErr error) {
 			apiClient,
 			gitClient,
 			applicationLister,
+			environmentStore,
 			cfg,
 			p.gracePeriod,
 			input.Logger,

--- a/pkg/config/deployment.go
+++ b/pkg/config/deployment.go
@@ -29,7 +29,10 @@ const (
 )
 
 type GenericDeploymentSpec struct {
-	model.ApplicationInfo `json:",inline"`
+	Name   string            `json:"name"`
+	EnvId  string            `json:"env_id"`
+	Labels map[string]string `json:"labels"`
+
 	// Configuration used while planning deployment.
 	Planner DeploymentPlanner `json:"planner"`
 	// Forcibly use QuickSync or Pipeline when commit message matched the specified pattern.

--- a/pkg/config/deployment.go
+++ b/pkg/config/deployment.go
@@ -29,7 +29,7 @@ const (
 )
 
 type GenericDeploymentSpec struct {
-	Labels map[string]string `json:"labels"`
+	model.ApplicationInfo `json:",inline"`
 	// Configuration used while planning deployment.
 	Planner DeploymentPlanner `json:"planner"`
 	// Forcibly use QuickSync or Pipeline when commit message matched the specified pattern.

--- a/pkg/config/deployment.go
+++ b/pkg/config/deployment.go
@@ -29,6 +29,7 @@ const (
 )
 
 type GenericDeploymentSpec struct {
+	Labels map[string]string `json:"labels"`
 	// Configuration used while planning deployment.
 	Planner DeploymentPlanner `json:"planner"`
 	// Forcibly use QuickSync or Pipeline when commit message matched the specified pattern.

--- a/pkg/config/deployment.go
+++ b/pkg/config/deployment.go
@@ -29,9 +29,9 @@ const (
 )
 
 type GenericDeploymentSpec struct {
-	Name   string            `json:"name"`
-	EnvID  string            `json:"envId"`
-	Labels map[string]string `json:"labels"`
+	Name    string            `json:"name"`
+	EnvName string            `json:"envName"`
+	Labels  map[string]string `json:"labels"`
 
 	// Configuration used while planning deployment.
 	Planner DeploymentPlanner `json:"planner"`

--- a/pkg/config/deployment.go
+++ b/pkg/config/deployment.go
@@ -30,7 +30,7 @@ const (
 
 type GenericDeploymentSpec struct {
 	Name   string            `json:"name"`
-	EnvID  string            `json:"env_id"`
+	EnvID  string            `json:"envId"`
 	Labels map[string]string `json:"labels"`
 
 	// Configuration used while planning deployment.

--- a/pkg/config/deployment.go
+++ b/pkg/config/deployment.go
@@ -30,7 +30,7 @@ const (
 
 type GenericDeploymentSpec struct {
 	Name   string            `json:"name"`
-	EnvId  string            `json:"env_id"`
+	EnvID  string            `json:"env_id"`
 	Labels map[string]string `json:"labels"`
 
 	// Configuration used while planning deployment.

--- a/pkg/model/application.go
+++ b/pkg/model/application.go
@@ -23,7 +23,7 @@ import (
 const (
 	// TODO: Consider changing the default application config name
 	DefaultDeploymentConfigFileName      = ".pipe.yaml"
-	DefaultDeploymentConfigFileExtension = ".pipe.yaml"
+	DefaultDeploymentConfigFileExtension = ".pipecd.yaml"
 )
 
 // GetDeploymentConfigFilePath returns the path to deployment configuration file.

--- a/pkg/model/application.go
+++ b/pkg/model/application.go
@@ -20,7 +20,11 @@ import (
 	"strings"
 )
 
-const DefaultDeploymentConfigFileName = ".pipe.yaml"
+const (
+	// TODO: Consider changing the default application config name
+	DefaultDeploymentConfigFileName      = ".pipe.yaml"
+	DefaultDeploymentConfigFileExtension = ".pipe.yaml"
+)
 
 // GetDeploymentConfigFilePath returns the path to deployment configuration file.
 func (p ApplicationGitPath) GetDeploymentConfigFilePath() string {

--- a/pkg/model/common.go
+++ b/pkg/model/common.go
@@ -14,6 +14,8 @@
 
 package model
 
+import "fmt"
+
 // ApplicationKindStrings returns a list of available deployment kinds in string.
 func ApplicationKindStrings() []string {
 	out := make([]string, 0, len(ApplicationKind_value))
@@ -21,4 +23,9 @@ func ApplicationKindStrings() []string {
 		out = append(out, k)
 	}
 	return out
+}
+
+// BuildGitPathID builds a unique path between repositories.
+func BuildGitPathID(repoID, path, configFileName string) string {
+	return fmt.Sprintf("%s:%s/%s", repoID, path, configFileName)
 }

--- a/pkg/model/common.go
+++ b/pkg/model/common.go
@@ -14,8 +14,6 @@
 
 package model
 
-import "fmt"
-
 // ApplicationKindStrings returns a list of available deployment kinds in string.
 func ApplicationKindStrings() []string {
 	out := make([]string, 0, len(ApplicationKind_value))
@@ -23,9 +21,4 @@ func ApplicationKindStrings() []string {
 		out = append(out, k)
 	}
 	return out
-}
-
-// BuildGitPathID builds a unique path between repositories.
-func BuildGitPathID(repoID, path, configFileName string) string {
-	return fmt.Sprintf("%s:%s/%s", repoID, path, configFileName)
 }

--- a/pkg/model/common.proto
+++ b/pkg/model/common.proto
@@ -55,3 +55,12 @@ enum SyncStrategy {
     QUICK_SYNC = 1;
     PIPELINE = 2;
 }
+
+message ApplicationInfo {
+    string name = 1 [(validate.rules).string.min_len = 1];
+    string kind = 2 [(validate.rules).string.min_len = 1];
+    string env_id = 3 [(validate.rules).string.min_len = 1];
+    string path = 4 [(validate.rules).string.pattern = "^[^/].+$"];
+    string config_filename = 5;
+    map<string, string> labels = 6;
+}

--- a/pkg/model/common.proto
+++ b/pkg/model/common.proto
@@ -58,7 +58,7 @@ enum SyncStrategy {
 
 message ApplicationInfo {
     string name = 1 [(validate.rules).string.min_len = 1];
-    string kind = 2 [(validate.rules).string.min_len = 1];
+    ApplicationKind kind = 2 [(validate.rules).enum.defined_only = true];
     string env_id = 3 [(validate.rules).string.min_len = 1];
     string path = 4 [(validate.rules).string.pattern = "^[^/].+$"];
     string config_filename = 5;


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a new Piped component that primarily watches two types of Applications that is:
- already registered
- unregistered

For the first one (already registered):
- Piped sends only configs that have been changed since then
- Contol-plane updates Applications stored in Datastore

For the second one (unregistered):
- Piped sends all the latest configs every time whatever the repo is changed or not. The reason is the cache in control-plane is likely to be removed, and configs in Git is also likely to be removed
- Control-plane caches them for suggesting when you attempt to add a new Application

Once this gets merged, I will drill into the detailed implementation.

**Which issue(s) this PR fixes**:

Fixes https://github.com/pipe-cd/pipe/issues/2755
Ref https://github.com/pipe-cd/pipe/pull/2772
Ref https://github.com/pipe-cd/pipe/issues/2750

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
