### PR TITLE
Hide database migration post from table of content list

### DIFF
--- a/docs/content/en/blog/news/migrate-control-plane-datastore-to-mysql.md
+++ b/docs/content/en/blog/news/migrate-control-plane-datastore-to-mysql.md
@@ -5,6 +5,7 @@ linkTitle: "Migrate Control Plane datastore from MongoDB to MySQL"
 weight: 999
 description: "This page describes how to migrate Control Plane' datastore from MongoDB to MySQL."
 author: Khanh Tran ([@khanhtc1202](https://twitter.com/khanhtc1202))
+toc_hide: true
 ---
 
 Since PipeCD release [v0.9.8](/blog/2021/03/25/release-v0.9.8) which introduces MySQL as PipeCD control-plane datastore, we plan to drop the support for MongoDB datastore in the near future.


### PR DESCRIPTION
**What this PR does / why we need it**:

Hide the database migration post from blog table of content, since that version is staled and we're not going to support that migration script in the future.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
