### PR TITLE
Add trigger application grpc to piped api

### DIFF
--- a/pkg/app/api/service/pipedservice/service.proto
+++ b/pkg/app/api/service/pipedservice/service.proto
@@ -51,6 +51,8 @@ service PipedService {
     // GetEnvironment finds and returns the environment for the specified ID.
     rpc GetEnvironment(GetEnvironmentRequest) returns (GetEnvironmentResponse) {}
 
+    // Application rpc.
+
     // ListApplications returns a list of registered applications
     // that should be managed by the requested piped.
     // Disabled applications should not be included in the response.
@@ -69,6 +71,33 @@ service PipedService {
 
     // GetApplicationMostRecentDeployment returns the most recent deployment of the given application.
     rpc GetApplicationMostRecentDeployment(GetApplicationMostRecentDeploymentRequest) returns (GetApplicationMostRecentDeploymentResponse) {}
+
+    // ReportApplicationLiveState is periodically sent to correct full state of an application.
+    // For kubernetes application, this contains a full tree of its kubernetes resources.
+    // The tree data should be written into filestore immediately and then the state in cache should be refreshsed too.
+    rpc ReportApplicationLiveState(ReportApplicationLiveStateRequest) returns (ReportApplicationLiveStateResponse) {}
+
+    // ReportApplicationLiveStateEvents is sent to submit one or multiple events
+    // about the changes of application live state.
+    // Control plane uses the received events to update the state of application-resource-tree.
+    // We want to start by a simple solution at this initial stage of development,
+    // so the API server just handles as below:
+    // - loads the releated application-resource-tree from the cache
+    // - checks and builds new state for the application-resource-tree
+    // - updates new state into cache (cache data is for reading while handling web requests)
+    // In the future, we may want to redesign the behavior of this RPC by using pubsub/queue pattern.
+    // After receiving the events, all of them will be published into a queue immediately,
+    // and then another Handler service will pick them inorder to apply to build new state.
+    // By that way we can control the traffic to the datastore in a better way.
+    rpc ReportApplicationLiveStateEvents(ReportApplicationLiveStateEventsRequest) returns (ReportApplicationLiveStateEventsResponse) {}
+
+    // TriggerApplication creates a command to control-plane to start a deployment
+    // for a specifed application which it's not handle by the requested piped. The going to
+    // create deployment is a part of a deployment chain, this RPC is used as an indirection
+    // trigger to start other applications' deployment in the chain.
+    rpc TriggerApplication(TriggerApplicationRequest) returns (TriggerApplicationResponse) {}
+
+    // Deployment rpc.
 
     // GetDeployment returns the deployment for given deployment ID.
     rpc GetDeployment(GetDeploymentRequest) returns (GetDeploymentResponse) {}
@@ -99,6 +128,8 @@ service PipedService {
     // Different value for the same key will overwrite the previous value for that key.
     rpc SaveDeploymentMetadata(SaveDeploymentMetadataRequest) returns (SaveDeploymentMetadataResponse) {}
 
+    // Stage rpc.
+
     // SaveStageMetadata is used to persist the metadata
     // of a specific stage of a deployment.
     // Different value for the same key will overwrite the previous value for that key.
@@ -113,6 +144,8 @@ service PipedService {
     // ReportStageStatusChanged is used to update the status
     // of a specific stage of a deployment.
     rpc ReportStageStatusChanged(ReportStageStatusChangedRequest) returns (ReportStageStatusChangedResponse) {}
+
+    // Command rpc.
 
     // ListUnhandledCommands is periodically called to obtain the commands
     // that should be handled.
@@ -129,24 +162,7 @@ service PipedService {
     // The handle result should be updated to both datastore and cache (for reading from web).
     rpc ReportCommandHandled(ReportCommandHandledRequest) returns (ReportCommandHandledResponse) {}
 
-    // ReportApplicationLiveState is periodically sent to correct full state of an application.
-    // For kubernetes application, this contains a full tree of its kubernetes resources.
-    // The tree data should be written into filestore immediately and then the state in cache should be refreshsed too.
-    rpc ReportApplicationLiveState(ReportApplicationLiveStateRequest) returns (ReportApplicationLiveStateResponse) {}
-
-    // ReportApplicationLiveStateEvents is sent to submit one or multiple events
-    // about the changes of application live state.
-    // Control plane uses the received events to update the state of application-resource-tree.
-    // We want to start by a simple solution at this initial stage of development,
-    // so the API server just handles as below:
-    // - loads the releated application-resource-tree from the cache
-    // - checks and builds new state for the application-resource-tree
-    // - updates new state into cache (cache data is for reading while handling web requests)
-    // In the future, we may want to redesign the behavior of this RPC by using pubsub/queue pattern.
-    // After receiving the events, all of them will be published into a queue immediately,
-    // and then another Handler service will pick them inorder to apply to build new state.
-    // By that way we can control the traffic to the datastore in a better way.
-    rpc ReportApplicationLiveStateEvents(ReportApplicationLiveStateEventsRequest) returns (ReportApplicationLiveStateEventsResponse) {}
+    // Event rpc.
 
     // GetLatestEvent returns the latest event that meets the given conditions.
     rpc GetLatestEvent(GetLatestEventRequest) returns (GetLatestEventResponse) {}
@@ -455,4 +471,13 @@ message GetDesiredVersionRequest {
 
 message GetDesiredVersionResponse {
     string version = 1;
+}
+
+message TriggerApplicationRequest {
+    string application_id = 1 [(validate.rules).string.min_len = 1];
+    model.SyncStrategy sync_strategy = 2;
+}
+
+message TriggerApplicationResponse {
+    string command_id = 1;
 }

--- a/pkg/app/web/src/modules/commands/index.ts
+++ b/pkg/app/web/src/modules/commands/index.ts
@@ -19,6 +19,7 @@ export const COMMAND_TYPE_TEXT: Record<Command.Type, string> = {
   [Command.Type.SYNC_APPLICATION]: "Sync Application",
   [Command.Type.UPDATE_APPLICATION_CONFIG]: "Update Application Config",
   [Command.Type.BUILD_PLAN_PREVIEW]: "Build Plan Preview",
+  [Command.Type.IN_CHAIN_SYNC_APPLICATION]: "Sync Application In Chain",
 };
 
 const commandsAdapter = createEntityAdapter<Command.AsObject>();

--- a/pkg/model/command.proto
+++ b/pkg/model/command.proto
@@ -34,6 +34,7 @@ message Command {
         CANCEL_DEPLOYMENT = 2;
         APPROVE_STAGE = 3;
         BUILD_PLAN_PREVIEW = 4;
+        IN_CHAIN_SYNC_APPLICATION = 5;
     }
 
     message SyncApplication {
@@ -66,6 +67,11 @@ message Command {
         int64 timeout = 5 [(validate.rules).int64.gte = 0];
     }
 
+    message InChainSyncApplication {
+        string application_id = 1 [(validate.rules).string.min_len = 1];
+        SyncStrategy sync_strategy = 2;
+    }
+
     // The generated unique identifier.
     string id = 1 [(validate.rules).string.min_len = 1];
     string piped_id = 2 [(validate.rules).string.min_len = 1];
@@ -86,6 +92,7 @@ message Command {
     CancelDeployment cancel_deployment = 33;
     ApproveStage approve_stage = 34;
     BuildPlanPreview build_plan_preview = 35;
+    InChainSyncApplication in_chain_sync_application = 36;
 
     int64 created_at = 100 [(validate.rules).int64.gt = 0];
     int64 updated_at = 101 [(validate.rules).int64.gt = 0];


### PR DESCRIPTION
**What this PR does / why we need it**:

To implement trigger strategy in the deployment chain, this gRPC is needed. The plan is
- Piped1 triggers deployment for application1
- Piped1 load the application1 configuration, passes the postSync configuration section then use this gRPC to make a sync_application command for other applications.
- Pipedx (in-charge of applications other than application1) listens to the command and handles it as usual.

Thing to consider:
I created a new command type named `IN_CHAIN_SYNC_APPLICATION` in this PR since this command should be handled in a different way than the other commands (with OnChainDeterminer instead of OnCommandDeterminer). About the command name, `InChainTriggerApplication` and `InChainSyncApplication` which one do you guys prefer?

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
