### PR TITLE
Add deployment chain status

### DIFF
--- a/pkg/app/api/service/pipedservice/service.proto
+++ b/pkg/app/api/service/pipedservice/service.proto
@@ -324,6 +324,12 @@ message ReportDeploymentCompletedRequest {
     string status_reason = 3;
     // The completed statuses of all stages.
     map<string,model.StageStatus> stage_statuses = 4;
+    // The deployment chain id which this deployment possible to belong to
+    // In case the deployment does not belong to any deployment chain, this
+    // value will be empty.
+    string deployment_chain_id = 5;
+    // The deployment chain block index which the deployment assigned to.
+    uint32 deployment_chain_block_index = 6;
     // The completion time of deployment.
     int64 completed_at = 13 [(validate.rules).int64.gt = 0];
 }

--- a/pkg/app/piped/controller/planner.go
+++ b/pkg/app/piped/controller/planner.go
@@ -264,11 +264,13 @@ func (p *planner) reportDeploymentFailed(ctx context.Context, reason string) err
 		err error
 		now = p.nowFunc()
 		req = &pipedservice.ReportDeploymentCompletedRequest{
-			DeploymentId:  p.deployment.Id,
-			Status:        model.DeploymentStatus_DEPLOYMENT_FAILURE,
-			StatusReason:  reason,
-			StageStatuses: nil,
-			CompletedAt:   now.Unix(),
+			DeploymentId:              p.deployment.Id,
+			Status:                    model.DeploymentStatus_DEPLOYMENT_FAILURE,
+			StatusReason:              reason,
+			StageStatuses:             nil,
+			DeploymentChainId:         p.deployment.DeploymentChainId,
+			DeploymentChainBlockIndex: p.deployment.DeploymentChainBlockIndex,
+			CompletedAt:               now.Unix(),
 		}
 		retry = pipedservice.NewRetry(10)
 	)
@@ -308,11 +310,13 @@ func (p *planner) reportDeploymentCancelled(ctx context.Context, commander, reas
 		err error
 		now = p.nowFunc()
 		req = &pipedservice.ReportDeploymentCompletedRequest{
-			DeploymentId:  p.deployment.Id,
-			Status:        model.DeploymentStatus_DEPLOYMENT_CANCELLED,
-			StatusReason:  reason,
-			StageStatuses: nil,
-			CompletedAt:   now.Unix(),
+			DeploymentId:              p.deployment.Id,
+			Status:                    model.DeploymentStatus_DEPLOYMENT_CANCELLED,
+			StatusReason:              reason,
+			StageStatuses:             nil,
+			DeploymentChainId:         p.deployment.DeploymentChainId,
+			DeploymentChainBlockIndex: p.deployment.DeploymentChainBlockIndex,
+			CompletedAt:               now.Unix(),
 		}
 		retry = pipedservice.NewRetry(10)
 	)

--- a/pkg/app/piped/controller/scheduler.go
+++ b/pkg/app/piped/controller/scheduler.go
@@ -582,11 +582,13 @@ func (s *scheduler) reportDeploymentCompleted(ctx context.Context, status model.
 		err error
 		now = s.nowFunc()
 		req = &pipedservice.ReportDeploymentCompletedRequest{
-			DeploymentId:  s.deployment.Id,
-			Status:        status,
-			StatusReason:  desc,
-			StageStatuses: s.stageStatuses,
-			CompletedAt:   now.Unix(),
+			DeploymentId:              s.deployment.Id,
+			Status:                    status,
+			StatusReason:              desc,
+			StageStatuses:             s.stageStatuses,
+			DeploymentChainId:         s.deployment.DeploymentChainId,
+			DeploymentChainBlockIndex: s.deployment.DeploymentChainBlockIndex,
+			CompletedAt:               now.Unix(),
 		}
 		retry = pipedservice.NewRetry(10)
 	)

--- a/pkg/datastore/deploymentchainstore.go
+++ b/pkg/datastore/deploymentchainstore.go
@@ -51,6 +51,15 @@ var (
 			return nil
 		}
 	}
+
+	DeploymentChainCompletedStatusUpdater = func(status model.DeploymentChainStatus, statusReason string) func(*model.DeploymentChain) error {
+		return func(dc *model.DeploymentChain) error {
+			dc.Status = status
+			dc.StatusReason = statusReason
+			dc.CompletedAt = time.Now().Unix()
+			return nil
+		}
+	}
 )
 
 type DeploymentChainStore interface {

--- a/pkg/model/deployment_chain.proto
+++ b/pkg/model/deployment_chain.proto
@@ -19,6 +19,15 @@ option go_package = "github.com/pipe-cd/pipe/pkg/model";
 
 import "validate/validate.proto";
 
+// DeploymentChainStatus reprensents the current status of the deployment chain.
+enum DeploymentChainStatus {
+    DEPLOYMENT_CHAIN_RUNNING = 0;
+    DEPLOYMENT_CHAIN_ROLLING_BACK = 1;
+    DEPLOYMENT_CHAIN_SUCCESS = 2;
+    DEPLOYMENT_CHAIN_FAILURE = 3;
+    DEPLOYMENT_CHAIN_CANCELLED = 4;
+}
+
 message DeploymentChain {
     // The generated unique identifier.
     string id = 1 [(validate.rules).string.min_len = 1];
@@ -27,6 +36,10 @@ message DeploymentChain {
     // List of all deployment block in the chain which contains all
     // configuration required to perform deployment(s).
     repeated ChainBlock blocks = 3;
+
+    DeploymentChainStatus status = 30 [(validate.rules).enum.defined_only = true];
+    string status_reason = 31;
+
     // Unix time when all the applications in this chain are deployed.
     int64 completed_at = 100 [(validate.rules).int64.gte = 0];
     // Unix time when the deployment chain is created.


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds the status field to the deployment chain model, we will use that status to show the deployment chain status on the client. In my image, the deployment chain only has 2 states: Running (status: running) and Finished (status: success, failure, cancelled). Once the deployment chain is created, we add a new deployment to the deployment chain blocks[0] immediately and mark the deployment chain status as Running.

I also add the logic to update the deployment chain status on the deployment status report working process in this PR, PTAL.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
