### PR TITLE
Download the latest version of pipectl

### DIFF
--- a/docs/content/en/docs-dev/user-guide/command-line-tool.md
+++ b/docs/content/en/docs-dev/user-guide/command-line-tool.md
@@ -16,11 +16,11 @@ You can use pipectl to add and sync applications, wait for a deployment status.
 1. Download the appropriate version for your platform from [PipeCD Releases](https://github.com/pipe-cd/pipe/releases).
 
     We recommend using the latest version of pipectl to avoid unforeseen issues.
-    Please set `{VERSION}` to the same format like `v0.9.15`.
-    And `{OS}` can be replaced with either `linux` or `darwin`.
+    Run the following script:
 
     ``` console
-    curl -Lo ./pipectl https://github.com/pipe-cd/pipe/releases/download/{VERSION}/pipectl_{VERSION}_{OS}_amd64
+    OS="darwin" # or "linux"
+    curl -Lo ./pipectl https://github.com/pipe-cd/pipe/releases/download/{{< blocks/latest_version >}}/pipectl_{{< blocks/latest_version >}}_${OS}_amd64
     ```
 
 2. Make the pipectl binary executable.

--- a/docs/content/en/docs-v0.18.x/user-guide/command-line-tool.md
+++ b/docs/content/en/docs-v0.18.x/user-guide/command-line-tool.md
@@ -16,11 +16,11 @@ You can use pipectl to add and sync applications, wait for a deployment status.
 1. Download the appropriate version for your platform from [PipeCD Releases](https://github.com/pipe-cd/pipe/releases).
 
     We recommend using the latest version of pipectl to avoid unforeseen issues.
-    Please set `{VERSION}` to the same format like `v0.9.15`.
-    And `{OS}` can be replaced with either `linux` or `darwin`.
+    Run the following script:
 
     ``` console
-    curl -Lo ./pipectl https://github.com/pipe-cd/pipe/releases/download/{VERSION}/pipectl_{VERSION}_{OS}_amd64
+    OS="darwin" # or "linux"
+    curl -Lo ./pipectl https://github.com/pipe-cd/pipe/releases/download/{{< blocks/latest_version >}}/pipectl_{{< blocks/latest_version >}}_${OS}_amd64
     ```
 
 2. Make the pipectl binary executable.

--- a/docs/content/en/docs-v0.20.x/user-guide/command-line-tool.md
+++ b/docs/content/en/docs-v0.20.x/user-guide/command-line-tool.md
@@ -16,11 +16,11 @@ You can use pipectl to add and sync applications, wait for a deployment status.
 1. Download the appropriate version for your platform from [PipeCD Releases](https://github.com/pipe-cd/pipe/releases).
 
     We recommend using the latest version of pipectl to avoid unforeseen issues.
-    Please set `{VERSION}` to the same format like `v0.9.15`.
-    And `{OS}` can be replaced with either `linux` or `darwin`.
+    Run the following script:
 
     ``` console
-    curl -Lo ./pipectl https://github.com/pipe-cd/pipe/releases/download/{VERSION}/pipectl_{VERSION}_{OS}_amd64
+    OS="darwin" # or "linux"
+    curl -Lo ./pipectl https://github.com/pipe-cd/pipe/releases/download/{{< blocks/latest_version >}}/pipectl_{{< blocks/latest_version >}}_${OS}_amd64
     ```
 
 2. Make the pipectl binary executable.

--- a/docs/content/en/docs-v0.21.x/user-guide/command-line-tool.md
+++ b/docs/content/en/docs-v0.21.x/user-guide/command-line-tool.md
@@ -16,11 +16,11 @@ You can use pipectl to add and sync applications, wait for a deployment status.
 1. Download the appropriate version for your platform from [PipeCD Releases](https://github.com/pipe-cd/pipe/releases).
 
     We recommend using the latest version of pipectl to avoid unforeseen issues.
-    Please set `{VERSION}` to the same format like `v0.9.15`.
-    And `{OS}` can be replaced with either `linux` or `darwin`.
+    Run the following script:
 
     ``` console
-    curl -Lo ./pipectl https://github.com/pipe-cd/pipe/releases/download/{VERSION}/pipectl_{VERSION}_{OS}_amd64
+    OS="darwin" # or "linux"
+    curl -Lo ./pipectl https://github.com/pipe-cd/pipe/releases/download/{{< blocks/latest_version >}}/pipectl_{{< blocks/latest_version >}}_${OS}_amd64
     ```
 
 2. Make the pipectl binary executable.

--- a/docs/content/en/docs/user-guide/command-line-tool.md
+++ b/docs/content/en/docs/user-guide/command-line-tool.md
@@ -16,11 +16,12 @@ You can use pipectl to add and sync applications, wait for a deployment status.
 1. Download the appropriate version for your platform from [PipeCD Releases](https://github.com/pipe-cd/pipe/releases).
 
     We recommend using the latest version of pipectl to avoid unforeseen issues.
-    Please set `{VERSION}` to the same format like `v0.9.15`.
-    And `{OS}` can be replaced with either `linux` or `darwin`.
+    Run the following script:
 
     ``` console
-    curl -Lo ./pipectl https://github.com/pipe-cd/pipe/releases/download/{VERSION}/pipectl_{VERSION}_{OS}_amd64
+    OS="darwin" # or "linux"
+    URL=$(curl -s https://api.github.com/repos/pipe-cd/pipe/releases/latest | grep browser_download_url | grep pipectl | grep "${OS}" | cut -d : -f 2,3 | tr -d '" ')
+    curl -Lo ./pipectl :"${URL}"
     ```
 
 2. Make the pipectl binary executable.

--- a/docs/content/en/docs/user-guide/command-line-tool.md
+++ b/docs/content/en/docs/user-guide/command-line-tool.md
@@ -20,8 +20,7 @@ You can use pipectl to add and sync applications, wait for a deployment status.
 
     ``` console
     OS="darwin" # or "linux"
-    URL=$(curl -s https://api.github.com/repos/pipe-cd/pipe/releases/latest | grep browser_download_url | grep pipectl | grep "${OS}" | cut -d : -f 2,3 | tr -d '" ')
-    curl -Lo ./pipectl :"${URL}"
+    curl -Lo ./pipectl https://github.com/pipe-cd/pipe/releases/download/{{< blocks/latest_version >}}/pipectl_{{< blocks/latest_version >}}_${OS}_amd64
     ```
 
 2. Make the pipectl binary executable.


### PR DESCRIPTION
**What this PR does / why we need it**:
When users download the pipectl binary, 
they need to check the GitHub release page to make sure they have the latest version.
It is better to be able to copy and paste to download the latest version easily.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
