### PR TITLE
Fix web:compile to support Apple M1

### DIFF
--- a/pkg/app/web/tsconfig.json
+++ b/pkg/app/web/tsconfig.json
@@ -9,6 +9,7 @@
       ],
       "pipe/*": [
         "../../../bazel-out/darwin-fastbuild/bin/*",
+        "../../../bazel-out/darwin_arm64-fastbuild/bin/*",
         "../../../bazel-out/k8-fastbuild/bin/*",
         "../../../bazel-out/x64_windows-fastbuild/bin/*",
         "../../../bazel-out/darwin-dbg/bin/*",
@@ -41,6 +42,7 @@
     "rootDirs": [
       ".",
       "../../../bazel-out/darwin-fastbuild/bin",
+      "../../../bazel-out/darwin_arm64-fastbuild/bin",
       "../../../bazel-out/k8-fastbuild/bin",
       "../../../bazel-out/x64_windows-fastbuild/bin",
       "../../../bazel-out/darwin-dbg/bin",


### PR DESCRIPTION
**What this PR does / why we need it**:

Can develop PipeCD on Apple M1 environment, finally 😂 

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
