### PR TITLE
Change DeploymentChainBlockIndex type

### DIFF
--- a/pkg/app/api/grpcapi/piped_api.go
+++ b/pkg/app/api/grpcapi/piped_api.go
@@ -1053,7 +1053,7 @@ func (a *PipedAPI) CreateDeploymentChain(ctx context.Context, req *pipedservice.
 
 		blockAppsMap[i+1] = blockApps
 		chainBlocks = append(chainBlocks, &model.ChainBlock{
-			Nodes: nodes,
+			Nodes:     nodes,
 			StartedAt: time.Now().Unix(),
 		})
 	}
@@ -1131,7 +1131,7 @@ func (a *PipedAPI) InChainDeploymentPlannable(ctx context.Context, req *pipedser
 		}, nil
 	}
 
-	if req.Deployment.DeploymentChainBlockIndex >= int32(len(dc.Blocks)) {
+	if req.Deployment.DeploymentChainBlockIndex >= uint32(len(dc.Blocks)) {
 		return nil, status.Error(codes.InvalidArgument, "invalid deployment with chain block index provided")
 	}
 

--- a/pkg/app/api/grpcapi/piped_api.go
+++ b/pkg/app/api/grpcapi/piped_api.go
@@ -1030,7 +1030,6 @@ func (a *PipedAPI) CreateDeploymentChain(ctx context.Context, req *pipedservice.
 	chainBlocks := make([]*model.ChainBlock, 0, len(req.Matchers)+1)
 	// Add the first deployment which created by piped as the first block of the chain.
 	chainBlocks = append(chainBlocks, &model.ChainBlock{
-		Index: 0,
 		Nodes: []*model.ChainNode{
 			{
 				ApplicationRef: &model.ChainApplicationRef{
@@ -1042,6 +1041,7 @@ func (a *PipedAPI) CreateDeploymentChain(ctx context.Context, req *pipedservice.
 				},
 			},
 		},
+		StartedAt: time.Now().Unix(),
 	})
 
 	blockAppsMap := make(map[int][]*model.Application, len(req.Matchers))

--- a/pkg/app/api/grpcapi/piped_api.go
+++ b/pkg/app/api/grpcapi/piped_api.go
@@ -1053,8 +1053,8 @@ func (a *PipedAPI) CreateDeploymentChain(ctx context.Context, req *pipedservice.
 
 		blockAppsMap[i+1] = blockApps
 		chainBlocks = append(chainBlocks, &model.ChainBlock{
-			Index: int32(i + 1),
 			Nodes: nodes,
+			StartedAt: time.Now().Unix(),
 		})
 	}
 
@@ -1089,7 +1089,7 @@ func (a *PipedAPI) CreateDeploymentChain(ctx context.Context, req *pipedservice.
 				Type:          model.Command_CHAIN_SYNC_APPLICATION,
 				ChainSyncApplication: &model.Command_ChainSyncApplication{
 					DeploymentChainId: dc.Id,
-					BlockIndex:        int32(blockIndex),
+					BlockIndex:        uint32(blockIndex),
 					ApplicationId:     app.Id,
 					SyncStrategy:      model.SyncStrategy_AUTO,
 				},

--- a/pkg/app/piped/trigger/deployment.go
+++ b/pkg/app/piped/trigger/deployment.go
@@ -50,7 +50,7 @@ func buildDeployment(
 	now time.Time,
 	noti *config.DeploymentNotification,
 	deploymentChainID string,
-	deploymentChainBlockIndex int32,
+	deploymentChainBlockIndex uint32,
 ) (*model.Deployment, error) {
 
 	var commitURL string

--- a/pkg/app/piped/trigger/trigger.go
+++ b/pkg/app/piped/trigger/trigger.go
@@ -252,7 +252,7 @@ func (t *Trigger) checkRepoCandidates(ctx context.Context, repoID string, cs []c
 			strategy                  model.SyncStrategy
 			strategySummary           string
 			deploymentChainID         string
-			deploymentChainBlockIndex int32
+			deploymentChainBlockIndex uint32
 		)
 
 		switch c.kind {

--- a/pkg/datastore/deploymentchainstore.go
+++ b/pkg/datastore/deploymentchainstore.go
@@ -31,7 +31,7 @@ var deploymentChainFactory = func() interface{} {
 var (
 	DeploymentChainAddDeploymentToBlock = func(deployment *model.Deployment) func(*model.DeploymentChain) error {
 		return func(dc *model.DeploymentChain) error {
-			if deployment.DeploymentChainBlockIndex == 0 || deployment.DeploymentChainBlockIndex >= int32(len(dc.Blocks)) {
+			if deployment.DeploymentChainBlockIndex == 0 || deployment.DeploymentChainBlockIndex >= uint32(len(dc.Blocks)) {
 				return fmt.Errorf("invalid block index provided")
 			}
 			block := dc.Blocks[deployment.DeploymentChainBlockIndex]

--- a/pkg/model/command.proto
+++ b/pkg/model/command.proto
@@ -69,7 +69,7 @@ message Command {
 
     message ChainSyncApplication {
         string deployment_chain_id = 1;
-        int32 block_index = 2;
+        uint32 block_index = 2;
         string application_id = 3 [(validate.rules).string.min_len = 1];
         SyncStrategy sync_strategy = 4;
     }

--- a/pkg/model/deployment.proto
+++ b/pkg/model/deployment.proto
@@ -91,7 +91,7 @@ message Deployment {
     string deployment_chain_id = 40;
     // Index represents the offset of the node which this deployment
     // belongs to.
-    int32 deployment_chain_block_index = 41;
+    uint32 deployment_chain_block_index = 41;
 
     int64 completed_at = 100 [(validate.rules).int64.gte = 0];
     int64 created_at = 101 [(validate.rules).int64.gte = 0];

--- a/pkg/model/deployment_chain.proto
+++ b/pkg/model/deployment_chain.proto
@@ -52,10 +52,8 @@ message ChainNode {
 }
 
 message ChainBlock {
-    // Index represent the offset of the node in chain.
-    int32 index = 1;
     // List of applications which should be deployed at the same time in chain.
-    repeated ChainNode nodes = 2;
+    repeated ChainNode nodes = 1;
 
     // Unix time when the deployment chain node is started.
     int64 started_at = 100 [(validate.rules).int64.gte = 0];


### PR DESCRIPTION
**What this PR does / why we need it**:

- Remove unused ChainBlockIndex field from DeploymentChain model's block
- Change type of DeploymentChainBlockIndex from `int32` to `uinit32`

**Which issue(s) this PR fixes**:

As discussed in https://github.com/pipe-cd/pipe/pull/2832#discussion_r755829482

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
