### PR TITLE
Update bazelrc

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -8,7 +8,7 @@ test --test_output=errors --test_verbose_timeout_warnings --incompatible_strict_
 build:stamping --stamp --workspace_status_command hack/print-workspace-status.sh
 
 # Enable go race detection
-build --features=race
+build --@io_bazel_rules_go//go/config:race
 
 # Output profiling to a file
 build --profile=/tmp/build.bazelprofile


### PR DESCRIPTION
**What this PR does / why we need it**:

Suspends this warning

> DEBUG: /private/var/tmp/_bazel_/2d45f513ea3114123209fc663da944fe/external/io_bazel_rules_go/go/private/context.bzl:505:14: WARNING: --features=race is no longer supported. Use --@io_bazel_rules_go//go/config:race instead.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
