### PR TITLE
Prevent local absolute paths from being entered in App config

### DIFF
--- a/pkg/app/piped/appconfigreporter/appconfigreporter.go
+++ b/pkg/app/piped/appconfigreporter/appconfigreporter.go
@@ -348,7 +348,7 @@ func (r *Reporter) readApplicationInfo(appPath, cfgFileAbsPath string) (*model.A
 	}
 
 	if spec.Name == "" {
-		return nil, fmt.Errorf("application name is empty")
+		return nil, fmt.Errorf("missing application name")
 	}
 	return &model.ApplicationInfo{
 		Name: spec.Name,

--- a/pkg/app/piped/appconfigreporter/appconfigreporter_test.go
+++ b/pkg/app/piped/appconfigreporter/appconfigreporter_test.go
@@ -110,7 +110,7 @@ spec:
 				{
 					Name:           "app-1",
 					Labels:         map[string]string{"key-1": "value-1"},
-					Path:           "path/to/repo-1/app-1",
+					Path:           "app-1",
 					ConfigFilename: "app.pipecd.yaml",
 				},
 			},
@@ -119,7 +119,7 @@ spec:
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := tc.reporter.findUnregisteredApps(context.Background(), tc.args.repoPath, tc.args.repoID, tc.args.registeredAppPaths)
+			got, err := tc.reporter.findUnregisteredApps(tc.args.repoPath, tc.args.repoID, tc.args.registeredAppPaths)
 			assert.Equal(t, tc.wantErr, err != nil)
 			assert.Equal(t, tc.want, got)
 		})
@@ -231,7 +231,7 @@ spec:
 				{
 					Name:           "app-1",
 					Labels:         map[string]string{"key-1": "value-1"},
-					Path:           "path/to/repo-1/app-1",
+					Path:           "app-1",
 					ConfigFilename: "app.pipecd.yaml",
 				},
 			},
@@ -263,7 +263,7 @@ spec:
 				{
 					Name:           "app-1",
 					Labels:         map[string]string{"key-1": "value-1"},
-					Path:           "path/to/repo-1/app-1",
+					Path:           "app-1",
 					ConfigFilename: "app.pipecd.yaml",
 				},
 			},

--- a/pkg/model/common.proto
+++ b/pkg/model/common.proto
@@ -61,5 +61,5 @@ message ApplicationInfo {
     ApplicationKind kind = 2 [(validate.rules).enum.defined_only = true];
     map<string, string> labels = 3;
     string path = 4 [(validate.rules).string.pattern = "^[^/].+$"];
-    string config_filename = 5;
+    string config_filename = 5 [(validate.rules).string.min_len = 1];
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR solves the problem where Piped would specify a local absolute path as GitPath when reporting a Git-defined Config to Control-plane.

**Which issue(s) this PR fixes**:

Close https://github.com/pipe-cd/pipe/issues/2806

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
