### PR TITLE
Change to treat .pipe.yaml as unregistered app config

### DIFF
--- a/pkg/app/pipectl/cmd/application/add.go
+++ b/pkg/app/pipectl/cmd/application/add.go
@@ -43,7 +43,7 @@ type add struct {
 func newAddCommand(root *command) *cobra.Command {
 	c := &add{
 		root:           root,
-		configFileName: model.DefaultDeploymentConfigFileName,
+		configFileName: model.DefaultApplicationConfigFilename,
 	}
 	cmd := &cobra.Command{
 		Use:   "add",

--- a/pkg/app/piped/appconfigreporter/appconfigreporter.go
+++ b/pkg/app/piped/appconfigreporter/appconfigreporter.go
@@ -282,7 +282,7 @@ func (r *Reporter) updateUnregisteredApps(ctx context.Context, registeredAppPath
 // The file name must be default name in order to be recognized as an Application config.
 func (r *Reporter) findUnregisteredApps(repoPath, repoID string, registeredAppPaths map[string]struct{}) ([]*model.ApplicationInfo, error) {
 	return r.scanAllFiles(repoPath, repoID, func(fileRelPath string) bool {
-		if filepath.Base(fileRelPath) != model.DefaultApplicationConfigFilename {
+		if !model.IsApplicationConfigFile(filepath.Base(fileRelPath)) {
 			return true
 		}
 

--- a/pkg/app/piped/appconfigreporter/appconfigreporter_test.go
+++ b/pkg/app/piped/appconfigreporter/appconfigreporter_test.go
@@ -41,7 +41,7 @@ func TestReporter_findUnregisteredApps(t *testing.T) {
 			name: "file not found",
 			reporter: &Reporter{
 				fileSystem: fstest.MapFS{
-					"path/to/repo-1/app-1/app.pipecd.yaml": &fstest.MapFile{Data: []byte("")},
+					"path/to/repo-1/app-1/.pipe.yaml": &fstest.MapFile{Data: []byte("")},
 				},
 				logger: zap.NewNop(),
 			},
@@ -57,7 +57,7 @@ func TestReporter_findUnregisteredApps(t *testing.T) {
 			name: "all are registered",
 			reporter: &Reporter{
 				fileSystem: fstest.MapFS{
-					"path/to/repo-1/app-1/app.pipecd.yaml": &fstest.MapFile{Data: []byte("")},
+					"path/to/repo-1/app-1/.pipe.yaml": &fstest.MapFile{Data: []byte("")},
 				},
 				logger: zap.NewNop(),
 			},
@@ -65,7 +65,7 @@ func TestReporter_findUnregisteredApps(t *testing.T) {
 				repoPath: "path/to/repo-1",
 				repoID:   "repo-1",
 				registeredAppPaths: map[string]struct{}{
-					"repo-1:app-1/app.pipecd.yaml": {},
+					"repo-1:app-1/.pipe.yaml": {},
 				},
 			},
 			want:    []*model.ApplicationInfo{},
@@ -75,7 +75,7 @@ func TestReporter_findUnregisteredApps(t *testing.T) {
 			name: "invalid app config is contained",
 			reporter: &Reporter{
 				fileSystem: fstest.MapFS{
-					"path/to/repo-1/app-1/app.pipecd.yaml": &fstest.MapFile{Data: []byte("invalid-text")},
+					"path/to/repo-1/app-1/.pipe.yaml": &fstest.MapFile{Data: []byte("invalid-text")},
 				},
 				logger: zap.NewNop(),
 			},
@@ -91,7 +91,7 @@ func TestReporter_findUnregisteredApps(t *testing.T) {
 			name: "valid app config that is unregistered",
 			reporter: &Reporter{
 				fileSystem: fstest.MapFS{
-					"path/to/repo-1/app-1/app.pipecd.yaml": &fstest.MapFile{Data: []byte(`
+					"path/to/repo-1/app-1/.pipe.yaml": &fstest.MapFile{Data: []byte(`
 apiVersion: pipecd.dev/v1beta1
 kind: KubernetesApp
 spec:
@@ -111,7 +111,7 @@ spec:
 					Name:           "app-1",
 					Labels:         map[string]string{"key-1": "value-1"},
 					Path:           "app-1",
-					ConfigFilename: "app.pipecd.yaml",
+					ConfigFilename: ".pipe.yaml",
 				},
 			},
 			wantErr: false,
@@ -158,7 +158,7 @@ func TestReporter_findRegisteredApps(t *testing.T) {
 			name: "no changed file",
 			reporter: &Reporter{
 				fileSystem: fstest.MapFS{
-					"path/to/repo-1/app-1/app.pipecd.yaml": &fstest.MapFile{Data: []byte("invalid-text")},
+					"path/to/repo-1/app-1/.pipe.yaml": &fstest.MapFile{Data: []byte("invalid-text")},
 				},
 				logger: zap.NewNop(),
 			},
@@ -174,13 +174,13 @@ func TestReporter_findRegisteredApps(t *testing.T) {
 			name: "all are unregistered",
 			reporter: &Reporter{
 				fileSystem: fstest.MapFS{
-					"path/to/repo-1/app-1/app.pipecd.yaml": &fstest.MapFile{Data: []byte("")},
+					"path/to/repo-1/app-1/.pipe.yaml": &fstest.MapFile{Data: []byte("")},
 				},
 				logger: zap.NewNop(),
 			},
 			args: args{
 				repoID:            "repo-1",
-				repo:              &fakeGitRepo{path: "path/to/repo-1", changedFiles: []string{"app-1/app.pipecd.yaml"}},
+				repo:              &fakeGitRepo{path: "path/to/repo-1", changedFiles: []string{"app-1/.pipe.yaml"}},
 				lastScannedCommit: "xxx",
 			},
 			want:    []*model.ApplicationInfo{},
@@ -190,16 +190,16 @@ func TestReporter_findRegisteredApps(t *testing.T) {
 			name: "invalid app config is contained",
 			reporter: &Reporter{
 				fileSystem: fstest.MapFS{
-					"path/to/repo-1/app-1/app.pipecd.yaml": &fstest.MapFile{Data: []byte("invalid-text")},
+					"path/to/repo-1/app-1/.pipe.yaml": &fstest.MapFile{Data: []byte("invalid-text")},
 				},
 				logger: zap.NewNop(),
 			},
 			args: args{
 				repoID:            "repo-1",
-				repo:              &fakeGitRepo{path: "path/to/repo-1", changedFiles: []string{"app-1/app.pipecd.yaml"}},
+				repo:              &fakeGitRepo{path: "path/to/repo-1", changedFiles: []string{"app-1/.pipe.yaml"}},
 				lastScannedCommit: "xxx",
 				registeredAppPaths: map[string]struct{}{
-					"repo-1:app-1/app.pipecd.yaml": {},
+					"repo-1:app-1/.pipe.yaml": {},
 				},
 			},
 			want:    []*model.ApplicationInfo{},
@@ -209,7 +209,7 @@ func TestReporter_findRegisteredApps(t *testing.T) {
 			name: "valid app config that is registered",
 			reporter: &Reporter{
 				fileSystem: fstest.MapFS{
-					"path/to/repo-1/app-1/app.pipecd.yaml": &fstest.MapFile{Data: []byte(`
+					"path/to/repo-1/app-1/.pipe.yaml": &fstest.MapFile{Data: []byte(`
 apiVersion: pipecd.dev/v1beta1
 kind: KubernetesApp
 spec:
@@ -221,10 +221,10 @@ spec:
 			},
 			args: args{
 				repoID:            "repo-1",
-				repo:              &fakeGitRepo{path: "path/to/repo-1", changedFiles: []string{"app-1/app.pipecd.yaml"}},
+				repo:              &fakeGitRepo{path: "path/to/repo-1", changedFiles: []string{"app-1/.pipe.yaml"}},
 				lastScannedCommit: "xxx",
 				registeredAppPaths: map[string]struct{}{
-					"repo-1:app-1/app.pipecd.yaml": {},
+					"repo-1:app-1/.pipe.yaml": {},
 				},
 			},
 			want: []*model.ApplicationInfo{
@@ -232,7 +232,7 @@ spec:
 					Name:           "app-1",
 					Labels:         map[string]string{"key-1": "value-1"},
 					Path:           "app-1",
-					ConfigFilename: "app.pipecd.yaml",
+					ConfigFilename: ".pipe.yaml",
 				},
 			},
 			wantErr: false,
@@ -241,7 +241,7 @@ spec:
 			name: "last commit commit is empty",
 			reporter: &Reporter{
 				fileSystem: fstest.MapFS{
-					"path/to/repo-1/app-1/app.pipecd.yaml": &fstest.MapFile{Data: []byte(`
+					"path/to/repo-1/app-1/.pipe.yaml": &fstest.MapFile{Data: []byte(`
 apiVersion: pipecd.dev/v1beta1
 kind: KubernetesApp
 spec:
@@ -256,7 +256,7 @@ spec:
 				repo:              &fakeGitRepo{path: "path/to/repo-1"},
 				lastScannedCommit: "",
 				registeredAppPaths: map[string]struct{}{
-					"repo-1:app-1/app.pipecd.yaml": {},
+					"repo-1:app-1/.pipe.yaml": {},
 				},
 			},
 			want: []*model.ApplicationInfo{
@@ -264,7 +264,7 @@ spec:
 					Name:           "app-1",
 					Labels:         map[string]string{"key-1": "value-1"},
 					Path:           "app-1",
-					ConfigFilename: "app.pipecd.yaml",
+					ConfigFilename: ".pipe.yaml",
 				},
 			},
 			wantErr: false,

--- a/pkg/app/piped/appconfigreporter/appconfigreporter_test.go
+++ b/pkg/app/piped/appconfigreporter/appconfigreporter_test.go
@@ -116,6 +116,35 @@ spec:
 			},
 			wantErr: false,
 		},
+		{
+			name: "valid app config that name isn't default",
+			reporter: &Reporter{
+				fileSystem: fstest.MapFS{
+					"path/to/repo-1/app-1/dev.pipecd.yaml": &fstest.MapFile{Data: []byte(`
+apiVersion: pipecd.dev/v1beta1
+kind: KubernetesApp
+spec:
+  name: app-1
+  labels:
+    key-1: value-1`)},
+				},
+				logger: zap.NewNop(),
+			},
+			args: args{
+				repoPath:           "path/to/repo-1",
+				repoID:             "repo-1",
+				registeredAppPaths: map[string]struct{}{},
+			},
+			want: []*model.ApplicationInfo{
+				{
+					Name:           "app-1",
+					Labels:         map[string]string{"key-1": "value-1"},
+					Path:           "app-1",
+					ConfigFilename: "dev.pipecd.yaml",
+				},
+			},
+			wantErr: false,
+		},
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -238,7 +267,7 @@ spec:
 			wantErr: false,
 		},
 		{
-			name: "last commit commit is empty",
+			name: "last scanned commit is empty",
 			reporter: &Reporter{
 				fileSystem: fstest.MapFS{
 					"path/to/repo-1/app-1/.pipe.yaml": &fstest.MapFile{Data: []byte(`

--- a/pkg/app/piped/cloudprovider/kubernetes/manifest.go
+++ b/pkg/app/piped/cloudprovider/kubernetes/manifest.go
@@ -183,7 +183,7 @@ func LoadPlainYAMLManifests(dir string, names []string, configFileName string) (
 			if ext != ".yaml" && ext != ".yml" && ext != ".json" {
 				return nil
 			}
-			if f.Name() == model.DefaultDeploymentConfigFileName {
+			if f.Name() == model.DefaultApplicationConfigFilename {
 				return nil
 			}
 			if f.Name() == configFileName {

--- a/pkg/model/application.go
+++ b/pkg/model/application.go
@@ -22,6 +22,7 @@ import (
 
 const (
 	DefaultApplicationConfigFilename = ".pipe.yaml"
+	applicationConfigFileExtention   = ".pipecd.yaml"
 )
 
 // GetDeploymentConfigFilePath returns the path to deployment configuration file.
@@ -68,4 +69,8 @@ func (a *Application) ContainLabels(labels map[string]string) bool {
 		}
 	}
 	return true
+}
+
+func IsApplicationConfigFile(filename string) bool {
+	return filename == DefaultApplicationConfigFilename || strings.HasSuffix(filename, applicationConfigFileExtention)
 }

--- a/pkg/model/application.go
+++ b/pkg/model/application.go
@@ -21,14 +21,12 @@ import (
 )
 
 const (
-	// TODO: Consider changing the default application config name
-	DefaultDeploymentConfigFileName      = ".pipe.yaml"
-	DefaultDeploymentConfigFileExtension = ".pipecd.yaml"
+	DefaultApplicationConfigFilename = ".pipe.yaml"
 )
 
 // GetDeploymentConfigFilePath returns the path to deployment configuration file.
 func (p ApplicationGitPath) GetDeploymentConfigFilePath() string {
-	filename := DefaultDeploymentConfigFileName
+	filename := DefaultApplicationConfigFilename
 	if n := p.ConfigFilename; n != "" {
 		filename = n
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
I feel like it's better to use the default file name (`.pipe.yaml`) as well as the file extension (`.pipecd.yaml`) as a collection condition for UnregisteredApps.

Currently, ConfigFilename in the Application model is optional and is [considered to be ".pipe.yaml" if empty](https://github.com/pipe-cd/pipe/blob/d234a79e15f188c4b30d2917e4fe74bffaad9875/pkg/model/application.go#L28-L34). So changing the default ConfigFilename is a bit complicated.

It is confusing to recommend using the extension `.pipecd.yaml` without changing the default from `.pipe.yaml`, so I would say `pipe.yaml` should also be treated as a collection condition for UnregisteredApps.

~I don't think there are many people who would be happy with being able to freely decide the name of the application config file, so I would say it would be a good idea to fix the name from now on. Alternatively, you can also decide that a .pipe.yaml at the end is all you need, like: `if strings.HasSuffix(path, ".pipe.yaml")`~

This PR also removed the check the file extension for RegisteredApps, since it can be determined without checking them.

**Which issue(s) this PR fixes**:

Fixes https://github.com/pipe-cd/pipe/issues/2808

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
