### PR TITLE
Make EnvId in all models optional

### DIFF
--- a/pkg/app/api/service/apiservice/service.proto
+++ b/pkg/app/api/service/apiservice/service.proto
@@ -49,7 +49,7 @@ service APIService {
 
 message AddApplicationRequest {
     string name = 1 [(validate.rules).string.min_len = 1];
-    string env_id = 2 [(validate.rules).string.min_len = 1];
+    string env_id = 2;
     string piped_id = 3 [(validate.rules).string.min_len = 1];
     model.ApplicationGitPath git_path = 4 [(validate.rules).message.required = true];
     model.ApplicationKind kind = 5 [(validate.rules).enum.defined_only = true];

--- a/pkg/app/api/service/webservice/service.proto
+++ b/pkg/app/api/service/webservice/service.proto
@@ -138,7 +138,7 @@ message DeleteEnvironmentResponse {
 message RegisterPipedRequest {
     string name = 1;
     string desc = 2;
-    repeated string env_ids = 3 [(validate.rules).repeated.min_items = 1];
+    repeated string env_ids = 3;
 }
 
 message RegisterPipedResponse {
@@ -150,7 +150,7 @@ message UpdatePipedRequest {
     string piped_id = 1 [(validate.rules).string.min_len = 1];
     string name = 2 [(validate.rules).string.min_len = 1];
     string desc = 3;
-    repeated string env_ids = 4 [(validate.rules).repeated.min_items = 1];
+    repeated string env_ids = 4;
 }
 
 message UpdatePipedResponse {
@@ -221,7 +221,7 @@ message AddEnvironmentRequest {
 
 message AddApplicationRequest {
     string name = 1 [(validate.rules).string.min_len = 1];
-    string env_id = 2 [(validate.rules).string.min_len = 1];
+    string env_id = 2;
     string piped_id = 3 [(validate.rules).string.min_len = 1];
     model.ApplicationGitPath git_path = 4 [(validate.rules).message.required = true];
     model.ApplicationKind kind = 5 [(validate.rules).enum.defined_only = true];
@@ -236,7 +236,7 @@ message AddApplicationResponse {
 message UpdateApplicationRequest {
     string application_id = 1 [(validate.rules).string.min_len = 1];
     string name = 2 [(validate.rules).string.min_len = 1];
-    string env_id = 3 [(validate.rules).string.min_len = 1];
+    string env_id = 3;
     string piped_id = 4 [(validate.rules).string.min_len = 1];
     model.ApplicationKind kind = 6 [(validate.rules).enum.defined_only = true];
     string cloud_provider = 7 [(validate.rules).string.min_len = 1];

--- a/pkg/app/piped/appconfigreporter/appconfigreporter_test.go
+++ b/pkg/app/piped/appconfigreporter/appconfigreporter_test.go
@@ -25,19 +25,6 @@ import (
 	"github.com/pipe-cd/pipe/pkg/model"
 )
 
-type fakeEnvGetter struct {
-	env *model.Environment
-	err error
-}
-
-func (f fakeEnvGetter) Get(_ context.Context, _ string) (*model.Environment, error) {
-	return f.env, f.err
-}
-
-func (f fakeEnvGetter) GetByName(_ context.Context, _ string) (*model.Environment, error) {
-	return f.env, f.err
-}
-
 func TestReporter_findUnregisteredApps(t *testing.T) {
 	type args struct {
 		registeredAppPaths map[string]struct{}
@@ -53,7 +40,6 @@ func TestReporter_findUnregisteredApps(t *testing.T) {
 		{
 			name: "file not found",
 			reporter: &Reporter{
-				envGetter: &fakeEnvGetter{env: &model.Environment{Id: "env-1"}},
 				fileSystem: fstest.MapFS{
 					"path/to/repo-1/app-1/app.pipecd.yaml": &fstest.MapFile{Data: []byte("")},
 				},
@@ -70,7 +56,6 @@ func TestReporter_findUnregisteredApps(t *testing.T) {
 		{
 			name: "all are registered",
 			reporter: &Reporter{
-				envGetter: &fakeEnvGetter{env: &model.Environment{Id: "env-1"}},
 				fileSystem: fstest.MapFS{
 					"path/to/repo-1/app-1/app.pipecd.yaml": &fstest.MapFile{Data: []byte("")},
 				},
@@ -89,7 +74,6 @@ func TestReporter_findUnregisteredApps(t *testing.T) {
 		{
 			name: "invalid app config is contained",
 			reporter: &Reporter{
-				envGetter: &fakeEnvGetter{env: &model.Environment{Id: "env-1"}},
 				fileSystem: fstest.MapFS{
 					"path/to/repo-1/app-1/app.pipecd.yaml": &fstest.MapFile{Data: []byte("invalid-text")},
 				},
@@ -106,7 +90,6 @@ func TestReporter_findUnregisteredApps(t *testing.T) {
 		{
 			name: "valid app config that is unregistered",
 			reporter: &Reporter{
-				envGetter: &fakeEnvGetter{env: &model.Environment{Id: "env-1"}},
 				fileSystem: fstest.MapFS{
 					"path/to/repo-1/app-1/app.pipecd.yaml": &fstest.MapFile{Data: []byte(`
 apiVersion: pipecd.dev/v1beta1
@@ -126,7 +109,6 @@ spec:
 			want: []*model.ApplicationInfo{
 				{
 					Name:           "app-1",
-					EnvId:          "env-1",
 					Labels:         map[string]string{"key-1": "value-1"},
 					Path:           "path/to/repo-1/app-1",
 					ConfigFilename: "app.pipecd.yaml",
@@ -175,7 +157,6 @@ func TestReporter_findRegisteredApps(t *testing.T) {
 		{
 			name: "no changed file",
 			reporter: &Reporter{
-				envGetter: &fakeEnvGetter{env: &model.Environment{Id: "env-1"}},
 				fileSystem: fstest.MapFS{
 					"path/to/repo-1/app-1/app.pipecd.yaml": &fstest.MapFile{Data: []byte("invalid-text")},
 				},
@@ -192,7 +173,6 @@ func TestReporter_findRegisteredApps(t *testing.T) {
 		{
 			name: "all are unregistered",
 			reporter: &Reporter{
-				envGetter: &fakeEnvGetter{env: &model.Environment{Id: "env-1"}},
 				fileSystem: fstest.MapFS{
 					"path/to/repo-1/app-1/app.pipecd.yaml": &fstest.MapFile{Data: []byte("")},
 				},
@@ -209,7 +189,6 @@ func TestReporter_findRegisteredApps(t *testing.T) {
 		{
 			name: "invalid app config is contained",
 			reporter: &Reporter{
-				envGetter: &fakeEnvGetter{env: &model.Environment{Id: "env-1"}},
 				fileSystem: fstest.MapFS{
 					"path/to/repo-1/app-1/app.pipecd.yaml": &fstest.MapFile{Data: []byte("invalid-text")},
 				},
@@ -229,7 +208,6 @@ func TestReporter_findRegisteredApps(t *testing.T) {
 		{
 			name: "valid app config that is registered",
 			reporter: &Reporter{
-				envGetter: &fakeEnvGetter{env: &model.Environment{Id: "env-1"}},
 				fileSystem: fstest.MapFS{
 					"path/to/repo-1/app-1/app.pipecd.yaml": &fstest.MapFile{Data: []byte(`
 apiVersion: pipecd.dev/v1beta1
@@ -252,7 +230,6 @@ spec:
 			want: []*model.ApplicationInfo{
 				{
 					Name:           "app-1",
-					EnvId:          "env-1",
 					Labels:         map[string]string{"key-1": "value-1"},
 					Path:           "path/to/repo-1/app-1",
 					ConfigFilename: "app.pipecd.yaml",
@@ -263,7 +240,6 @@ spec:
 		{
 			name: "last commit commit is empty",
 			reporter: &Reporter{
-				envGetter: &fakeEnvGetter{env: &model.Environment{Id: "env-1"}},
 				fileSystem: fstest.MapFS{
 					"path/to/repo-1/app-1/app.pipecd.yaml": &fstest.MapFile{Data: []byte(`
 apiVersion: pipecd.dev/v1beta1
@@ -286,7 +262,6 @@ spec:
 			want: []*model.ApplicationInfo{
 				{
 					Name:           "app-1",
-					EnvId:          "env-1",
 					Labels:         map[string]string{"key-1": "value-1"},
 					Path:           "path/to/repo-1/app-1",
 					ConfigFilename: "app.pipecd.yaml",

--- a/pkg/app/piped/cmd/piped/piped.go
+++ b/pkg/app/piped/cmd/piped/piped.go
@@ -447,7 +447,6 @@ func (p *piped) run(ctx context.Context, input cli.Input) (runErr error) {
 			apiClient,
 			gitClient,
 			applicationLister,
-			environmentStore,
 			cfg,
 			p.gracePeriod,
 			input.Logger,

--- a/pkg/app/web/src/components/application-form/index.tsx
+++ b/pkg/app/web/src/components/application-form/index.tsx
@@ -130,6 +130,7 @@ function FormSelectInput<T extends { name: string; value: string }>({
 export const validationSchema = yup.object().shape({
   name: yup.string().required(),
   kind: yup.number().required(),
+  // TODO: Make all environment fields in the form in optional
   env: yup.string().required(),
   pipedId: yup.string().required(),
   repo: yup

--- a/pkg/model/application.proto
+++ b/pkg/model/application.proto
@@ -27,7 +27,7 @@ message Application {
     // The name of the application.
     string name = 2 [(validate.rules).string.min_len = 1];
     // The id of environment this application belongs to.
-    string env_id = 3 [(validate.rules).string.min_len = 1];
+    string env_id = 3;
     // The ID of the piped that should handle this application.
     string piped_id = 4 [(validate.rules).string.min_len = 1];
     // The ID of the project this environment belongs to.

--- a/pkg/model/application_live_state.proto
+++ b/pkg/model/application_live_state.proto
@@ -29,7 +29,7 @@ message ApplicationLiveStateSnapshot {
         OTHER = 2;
     }
     string application_id = 1 [(validate.rules).string.min_len = 1];
-    string env_id = 2 [(validate.rules).string.min_len = 1];
+    string env_id = 2;
     string piped_id = 3 [(validate.rules).string.min_len = 1];
     string project_id = 4 [(validate.rules).string.min_len = 1];
     ApplicationKind kind = 5 [(validate.rules).enum.defined_only = true];

--- a/pkg/model/common.proto
+++ b/pkg/model/common.proto
@@ -59,8 +59,7 @@ enum SyncStrategy {
 message ApplicationInfo {
     string name = 1 [(validate.rules).string.min_len = 1];
     ApplicationKind kind = 2 [(validate.rules).enum.defined_only = true];
-    string env_id = 3 [(validate.rules).string.min_len = 1];
+    map<string, string> labels = 3;
     string path = 4 [(validate.rules).string.pattern = "^[^/].+$"];
     string config_filename = 5;
-    map<string, string> labels = 6;
 }

--- a/pkg/model/deployment.proto
+++ b/pkg/model/deployment.proto
@@ -59,7 +59,7 @@ message Deployment {
     string id = 1 [(validate.rules).string.min_len = 1];
     string application_id = 2 [(validate.rules).string.min_len = 1];
     string application_name = 3 [(validate.rules).string.min_len = 1];
-    string env_id = 4 [(validate.rules).string.min_len = 1];
+    string env_id = 4;
     string piped_id = 5 [(validate.rules).string.min_len = 1];
     string project_id = 6 [(validate.rules).string.min_len = 1];
     ApplicationKind kind = 7 [(validate.rules).enum.defined_only = true];

--- a/pkg/model/piped.proto
+++ b/pkg/model/piped.proto
@@ -49,7 +49,7 @@ message Piped {
     // The ID of the project this enviroment belongs to.
     string project_id = 5 [(validate.rules).string.min_len = 1];
     // The IDs of environments where this piped can be connected to.
-    repeated string env_ids = 6 [(validate.rules).repeated.min_items = 1];
+    repeated string env_ids = 6;
 
     // Currently running version.
     string version = 7;

--- a/pkg/model/planpreview.proto
+++ b/pkg/model/planpreview.proto
@@ -44,7 +44,7 @@ message ApplicationPlanPreviewResult {
     ApplicationKind application_kind = 4 [(validate.rules).enum.defined_only = true];
     string application_directory = 5 [(validate.rules).string.min_len = 1];
 
-    string env_id = 6 [(validate.rules).string.min_len = 1];
+    string env_id = 6;
     string env_name = 7;
     // Web URL to the environment page.
     // This is only filled before returning to the client.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes all EnvID(s) optional since we're going to migrate Environment to Labels.
I looked up places where use EnvId and confirmed all seem to be able to work well without EnvId.

**Which issue(s) this PR fixes**:

Close https://github.com/pipe-cd/pipe/issues/2805

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
