### PR TITLE
Move TriggeredDeploymentID metadata key to command model

### DIFF
--- a/pkg/app/pipectl/client/application.go
+++ b/pkg/app/pipectl/client/application.go
@@ -51,8 +51,6 @@ func SyncApplication(
 	defer ticker.Stop()
 
 	check := func() (deploymentID string, shouldRetry bool) {
-		const triggeredDeploymentIDKey = "TriggeredDeploymentID"
-
 		cmd, err := getCommand(ctx, cli, resp.CommandId)
 		if err != nil {
 			logger.Error(fmt.Sprintf("Failed while retrieving command information. Try again. (%v)", err))
@@ -67,7 +65,7 @@ func SyncApplication(
 
 		switch cmd.Status {
 		case model.CommandStatus_COMMAND_SUCCEEDED:
-			deploymentID = cmd.Metadata[triggeredDeploymentIDKey]
+			deploymentID = cmd.Metadata[model.MetadataKeyTriggeredDeploymentID]
 			return
 
 		case model.CommandStatus_COMMAND_FAILED:

--- a/pkg/app/piped/trigger/trigger.go
+++ b/pkg/app/piped/trigger/trigger.go
@@ -37,7 +37,6 @@ import (
 const (
 	ondemandCheckInterval               = 10 * time.Second
 	defaultLastTriggeredCommitCacheSize = 500
-	triggeredDeploymentIDKey            = "TriggeredDeploymentID"
 )
 
 type apiClient interface {
@@ -286,7 +285,7 @@ func (t *Trigger) checkRepoCandidates(ctx context.Context, repoID string, cs []c
 		// Mask command as handled since the deployment has been triggered successfully.
 		if c.kind == model.TriggerKind_ON_COMMAND {
 			metadata := map[string]string{
-				triggeredDeploymentIDKey: deployment.Id,
+				model.MetadataKeyTriggeredDeploymentID: deployment.Id,
 			}
 			if err := c.command.Report(ctx, model.CommandStatus_COMMAND_SUCCEEDED, metadata, nil); err != nil {
 				t.logger.Error("failed to report command status", zap.Error(err))

--- a/pkg/model/command.go
+++ b/pkg/model/command.go
@@ -16,6 +16,10 @@ package model
 
 import "context"
 
+const (
+	MetadataKeyTriggeredDeploymentID = "TriggeredDeploymentID"
+)
+
 type ReportableCommand struct {
 	*Command
 	Report func(ctx context.Context, status CommandStatus, metadata map[string]string, output []byte) error


### PR DESCRIPTION
**What this PR does / why we need it**:

`triggeredDeploymentIDKey` used in both trigger(piped) and pipectl but must be defined to use could lead to unexpected error in case the key name changed in one end. This PR moves the key to the Command model (since it is the key in command metadata) and explicitly refers it in the used end.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
