### PR TITLE
Enable to convert config kind into model.ApplicationKind

### DIFF
--- a/pkg/app/piped/appconfigreporter/appconfigreporter.go
+++ b/pkg/app/piped/appconfigreporter/appconfigreporter.go
@@ -356,10 +356,13 @@ func (r *Reporter) readApplicationInfo(repoDir, appDirRelPath, cfgFilename strin
 	if spec.Name == "" {
 		return nil, fmt.Errorf("missing application name")
 	}
+	kind, ok := cfg.Kind.ToApplicationKind()
+	if !ok {
+		return nil, fmt.Errorf("%q is not application config kind", cfg.Kind)
+	}
 	return &model.ApplicationInfo{
-		Name: spec.Name,
-		// TODO: Convert Kind string into dedicated type
-		//Kind:           cfg.Kind,
+		Name:           spec.Name,
+		Kind:           kind,
 		Labels:         spec.Labels,
 		Path:           appDirRelPath,
 		ConfigFilename: cfgFilename,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/creasty/defaults"
 	"sigs.k8s.io/yaml"
@@ -66,6 +67,18 @@ const (
 	// KindEventWatcher represents configuration for Event Watcher.
 	KindEventWatcher Kind = "EventWatcher"
 )
+
+// ToApplicationKind converts itself into model.ApplicationKind if it's for an application config.
+// Return false as a second returned value if it's not an application config.
+func (k Kind) ToApplicationKind() (model.ApplicationKind, bool) {
+	upper := strings.ToUpper(string(k))
+	kind := strings.TrimSuffix(upper, "APP")
+	appKind, ok := model.ApplicationKind_value[kind]
+	if !ok {
+		return -1, false
+	}
+	return model.ApplicationKind(appKind), true
+}
 
 var (
 	ErrNotFound = errors.New("not found")

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -19,6 +19,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/pipe-cd/pipe/pkg/model"
 )
 
 func TestUnmarshalConfig(t *testing.T) {
@@ -78,4 +80,33 @@ func TestUnmarshalConfig(t *testing.T) {
 
 func newBoolPointer(v bool) *bool {
 	return &v
+}
+
+func TestKind_ToApplicationKind(t *testing.T) {
+	testcases := []struct {
+		name   string
+		k      Kind
+		want   model.ApplicationKind
+		wantOk bool
+	}{
+		{
+			name:   "App config",
+			k:      KindKubernetesApp,
+			want:   model.ApplicationKind_KUBERNETES,
+			wantOk: true,
+		},
+		{
+			name:   "Not an app config",
+			k:      KindPiped,
+			want:   -1,
+			wantOk: false,
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, gotOk := tc.k.ToApplicationKind()
+			assert.Equal(t, tc.want, got)
+			assert.Equal(t, tc.wantOk, gotOk)
+		})
+	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
In order to get to know the kind of Application config defined in Git without any additional field, we need kind of like this a bit dirty method.

**Which issue(s) this PR fixes**:

Fixes https://github.com/pipe-cd/pipe/issues/2807

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
