### PR TITLE
Add GetDeployment RPC to piped api

### DIFF
--- a/pkg/app/api/service/pipedservice/service.proto
+++ b/pkg/app/api/service/pipedservice/service.proto
@@ -70,6 +70,9 @@ service PipedService {
     // GetApplicationMostRecentDeployment returns the most recent deployment of the given application.
     rpc GetApplicationMostRecentDeployment(GetApplicationMostRecentDeploymentRequest) returns (GetApplicationMostRecentDeploymentResponse) {}
 
+    // GetDeployment returns the deployment for given deployment ID.
+    rpc GetDeployment(GetDeploymentRequest) returns (GetDeploymentResponse) {}
+
     // ListNotCompletedDeployments returns a list of not completed deployments
     // which are managed by this piped.
     // DeploymentController component uses this RPC to spawns/syncs its local deployment executors.
@@ -247,6 +250,14 @@ message GetApplicationMostRecentDeploymentRequest {
 
 message GetApplicationMostRecentDeploymentResponse {
     pipe.model.ApplicationDeploymentReference deployment = 1 [(validate.rules).message.required = true];
+}
+
+message GetDeploymentRequest {
+    string id = 1 [(validate.rules).string.min_len = 1];
+}
+
+message GetDeploymentResponse {
+    pipe.model.Deployment deployment = 1 [(validate.rules).message.required = true];
 }
 
 message ListNotCompletedDeploymentsRequest {


### PR DESCRIPTION
**What this PR does / why we need it**:

This is needed for implementing `onOutOfSync` feature.
Piped needs to know the status of a specific deployment.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
