### PR TITLE
Update CreateDeployment RPC to handle create in chain deployment

### DIFF
--- a/pkg/app/piped/trigger/deployment.go
+++ b/pkg/app/piped/trigger/deployment.go
@@ -50,6 +50,7 @@ func buildDeployment(
 	now time.Time,
 	noti *config.DeploymentNotification,
 	deploymentChainID string,
+	deploymentChainBlockIndex int32,
 ) (*model.Deployment, error) {
 
 	var commitURL string
@@ -92,15 +93,16 @@ func buildDeployment(
 			SyncStrategy:    syncStrategy,
 			StrategySummary: strategySummary,
 		},
-		GitPath:           app.GitPath,
-		CloudProvider:     app.CloudProvider,
-		Labels:            app.Labels,
-		Status:            model.DeploymentStatus_DEPLOYMENT_PENDING,
-		StatusReason:      "The deployment is waiting to be planned",
-		Metadata:          metadata,
-		CreatedAt:         now.Unix(),
-		UpdatedAt:         now.Unix(),
-		DeploymentChainId: deploymentChainID,
+		GitPath:                   app.GitPath,
+		CloudProvider:             app.CloudProvider,
+		Labels:                    app.Labels,
+		Status:                    model.DeploymentStatus_DEPLOYMENT_PENDING,
+		StatusReason:              "The deployment is waiting to be planned",
+		Metadata:                  metadata,
+		CreatedAt:                 now.Unix(),
+		UpdatedAt:                 now.Unix(),
+		DeploymentChainId:         deploymentChainID,
+		DeploymentChainBlockIndex: deploymentChainBlockIndex,
 	}
 
 	return deployment, nil

--- a/pkg/app/piped/trigger/trigger.go
+++ b/pkg/app/piped/trigger/trigger.go
@@ -248,10 +248,11 @@ func (t *Trigger) checkRepoCandidates(ctx context.Context, repoID string, cs []c
 		}
 
 		var (
-			commander         string
-			strategy          model.SyncStrategy
-			strategySummary   string
-			deploymentChainID string
+			commander                 string
+			strategy                  model.SyncStrategy
+			strategySummary           string
+			deploymentChainID         string
+			deploymentChainBlockIndex int32
 		)
 
 		switch c.kind {
@@ -269,6 +270,7 @@ func (t *Trigger) checkRepoCandidates(ctx context.Context, repoID string, cs []c
 			commander = c.command.Commander
 			strategySummary = "Sync application in chain"
 			deploymentChainID = c.command.GetChainSyncApplication().DeploymentChainId
+			deploymentChainBlockIndex = c.command.GetChainSyncApplication().BlockIndex
 
 		case model.TriggerKind_ON_OUT_OF_SYNC:
 			strategy = model.SyncStrategy_QUICK_SYNC
@@ -289,6 +291,7 @@ func (t *Trigger) checkRepoCandidates(ctx context.Context, repoID string, cs []c
 			time.Now(),
 			appCfg.DeploymentNotification,
 			deploymentChainID,
+			deploymentChainBlockIndex,
 		)
 		if err != nil {
 			msg := fmt.Sprintf("failed to build deployment for application %s: %v", app.Id, err)

--- a/pkg/app/web/src/__fixtures__/dummy-deployment.ts
+++ b/pkg/app/web/src/__fixtures__/dummy-deployment.ts
@@ -44,6 +44,7 @@ export const dummyDeployment: Deployment.AsObject = {
   kind: ApplicationKind.KUBERNETES,
   metadataMap: [],
   deploymentChainId: "",
+  deploymentChainBlockIndex: 0,
 };
 
 export function createDeploymentFromObject(o: Deployment.AsObject): Deployment {

--- a/pkg/app/web/src/components/deployments-detail-page/pipeline/index.stories.tsx
+++ b/pkg/app/web/src/components/deployments-detail-page/pipeline/index.stories.tsx
@@ -119,6 +119,7 @@ const fakeDeployment: Deployment.AsObject = {
   createdAt: 1592203166,
   updatedAt: 1592203166,
   deploymentChainId: "",
+  deploymentChainBlockIndex: 0,
 };
 
 export default {

--- a/pkg/model/deployment.proto
+++ b/pkg/model/deployment.proto
@@ -89,6 +89,9 @@ message Deployment {
     // Reference to the chain which the deployment belongs to.
     // Empty means the deployment is a standalone deployment.
     string deployment_chain_id = 40;
+    // Index represents the offset of the node which this deployment
+    // belongs to.
+    int32 deployment_chain_block_index = 41;
 
     int64 completed_at = 100 [(validate.rules).int64.gte = 0];
     int64 created_at = 101 [(validate.rules).int64.gte = 0];


### PR DESCRIPTION
**What this PR does / why we need it**:

For deployment which be created to sync application in chain, we should add the ref to it in the chain model it belongs to, otherwise is keep as is for standalone deployment (deployment that does not belong to any chain called standalone deployment)

**Which issue(s) this PR fixes**:

Follow PR #2815 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
