### PR TITLE
Trigger new deployment chain via piped api

### DIFF
--- a/pkg/app/api/grpcapi/piped_api.go
+++ b/pkg/app/api/grpcapi/piped_api.go
@@ -1046,7 +1046,7 @@ func (a *PipedAPI) CreateDeploymentChain(ctx context.Context, req *pipedservice.
 	}
 
 	dc := model.DeploymentChain{
-		Id:        req.Id,
+		Id:        uuid.New().String(),
 		ProjectId: projectID,
 		Blocks:    chainBlocks,
 	}
@@ -1057,8 +1057,10 @@ func (a *PipedAPI) CreateDeploymentChain(ctx context.Context, req *pipedservice.
 		return nil, status.Error(codes.Internal, "failed to trigger new deployment chain")
 	}
 
+	firstDeployment := req.FirstDeployment
+	firstDeployment.DeploymentChainId = dc.Id
 	// Trigger new deployment for the first application by store first deployment to datastore.
-	if err := a.deploymentStore.AddDeployment(ctx, req.FirstDeployment); err != nil {
+	if err := a.deploymentStore.AddDeployment(ctx, firstDeployment); err != nil {
 		a.logger.Error("failed to create deployment", zap.Error(err))
 		return nil, status.Error(codes.Internal, "failed to trigger new deployment for the first application in chain")
 	}

--- a/pkg/app/api/grpcapi/piped_api.go
+++ b/pkg/app/api/grpcapi/piped_api.go
@@ -20,12 +20,11 @@ import (
 	"errors"
 	"time"
 
+	"github.com/google/uuid"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-
-	"github.com/google/uuid"
 
 	"github.com/pipe-cd/pipe/pkg/app/api/analysisresultstore"
 	"github.com/pipe-cd/pipe/pkg/app/api/applicationlivestatestore"
@@ -1016,7 +1015,7 @@ func (a *PipedAPI) CreateDeploymentChain(ctx context.Context, req *pipedservice.
 
 	chainBlocks := make([]*model.ChainBlock, 0, len(req.Matchers)+1)
 	// Add the first deployment which created by piped as the first block of the chain.
-	chainBlocks[0] = &model.ChainBlock{
+	chainBlocks = append(chainBlocks, &model.ChainBlock{
 		Index: 0,
 		Nodes: []*model.ChainNode{
 			{
@@ -1029,7 +1028,7 @@ func (a *PipedAPI) CreateDeploymentChain(ctx context.Context, req *pipedservice.
 				},
 			},
 		},
-	}
+	})
 
 	apps := make([]*model.Application, 0)
 	for i, filter := range req.Matchers {

--- a/pkg/app/api/grpcapi/piped_api.go
+++ b/pkg/app/api/grpcapi/piped_api.go
@@ -975,7 +975,7 @@ func (a *PipedAPI) CreateDeploymentChain(ctx context.Context, req *pipedservice.
 		return nil, err
 	}
 
-	findNodeApps := func(filter *pipedservice.CreateDeploymentChainRequest_ApplicationsFilter) ([]*model.Application, error) {
+	findNodeApps := func(matcher *pipedservice.CreateDeploymentChainRequest_ApplicationMatcher) ([]*model.Application, error) {
 		filters := []datastore.ListFilter{
 			{
 				Field:    "ProjectId",
@@ -984,11 +984,11 @@ func (a *PipedAPI) CreateDeploymentChain(ctx context.Context, req *pipedservice.
 			},
 		}
 
-		if filter.AppName != "" {
+		if matcher.Name != "" {
 			filters = append(filters, datastore.ListFilter{
 				Field:    "Name",
 				Operator: datastore.OperatorEqual,
-				Value:    filter.AppName,
+				Value:    matcher.Name,
 			})
 		}
 
@@ -1004,9 +1004,9 @@ func (a *PipedAPI) CreateDeploymentChain(ctx context.Context, req *pipedservice.
 		return apps, nil
 	}
 
-	chainNodes := make([]*model.DeploymentChainNode, 0, len(req.Filters))
+	chainNodes := make([]*model.DeploymentChainNode, 0, len(req.Matchers))
 	apps := make([]*model.Application, 0)
-	for i, filter := range req.Filters {
+	for i, filter := range req.Matchers {
 		nodeApps, err := findNodeApps(filter)
 		if err != nil {
 			return nil, err

--- a/pkg/app/api/grpcapi/piped_api.go
+++ b/pkg/app/api/grpcapi/piped_api.go
@@ -991,14 +991,7 @@ func (a *PipedAPI) CreateDeploymentChain(ctx context.Context, req *pipedservice.
 			})
 		}
 
-		if filter.AppKind != "" {
-			filters = append(filters, datastore.ListFilter{
-				Field:    "Kind",
-				Operator: datastore.OperatorEqual,
-				// TODO: AppKind enum refinement.
-				Value: 0,
-			})
-		}
+		// TODO: Support find node apps by appKind and appLabels.
 
 		apps, _, err := a.applicationStore.ListApplications(ctx, datastore.ListOptions{
 			Filters: filters,

--- a/pkg/app/api/grpcapi/piped_api.go
+++ b/pkg/app/api/grpcapi/piped_api.go
@@ -26,6 +26,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/google/uuid"
+
 	"github.com/pipe-cd/pipe/pkg/app/api/analysisresultstore"
 	"github.com/pipe-cd/pipe/pkg/app/api/applicationlivestatestore"
 	"github.com/pipe-cd/pipe/pkg/app/api/commandstore"

--- a/pkg/app/api/service/pipedservice/service.proto
+++ b/pkg/app/api/service/pipedservice/service.proto
@@ -489,9 +489,8 @@ message CreateDeploymentChainRequest {
         map<string,string> labels = 3;
     }
 
-    string Id = 1;
-    pipe.model.Deployment first_deployment = 2 [(validate.rules).message.required = true];
-    repeated ApplicationMatcher matchers = 3;
+    pipe.model.Deployment first_deployment = 1 [(validate.rules).message.required = true];
+    repeated ApplicationMatcher matchers = 2;
 }
 
 message CreateDeploymentChainResponse {

--- a/pkg/app/api/service/pipedservice/service.proto
+++ b/pkg/app/api/service/pipedservice/service.proto
@@ -489,7 +489,9 @@ message CreateDeploymentChainRequest {
         map<string,string> labels = 3;
     }
 
-    repeated ApplicationMatcher matchers = 1;
+    string Id = 1;
+    pipe.model.Deployment first_deployment = 2 [(validate.rules).message.required = true];
+    repeated ApplicationMatcher matchers = 3;
 }
 
 message CreateDeploymentChainResponse {

--- a/pkg/app/api/service/pipedservice/service.proto
+++ b/pkg/app/api/service/pipedservice/service.proto
@@ -483,13 +483,13 @@ message ReportUnregisteredApplicationConfigurationsResponse {
 }
 
 message CreateDeploymentChainRequest {
-    message ApplicationsFilter {
-        string app_name = 1;
-        string app_kind = 2;
-        map<string,string> app_labels = 3;
+    message ApplicationMatcher {
+        string name = 1;
+        string kind = 2;
+        map<string,string> labels = 3;
     }
 
-    repeated ApplicationsFilter filters = 1;
+    repeated ApplicationMatcher matchers = 1;
 }
 
 message CreateDeploymentChainResponse {

--- a/pkg/app/api/service/pipedservice/service.proto
+++ b/pkg/app/api/service/pipedservice/service.proto
@@ -169,6 +169,10 @@ service PipedService {
     rpc UpdateApplicationConfigurations(UpdateApplicationConfigurationsRequest) returns (UpdateApplicationConfigurationsResponse) {}
     // ReportLatestUnusedApplicationConfigurations puts the latest configurations of applications that isn't registered yet.
     rpc ReportUnregisteredApplicationConfigurations(ReportUnregisteredApplicationConfigurationsRequest) returns (ReportUnregisteredApplicationConfigurationsResponse) {}
+
+    // CreateDeploymentChain creates a new deployment chain object and all required commands to
+    // trigger deployment for applications in the chain.
+    rpc CreateDeploymentChain(CreateDeploymentChainRequest) returns (CreateDeploymentChainResponse) {}
 }
 
 enum ListOrder {
@@ -476,4 +480,17 @@ message ReportUnregisteredApplicationConfigurationsRequest {
 }
 
 message ReportUnregisteredApplicationConfigurationsResponse {
+}
+
+message CreateDeploymentChainRequest {
+    message ApplicationsFilter {
+        string app_name = 1;
+        string app_kind = 2;
+        map<string,string> app_labels = 3;
+    }
+
+    repeated ApplicationsFilter filters = 1;
+}
+
+message CreateDeploymentChainResponse {
 }

--- a/pkg/app/piped/trigger/BUILD.bazel
+++ b/pkg/app/piped/trigger/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "cache.go",
         "deployment.go",
+        "deployment_chain.go",
         "determiner.go",
         "trigger.go",
     ],

--- a/pkg/app/piped/trigger/deployment.go
+++ b/pkg/app/piped/trigger/deployment.go
@@ -49,7 +49,7 @@ func buildDeployment(
 	strategySummary string,
 	now time.Time,
 	noti *config.DeploymentNotification,
-	deploymentChainId string,
+	deploymentChainID string,
 ) (*model.Deployment, error) {
 
 	var commitURL string
@@ -100,7 +100,7 @@ func buildDeployment(
 		Metadata:          metadata,
 		CreatedAt:         now.Unix(),
 		UpdatedAt:         now.Unix(),
-		DeploymentChainId: deploymentChainId,
+		DeploymentChainId: deploymentChainID,
 	}
 
 	return deployment, nil

--- a/pkg/app/piped/trigger/deployment.go
+++ b/pkg/app/piped/trigger/deployment.go
@@ -29,7 +29,7 @@ import (
 	"github.com/pipe-cd/pipe/pkg/model"
 )
 
-func (t *Trigger) triggerStandaloneDeployment(
+func (t *Trigger) triggerDeployment(
 	ctx context.Context,
 	app *model.Application,
 	appCfg *config.GenericDeploymentSpec,
@@ -38,6 +38,7 @@ func (t *Trigger) triggerStandaloneDeployment(
 	commander string,
 	syncStrategy model.SyncStrategy,
 	strategySummary string,
+	deploymentChainId string,
 ) (*model.Deployment, error) {
 
 	// Build deployment model to trigger.
@@ -50,8 +51,7 @@ func (t *Trigger) triggerStandaloneDeployment(
 		strategySummary,
 		time.Now(),
 		appCfg.DeploymentNotification,
-		// Standalone deployment has empty value for its deploymentChainId.
-		"",
+		deploymentChainId,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("could not initialize deployment: %w", err)

--- a/pkg/app/piped/trigger/deployment.go
+++ b/pkg/app/piped/trigger/deployment.go
@@ -29,7 +29,7 @@ import (
 	"github.com/pipe-cd/pipe/pkg/model"
 )
 
-func (t *Trigger) triggerDeployment(
+func (t *Trigger) triggerStandaloneDeployment(
 	ctx context.Context,
 	app *model.Application,
 	appCfg *config.GenericDeploymentSpec,
@@ -50,6 +50,8 @@ func (t *Trigger) triggerDeployment(
 		strategySummary,
 		time.Now(),
 		appCfg.DeploymentNotification,
+		// Standalone deployment has empty value for its deploymentChainId.
+		"",
 	)
 	if err != nil {
 		return nil, fmt.Errorf("could not initialize deployment: %w", err)
@@ -83,6 +85,7 @@ func buildDeployment(
 	strategySummary string,
 	now time.Time,
 	noti *config.DeploymentNotification,
+	deploymentChainId string,
 ) (*model.Deployment, error) {
 
 	var commitURL string
@@ -125,14 +128,15 @@ func buildDeployment(
 			SyncStrategy:    syncStrategy,
 			StrategySummary: strategySummary,
 		},
-		GitPath:       app.GitPath,
-		CloudProvider: app.CloudProvider,
-		Labels:        app.Labels,
-		Status:        model.DeploymentStatus_DEPLOYMENT_PENDING,
-		StatusReason:  "The deployment is waiting to be planned",
-		Metadata:      metadata,
-		CreatedAt:     now.Unix(),
-		UpdatedAt:     now.Unix(),
+		GitPath:           app.GitPath,
+		CloudProvider:     app.CloudProvider,
+		Labels:            app.Labels,
+		Status:            model.DeploymentStatus_DEPLOYMENT_PENDING,
+		StatusReason:      "The deployment is waiting to be planned",
+		Metadata:          metadata,
+		CreatedAt:         now.Unix(),
+		UpdatedAt:         now.Unix(),
+		DeploymentChainId: deploymentChainId,
 	}
 
 	return deployment, nil

--- a/pkg/app/piped/trigger/deployment_chain.go
+++ b/pkg/app/piped/trigger/deployment_chain.go
@@ -1,0 +1,41 @@
+// Copyright 2021 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trigger
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pipe-cd/pipe/pkg/app/api/service/pipedservice"
+	"github.com/pipe-cd/pipe/pkg/config"
+)
+
+func (t *Trigger) triggerDeploymentChain(ctx context.Context, dc *config.DeploymentChain) error {
+	filters := make([]*pipedservice.CreateDeploymentChainRequest_ApplicationsFilter, 0, len(dc.Nodes))
+	for _, node := range dc.Nodes {
+		filters = append(filters, &pipedservice.CreateDeploymentChainRequest_ApplicationsFilter{
+			AppName:   node.AppName,
+			AppKind:   node.AppKind,
+			AppLabels: node.AppLabels,
+		})
+	}
+
+	if _, err := t.apiClient.CreateDeploymentChain(ctx, &pipedservice.CreateDeploymentChainRequest{
+		Filters: filters,
+	}); err != nil {
+		return fmt.Errorf("could not create new deployment chain: %w", err)
+	}
+	return nil
+}

--- a/pkg/app/piped/trigger/deployment_chain.go
+++ b/pkg/app/piped/trigger/deployment_chain.go
@@ -20,9 +20,15 @@ import (
 
 	"github.com/pipe-cd/pipe/pkg/app/api/service/pipedservice"
 	"github.com/pipe-cd/pipe/pkg/config"
+	"github.com/pipe-cd/pipe/pkg/model"
 )
 
-func (t *Trigger) triggerDeploymentChain(ctx context.Context, dc *config.DeploymentChain) error {
+func (t *Trigger) triggerDeploymentChain(
+	ctx context.Context,
+	deploymentChainId string,
+	dc *config.DeploymentChain,
+	firstDeployment *model.Deployment,
+) error {
 	matchers := make([]*pipedservice.CreateDeploymentChainRequest_ApplicationMatcher, 0, len(dc.ApplicationMatchers))
 	for _, m := range dc.ApplicationMatchers {
 		matchers = append(matchers, &pipedservice.CreateDeploymentChainRequest_ApplicationMatcher{
@@ -33,7 +39,9 @@ func (t *Trigger) triggerDeploymentChain(ctx context.Context, dc *config.Deploym
 	}
 
 	if _, err := t.apiClient.CreateDeploymentChain(ctx, &pipedservice.CreateDeploymentChainRequest{
-		Matchers: matchers,
+		Id:              deploymentChainId,
+		Matchers:        matchers,
+		FirstDeployment: firstDeployment,
 	}); err != nil {
 		return fmt.Errorf("could not create new deployment chain: %w", err)
 	}

--- a/pkg/app/piped/trigger/deployment_chain.go
+++ b/pkg/app/piped/trigger/deployment_chain.go
@@ -25,7 +25,6 @@ import (
 
 func (t *Trigger) triggerDeploymentChain(
 	ctx context.Context,
-	deploymentChainId string,
 	dc *config.DeploymentChain,
 	firstDeployment *model.Deployment,
 ) error {
@@ -39,7 +38,6 @@ func (t *Trigger) triggerDeploymentChain(
 	}
 
 	if _, err := t.apiClient.CreateDeploymentChain(ctx, &pipedservice.CreateDeploymentChainRequest{
-		Id:              deploymentChainId,
 		Matchers:        matchers,
 		FirstDeployment: firstDeployment,
 	}); err != nil {

--- a/pkg/app/piped/trigger/deployment_chain.go
+++ b/pkg/app/piped/trigger/deployment_chain.go
@@ -23,17 +23,17 @@ import (
 )
 
 func (t *Trigger) triggerDeploymentChain(ctx context.Context, dc *config.DeploymentChain) error {
-	filters := make([]*pipedservice.CreateDeploymentChainRequest_ApplicationsFilter, 0, len(dc.Nodes))
-	for _, node := range dc.Nodes {
-		filters = append(filters, &pipedservice.CreateDeploymentChainRequest_ApplicationsFilter{
-			AppName:   node.AppName,
-			AppKind:   node.AppKind,
-			AppLabels: node.AppLabels,
+	matchers := make([]*pipedservice.CreateDeploymentChainRequest_ApplicationMatcher, 0, len(dc.ApplicationMatchers))
+	for _, m := range dc.ApplicationMatchers {
+		matchers = append(matchers, &pipedservice.CreateDeploymentChainRequest_ApplicationMatcher{
+			Name:   m.Name,
+			Kind:   m.Kind,
+			Labels: m.Labels,
 		})
 	}
 
 	if _, err := t.apiClient.CreateDeploymentChain(ctx, &pipedservice.CreateDeploymentChainRequest{
-		Filters: filters,
+		Matchers: matchers,
 	}); err != nil {
 		return fmt.Errorf("could not create new deployment chain: %w", err)
 	}

--- a/pkg/app/piped/trigger/trigger.go
+++ b/pkg/app/piped/trigger/trigger.go
@@ -270,44 +270,51 @@ func (t *Trigger) checkRepoCandidates(ctx context.Context, repoID string, cs []c
 			strategy = model.SyncStrategy_AUTO
 		}
 
+		// TODO: Add ability to get deployment chain id from CHAIN_SYNC_APPLICATION command.
+		var deploymentChainId string
+		// Build the deployment to trigger.
+		deployment, err := buildDeployment(
+			app,
+			branch,
+			headCommit,
+			commander,
+			strategy,
+			strategySummary,
+			time.Now(),
+			appCfg.DeploymentNotification,
+			deploymentChainId,
+		)
+		if err != nil {
+			msg := fmt.Sprintf("failed to build deployment for application %s: %v", app.Id, err)
+			t.notifyDeploymentTriggerFailed(app, appCfg, msg, headCommit)
+			t.logger.Error(msg, zap.Error(err))
+			continue
+		}
+
 		// In case the triggered deployment is of application that can trigger a deployment chain
 		// create a new deployment chain with it's configuration.
 		if appCfg.PostSync != nil && appCfg.PostSync.DeploymentChain != nil {
-			// Build the first deployment of the deployment chain.
-			firstDeployment, err := buildDeployment(
-				app,
-				branch,
-				headCommit,
-				commander,
-				strategy,
-				strategySummary,
-				time.Now(),
-				appCfg.DeploymentNotification,
-				"",
-			)
-			if err != nil {
-				msg := fmt.Sprintf("failed to build first application %s in chain: %v", app.Id, err)
+			if err := t.triggerDeploymentChain(ctx, appCfg.PostSync.DeploymentChain, deployment); err != nil {
+				msg := fmt.Sprintf("failed to trigger new deployment chain: %v", err)
 				t.notifyDeploymentTriggerFailed(app, appCfg, msg, headCommit)
 				t.logger.Error(msg, zap.Error(err))
 				continue
 			}
-
-			if err := t.triggerDeploymentChain(ctx, appCfg.PostSync.DeploymentChain, firstDeployment); err != nil {
-				t.logger.Error("failed to trigger new deployment chain", zap.Error(err))
+		} else {
+			// Build deployment model and send a request to API to create a new deployment.
+			if err := t.triggerDeployment(ctx, deployment); err != nil {
+				msg := fmt.Sprintf("failed to trigger application %s: %v", app.Id, err)
+				t.notifyDeploymentTriggerFailed(app, appCfg, msg, headCommit)
+				t.logger.Error(msg, zap.Error(err))
+				continue
 			}
-
-			continue
 		}
 
-		// TODO: Add ability to get deployment chain id from CHAIN_SYNC_APPLICATION command.
-		var deploymentChainId string
-		// Build deployment model and send a request to API to create a new deployment.
-		deployment, err := t.triggerDeployment(ctx, app, appCfg, branch, headCommit, commander, strategy, strategySummary, deploymentChainId)
-		if err != nil {
-			msg := fmt.Sprintf("failed to trigger application %s: %v", app.Id, err)
-			t.notifyDeploymentTriggerFailed(app, appCfg, msg, headCommit)
-			t.logger.Error(msg, zap.Error(err))
-			continue
+		// TODO: Find a better way to ensure that the application should be updated correctly
+		// when the deployment was successfully triggered.
+		// This error is ignored because the deployment was already registered successfully.
+		if e := reportMostRecentlyTriggeredDeployment(ctx, t.apiClient, deployment); e != nil {
+			t.logger.Error("failed to report most recently triggered deployment", zap.Error(e))
 		}
 
 		triggered[app.Id] = struct{}{}

--- a/pkg/app/piped/trigger/trigger.go
+++ b/pkg/app/piped/trigger/trigger.go
@@ -296,7 +296,7 @@ func (t *Trigger) checkRepoCandidates(ctx context.Context, repoID string, cs []c
 		// in that chain.
 		if appCfg.PostSync != nil && appCfg.PostSync.DeploymentChain != nil {
 			if err := t.triggerDeploymentChain(ctx, appCfg.PostSync.DeploymentChain, deployment); err != nil {
-				msg := fmt.Sprintf("failed to trigger new deployment chain: %v", err)
+				msg := fmt.Sprintf("failed to trigger application %s and its deployment chain: %v", app.Id, err)
 				t.notifyDeploymentTriggerFailed(app, appCfg, msg, headCommit)
 				t.logger.Error(msg, zap.Error(err))
 				continue

--- a/pkg/app/piped/trigger/trigger.go
+++ b/pkg/app/piped/trigger/trigger.go
@@ -271,7 +271,7 @@ func (t *Trigger) checkRepoCandidates(ctx context.Context, repoID string, cs []c
 		}
 
 		// TODO: Add ability to get deployment chain id from CHAIN_SYNC_APPLICATION command.
-		var deploymentChainId string
+		var deploymentChainID string
 		// Build the deployment to trigger.
 		deployment, err := buildDeployment(
 			app,
@@ -282,7 +282,7 @@ func (t *Trigger) checkRepoCandidates(ctx context.Context, repoID string, cs []c
 			strategySummary,
 			time.Now(),
 			appCfg.DeploymentNotification,
-			deploymentChainId,
+			deploymentChainID,
 		)
 		if err != nil {
 			msg := fmt.Sprintf("failed to build deployment for application %s: %v", app.Id, err)
@@ -292,7 +292,8 @@ func (t *Trigger) checkRepoCandidates(ctx context.Context, repoID string, cs []c
 		}
 
 		// In case the triggered deployment is of application that can trigger a deployment chain
-		// create a new deployment chain with it's configuration.
+		// create a new deployment chain with its configuration besides with the first deployment
+		// in that chain.
 		if appCfg.PostSync != nil && appCfg.PostSync.DeploymentChain != nil {
 			if err := t.triggerDeploymentChain(ctx, appCfg.PostSync.DeploymentChain, deployment); err != nil {
 				msg := fmt.Sprintf("failed to trigger new deployment chain: %v", err)
@@ -301,7 +302,7 @@ func (t *Trigger) checkRepoCandidates(ctx context.Context, repoID string, cs []c
 				continue
 			}
 		} else {
-			// Build deployment model and send a request to API to create a new deployment.
+			// Send a request to API to create a new deployment.
 			if err := t.triggerDeployment(ctx, deployment); err != nil {
 				msg := fmt.Sprintf("failed to trigger application %s: %v", app.Id, err)
 				t.notifyDeploymentTriggerFailed(app, appCfg, msg, headCommit)

--- a/pkg/app/web/src/__fixtures__/dummy-deployment.ts
+++ b/pkg/app/web/src/__fixtures__/dummy-deployment.ts
@@ -43,6 +43,7 @@ export const dummyDeployment: Deployment.AsObject = {
   },
   kind: ApplicationKind.KUBERNETES,
   metadataMap: [],
+  deploymentChainId: "",
 };
 
 export function createDeploymentFromObject(o: Deployment.AsObject): Deployment {

--- a/pkg/app/web/src/components/deployments-detail-page/pipeline/index.stories.tsx
+++ b/pkg/app/web/src/components/deployments-detail-page/pipeline/index.stories.tsx
@@ -118,6 +118,7 @@ const fakeDeployment: Deployment.AsObject = {
   completedAt: 0,
   createdAt: 1592203166,
   updatedAt: 1592203166,
+  deploymentChainId: "",
 };
 
 export default {

--- a/pkg/datastore/BUILD.bazel
+++ b/pkg/datastore/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
         "applicationstore.go",
         "commandstore.go",
         "datastore.go",
+        "deploymentchainstore.go",
         "deploymentstore.go",
         "environmentstore.go",
         "eventstore.go",

--- a/pkg/datastore/deploymentchainstore.go
+++ b/pkg/datastore/deploymentchainstore.go
@@ -1,0 +1,56 @@
+// Copyright 2021 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datastore
+
+import (
+	"context"
+	"time"
+
+	"github.com/pipe-cd/pipe/pkg/model"
+)
+
+const DeploymentChainModelKind = "DeploymentChain"
+
+type DeploymentChainStore interface {
+	AddDeploymentChain(ctx context.Context, d *model.DeploymentChain) error
+}
+
+type deploymentChainStore struct {
+	backend
+	nowFunc func() time.Time
+}
+
+func NewDeploymentChainStore(ds DataStore) DeploymentChainStore {
+	return &deploymentChainStore{
+		backend: backend{
+			ds: ds,
+		},
+		nowFunc: time.Now,
+	}
+}
+
+func (s *deploymentChainStore) AddDeploymentChain(ctx context.Context, dc *model.DeploymentChain) error {
+	now := s.nowFunc().Unix()
+	if dc.CreatedAt == 0 {
+		dc.CreatedAt = now
+	}
+	if dc.UpdatedAt == 0 {
+		dc.UpdatedAt = now
+	}
+	if err := dc.Validate(); err != nil {
+		return err
+	}
+	return s.ds.Create(ctx, DeploymentChainModelKind, dc.Id, dc)
+}

--- a/pkg/model/deployment.proto
+++ b/pkg/model/deployment.proto
@@ -86,6 +86,10 @@ message Deployment {
     repeated PipelineStage stages = 32;
     map<string,string> metadata = 33;
 
+    // Reference to the chain which the deployment belongs to.
+    // Empty means the deployment is a standalone deployment.
+    string deployment_chain_id = 40;
+
     int64 completed_at = 100 [(validate.rules).int64.gte = 0];
     int64 created_at = 101 [(validate.rules).int64.gte = 0];
     int64 updated_at = 102 [(validate.rules).int64.gte = 0];

--- a/pkg/model/deployment_chain.proto
+++ b/pkg/model/deployment_chain.proto
@@ -38,10 +38,12 @@ message DeploymentChain {
 }
 
 message DeploymentChainNode {
+    // Index represent the offset of the node in chain.
+    int32 index = 1;
     // List of applications which should be deployed at the same time in chain.
-    repeated Deployment deployments = 1;
+    repeated Deployment deployments = 2;
     // Control whether to start to deploy applications in this node or not.
-    bool runnable = 2;
+    bool runnable = 3;
     // Unix time when the deployment chain node is started.
     int64 started_at = 100 [(validate.rules).int64.gte = 0];
     // Unix time when all the applications in this chain node are deployed.

--- a/pkg/model/deployment_chain.proto
+++ b/pkg/model/deployment_chain.proto
@@ -26,9 +26,9 @@ message DeploymentChain {
     string id = 1 [(validate.rules).string.min_len = 1];
     // The ID of the project this environment belongs to.
     string project_id = 2 [(validate.rules).string.min_len = 1];
-    // List of all deployment node in the chain which contains all
+    // List of all deployment block in the chain which contains all
     // configuration required to perform deployment(s).
-    repeated DeploymentChainNode nodes = 3;
+    repeated ChainBlock blocks = 3;
     // Unix time when all the applications in this chain are deployed.
     int64 completed_at = 100 [(validate.rules).int64.gte = 0];
     // Unix time when the deployment chain is created.
@@ -37,13 +37,22 @@ message DeploymentChain {
     int64 updated_at = 102 [(validate.rules).int64.gt = 0];
 }
 
-message DeploymentChainNode {
+message ChainApplicationRef {
+    string application_id = 1 [(validate.rules).string.min_len = 1];
+    string application_name = 2;
+}
+
+message ChainNode {
+    ChainApplicationRef application_ref = 1 [(validate.rules).message.required = true];
+    Deployment deployment_ref = 2;
+}
+
+message ChainBlock {
     // Index represent the offset of the node in chain.
     int32 index = 1;
     // List of applications which should be deployed at the same time in chain.
-    repeated Deployment deployments = 2;
-    // Control whether to start to deploy applications in this node or not.
-    bool runnable = 3;
+    repeated ChainNode nodes = 2;
+
     // Unix time when the deployment chain node is started.
     int64 started_at = 100 [(validate.rules).int64.gte = 0];
     // Unix time when all the applications in this chain node are deployed.

--- a/pkg/model/deployment_chain.proto
+++ b/pkg/model/deployment_chain.proto
@@ -42,9 +42,13 @@ message ChainApplicationRef {
     string application_name = 2;
 }
 
+message ChainDeploymentRef {
+    string deployment_id = 1 [(validate.rules).string.min_len = 1];
+}
+
 message ChainNode {
     ChainApplicationRef application_ref = 1 [(validate.rules).message.required = true];
-    Deployment deployment_ref = 2;
+    ChainDeploymentRef deployment_ref = 2;
 }
 
 message ChainBlock {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR provides:
- logic to create a new deployment chain on trigger application which contains `spec.postSync.chain` configuration
- add grpc CreateDeploymentChain which add deployment chain model to control-plane datastore and make command to trigger all applications of the chain

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
