### PR TITLE
Add InChainDeploymentPlannable RPC

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/lambda v1.1.1
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.2.0
 	github.com/creasty/defaults v1.5.2
-	github.com/envoyproxy/protoc-gen-validate v0.1.0
+	github.com/envoyproxy/protoc-gen-validate v0.1.0 // indirect
 	github.com/fsouza/fake-gcs-server v1.21.0
 	github.com/go-sql-driver/mysql v1.5.0
 	github.com/goccy/go-yaml v1.9.3

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/lambda v1.1.1
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.2.0
 	github.com/creasty/defaults v1.5.2
-	github.com/envoyproxy/protoc-gen-validate v0.1.0 // indirect
+	github.com/envoyproxy/protoc-gen-validate v0.1.0
 	github.com/fsouza/fake-gcs-server v1.21.0
 	github.com/go-sql-driver/mysql v1.5.0
 	github.com/goccy/go-yaml v1.9.3

--- a/pkg/app/api/grpcapi/piped_api.go
+++ b/pkg/app/api/grpcapi/piped_api.go
@@ -1144,7 +1144,7 @@ func (a *PipedAPI) InChainDeploymentPlannable(ctx context.Context, req *pipedser
 		if err != nil {
 			return nil, status.Error(codes.Internal, "unable to process previous block nodes in deployment chain")
 		}
-		if model.IsCompletedSuccessfullyDeployment(dp.Status) {
+		if model.IsSuccessfullyCompletedDeployment(dp.Status) {
 			plannable = false
 			break
 		}

--- a/pkg/app/api/grpcapi/piped_api.go
+++ b/pkg/app/api/grpcapi/piped_api.go
@@ -1144,7 +1144,7 @@ func (a *PipedAPI) InChainDeploymentPlannable(ctx context.Context, req *pipedser
 		if err != nil {
 			return nil, status.Error(codes.Internal, "unable to process previous block nodes in deployment chain")
 		}
-		if dp.Status != model.DeploymentStatus_DEPLOYMENT_SUCCESS {
+		if model.IsCompletedSuccessfullyDeployment(dp.Status) {
 			plannable = false
 			break
 		}

--- a/pkg/app/api/grpcapi/piped_api.go
+++ b/pkg/app/api/grpcapi/piped_api.go
@@ -1138,6 +1138,8 @@ func (a *PipedAPI) InChainDeploymentPlannable(ctx context.Context, req *pipedser
 	prevBlock := dc.Blocks[req.Deployment.DeploymentChainBlockIndex-1]
 	plannable := true
 	for _, node := range prevBlock.Nodes {
+		// TODO: Consider add deployment status to the deployment ref in the deployment chain model
+		// instead of fetching deployment model here.
 		dp, err := a.deploymentStore.GetDeployment(ctx, node.DeploymentRef.DeploymentId)
 		if err != nil {
 			return nil, status.Error(codes.Internal, "unable to process previous block nodes in deployment chain")

--- a/pkg/app/api/grpcapi/piped_api.go
+++ b/pkg/app/api/grpcapi/piped_api.go
@@ -1105,6 +1105,54 @@ func (a *PipedAPI) CreateDeploymentChain(ctx context.Context, req *pipedservice.
 	return &pipedservice.CreateDeploymentChainResponse{}, nil
 }
 
+// InChainDeploymentPlannable hecks the completion and status of the previous block in the deployment chain.
+// An in chain deployment is treated as plannable in case:
+// - It's the first deployment of its deployment chain.
+// - All deployments of its previous block in chain are at DEPLOYMENT_SUCCESS state.
+func (a *PipedAPI) InChainDeploymentPlannable(ctx context.Context, req *pipedservice.InChainDeploymentPlannableRequest) (*pipedservice.InChainDeploymentPlannableResponse, error) {
+	_, pipedID, _, err := rpcauth.ExtractPipedToken(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if err := a.validateDeploymentBelongsToPiped(ctx, req.Deployment.Id, pipedID); err != nil {
+		return nil, err
+	}
+
+	dc, err := a.deploymentChainStore.GetDeploymentChain(ctx, req.Deployment.DeploymentChainId)
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, "unable to find the deployment chain which this deployment belongs to")
+	}
+
+	// Deployment of blocks[0] in the chain means it's the first deployment of the chain;
+	// hence it should be processed without any lock.
+	if req.Deployment.DeploymentChainBlockIndex == 0 {
+		return &pipedservice.InChainDeploymentPlannableResponse{
+			Plannable: true,
+		}, nil
+	}
+
+	if req.Deployment.DeploymentChainBlockIndex >= int32(len(dc.Blocks)) {
+		return nil, status.Error(codes.InvalidArgument, "invalid deployment with chain block index provided")
+	}
+
+	prevBlock := dc.Blocks[req.Deployment.DeploymentChainBlockIndex-1]
+	plannable := true
+	for _, node := range prevBlock.Nodes {
+		dp, err := a.deploymentStore.GetDeployment(ctx, node.DeploymentRef.DeploymentId)
+		if err != nil {
+			return nil, status.Error(codes.Internal, "unable to process previous block nodes in deployment chain")
+		}
+		if dp.Status != model.DeploymentStatus_DEPLOYMENT_SUCCESS {
+			plannable = false
+			break
+		}
+	}
+
+	return &pipedservice.InChainDeploymentPlannableResponse{
+		Plannable: plannable,
+	}, nil
+}
+
 // validateAppBelongsToPiped checks if the given application belongs to the given piped.
 // It gives back an error unless the application belongs to the piped.
 func (a *PipedAPI) validateAppBelongsToPiped(ctx context.Context, appID, pipedID string) error {

--- a/pkg/app/api/service/pipedservice/service.proto
+++ b/pkg/app/api/service/pipedservice/service.proto
@@ -173,6 +173,10 @@ service PipedService {
     // CreateDeploymentChain creates a new deployment chain object and all required commands to
     // trigger deployment for applications in the chain.
     rpc CreateDeploymentChain(CreateDeploymentChainRequest) returns (CreateDeploymentChainResponse) {}
+    // DeploymentPlannable checks the completion and status of the previous block in the deployment chain,
+    // only when all the nodes of the previous block are completed with a success status,
+    // the nodes of the next block will be treat as processable.
+    rpc InChainDeploymentPlannable(InChainDeploymentPlannableRequest) returns (InChainDeploymentPlannableResponse) {}
 }
 
 enum ListOrder {
@@ -494,4 +498,12 @@ message CreateDeploymentChainRequest {
 }
 
 message CreateDeploymentChainResponse {
+}
+
+message InChainDeploymentPlannableRequest {
+    pipe.model.Deployment deployment = 1 [(validate.rules).message.required = true];
+}
+
+message InChainDeploymentPlannableResponse {
+    bool plannable = 1;
 }

--- a/pkg/datastore/deploymentchainstore.go
+++ b/pkg/datastore/deploymentchainstore.go
@@ -56,6 +56,7 @@ var (
 type DeploymentChainStore interface {
 	AddDeploymentChain(ctx context.Context, d *model.DeploymentChain) error
 	UpdateDeploymentChain(ctx context.Context, id string, updater func(*model.DeploymentChain) error) error
+	GetDeploymentChain(ctx context.Context, id string) (*model.DeploymentChain, error)
 }
 
 type deploymentChainStore struct {
@@ -96,4 +97,12 @@ func (s *deploymentChainStore) UpdateDeploymentChain(ctx context.Context, id str
 		dc.UpdatedAt = now
 		return dc.Validate()
 	})
+}
+
+func (s *deploymentChainStore) GetDeploymentChain(ctx context.Context, id string) (*model.DeploymentChain, error) {
+	var entity model.DeploymentChain
+	if err := s.ds.Get(ctx, DeploymentChainModelKind, id, &entity); err != nil {
+		return nil, err
+	}
+	return &entity, nil
 }

--- a/pkg/model/deployment.go
+++ b/pkg/model/deployment.go
@@ -48,6 +48,11 @@ func IsCompletedDeployment(status DeploymentStatus) bool {
 	return false
 }
 
+// IsCompletedSuccessfullyDeployment checks whether the deployment is at a successfully addressed.
+func IsCompletedSuccessfullyDeployment(status DeploymentStatus) bool {
+	return status == DeploymentStatus_DEPLOYMENT_SUCCESS
+}
+
 // IsCompletedStage checks whether the stage is at a completion state.
 func IsCompletedStage(status StageStatus) bool {
 	if status.String() == "" {

--- a/pkg/model/deployment.go
+++ b/pkg/model/deployment.go
@@ -49,7 +49,7 @@ func IsCompletedDeployment(status DeploymentStatus) bool {
 }
 
 // IsCompletedSuccessfullyDeployment checks whether the deployment is at a successfully addressed.
-func IsCompletedSuccessfullyDeployment(status DeploymentStatus) bool {
+func IsSuccessfullyCompletedDeployment(status DeploymentStatus) bool {
 	return status == DeploymentStatus_DEPLOYMENT_SUCCESS
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds an RPC which be used by piped to determine whether to start planning a deployment that is triggered by the DeploymentChain model.

**Which issue(s) this PR fixes**:

Follow PR #2815 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
