### PR TITLE
Allow specifying SSH key for the Git repository where to fetch private Helm charts

### DIFF
--- a/docs/content/en/docs-dev/operator-manual/piped/configuration-reference.md
+++ b/docs/content/en/docs-dev/operator-manual/piped/configuration-reference.md
@@ -64,6 +64,8 @@ spec:
 | username | string | Username used for the repository backed by HTTP basic authentication. | No |
 | password | string | Password used for the repository backed by HTTP basic authentication. | No |
 | insecure | bool | Whether to skip TLS certificate checks for the repository or not. | No |
+| gitRemote | string | Remote address of the Git repository used to clone Helm charts. | No |
+| sshKeyFile | string | The path to the private ssh key file used while cloning Helm charts from above Git repository. | No |
 
 ## CloudProvider
 

--- a/docs/content/en/docs-dev/operator-manual/piped/configuration-reference.md
+++ b/docs/content/en/docs-dev/operator-manual/piped/configuration-reference.md
@@ -59,6 +59,7 @@ spec:
 
 | Field | Type | Description | Required |
 |-|-|-|-|
+| type | string | The repository type. Currently, HTTP and GIT are supported. Default is HTTP. | No |
 | name | string | The name of the Helm chart repository. Note that is not a Git repository but a [Helm chart repository](https://helm.sh/docs/topics/chart_repository/). | Yes |
 | address | string | The address to the Helm chart repository. | Yes |
 | username | string | Username used for the repository backed by HTTP basic authentication. | No |

--- a/pkg/config/piped.go
+++ b/pkg/config/piped.go
@@ -292,7 +292,8 @@ func (r *HelmChartRepository) Validate() error {
 			return errors.New("gitRemote must be set")
 		}
 	}
-	return nil
+
+	return errors.New("either HTTP repository or Git repository must be configured")
 }
 
 func (s *PipedSpec) HTTPHelmChartRepositories() []HelmChartRepository {

--- a/pkg/config/piped.go
+++ b/pkg/config/piped.go
@@ -250,7 +250,19 @@ type PipedRepository struct {
 	Branch string `json:"branch"`
 }
 
+type HelmChartRepositoryType string
+
+const (
+	HTTPHelmChartRepository HelmChartRepositoryType = "HTTP"
+	GITHelmChartRepository  HelmChartRepositoryType = "GIT"
+)
+
 type HelmChartRepository struct {
+	// The repository type. Currently, HTTP and GIT are supported.
+	// Default is HTTP.
+	Type HelmChartRepositoryType `json:"type" default:"HTTP"`
+
+	// Configuration for HTTP type.
 	// The name of the Helm chart repository.
 	Name string `json:"name"`
 	// The address to the Helm chart repository.
@@ -262,6 +274,7 @@ type HelmChartRepository struct {
 	// Whether to skip TLS certificate checks for the repository or not.
 	Insecure bool `json:"insecure"`
 
+	// Configuration for GIT type.
 	// Remote address of the Git repository used to clone Helm charts.
 	// e.g. git@github.com:org/repo.git
 	GitRemote string `json:"gitRemote"`
@@ -270,11 +283,11 @@ type HelmChartRepository struct {
 }
 
 func (r *HelmChartRepository) IsHTTPRepository() bool {
-	return r.Name != "" && r.Address != ""
+	return r.Type == HTTPHelmChartRepository
 }
 
 func (r *HelmChartRepository) IsGitRepository() bool {
-	return r.GitRemote != ""
+	return r.Type == GITHelmChartRepository
 }
 
 func (r *HelmChartRepository) Validate() error {

--- a/pkg/config/piped.go
+++ b/pkg/config/piped.go
@@ -285,12 +285,14 @@ func (r *HelmChartRepository) Validate() error {
 		if r.Address == "" {
 			return errors.New("address must be set")
 		}
+		return nil
 	}
 
 	if r.IsGitRepository() {
 		if r.GitRemote == "" {
 			return errors.New("gitRemote must be set")
 		}
+		return nil
 	}
 
 	return errors.New("either HTTP repository or Git repository must be configured")

--- a/pkg/config/piped.go
+++ b/pkg/config/piped.go
@@ -264,7 +264,7 @@ type HelmChartRepository struct {
 
 	// Remote address of the Git repository used to clone Helm charts.
 	// e.g. git@github.com:org/repo.git
-	GitRemote string
+	GitRemote string `json:"gitRemote"`
 	// The path to the private ssh key file used while cloning Helm charts from above Git repository.
 	SSHKeyFile string `json:"sshKeyFile"`
 }

--- a/pkg/config/piped.go
+++ b/pkg/config/piped.go
@@ -90,6 +90,11 @@ func (s *PipedSpec) Validate() error {
 	if s.SyncInterval < 0 {
 		return errors.New("syncInterval must be greater than or equal to 0")
 	}
+	for _, r := range s.ChartRepositories {
+		if err := r.Validate(); err != nil {
+			return err
+		}
+	}
 	if s.SecretManagement != nil {
 		if err := s.SecretManagement.Validate(); err != nil {
 			return err
@@ -256,6 +261,58 @@ type HelmChartRepository struct {
 	Password string `json:"password"`
 	// Whether to skip TLS certificate checks for the repository or not.
 	Insecure bool `json:"insecure"`
+
+	// Remote address of the Git repository used to clone Helm charts.
+	// e.g. git@github.com:org/repo.git
+	GitRemote string
+	// The path to the private ssh key file used while cloning Helm charts from above Git repository.
+	SSHKeyFile string `json:"sshKeyFile"`
+}
+
+func (r *HelmChartRepository) IsHTTPRepository() bool {
+	return r.Name != "" && r.Address != ""
+}
+
+func (r *HelmChartRepository) IsGitRepository() bool {
+	return r.GitRemote != ""
+}
+
+func (r *HelmChartRepository) Validate() error {
+	if r.IsHTTPRepository() {
+		if r.Name == "" {
+			return errors.New("name must be set")
+		}
+		if r.Address == "" {
+			return errors.New("address must be set")
+		}
+	}
+
+	if r.IsGitRepository() {
+		if r.GitRemote == "" {
+			return errors.New("gitRemote must be set")
+		}
+	}
+	return nil
+}
+
+func (s *PipedSpec) HTTPHelmChartRepositories() []HelmChartRepository {
+	repos := make([]HelmChartRepository, 0, len(s.ChartRepositories))
+	for _, r := range s.ChartRepositories {
+		if r.IsHTTPRepository() {
+			repos = append(repos, r)
+		}
+	}
+	return repos
+}
+
+func (s *PipedSpec) GitHelmChartRepositories() []HelmChartRepository {
+	repos := make([]HelmChartRepository, 0, len(s.ChartRepositories))
+	for _, r := range s.ChartRepositories {
+		if r.IsGitRepository() {
+			repos = append(repos, r)
+		}
+	}
+	return repos
 }
 
 type PipedCloudProvider struct {

--- a/pkg/config/piped.go
+++ b/pkg/config/piped.go
@@ -308,7 +308,7 @@ func (r *HelmChartRepository) Validate() error {
 		return nil
 	}
 
-	return errors.New("either HTTP repository or Git repository must be configured")
+	return fmt.Errorf("either %s repository or %s repository must be configured", HTTPHelmChartRepository, GITHelmChartRepository)
 }
 
 func (s *PipedSpec) HTTPHelmChartRepositories() []HelmChartRepository {

--- a/pkg/config/piped_test.go
+++ b/pkg/config/piped_test.go
@@ -63,10 +63,12 @@ func TestPipedConfig(t *testing.T) {
 				},
 				ChartRepositories: []HelmChartRepository{
 					{
+						Type:    HTTPHelmChartRepository,
 						Name:    "fantastic-charts",
 						Address: "https://fantastic-charts.storage.googleapis.com",
 					},
 					{
+						Type:     HTTPHelmChartRepository,
 						Name:     "private-charts",
 						Address:  "https://private-charts.com",
 						Username: "basic-username",


### PR DESCRIPTION

**What this PR does / why we need it**:

Basically, the same SSH key should be used for simplicity but users can specify another SSH key for the Git repositories where to fetch private Helm charts.

In that case, the path file of the private SSH key file must be specified in `chartRepositories` field of Piped configuration.

**Which issue(s) this PR fixes**:

Fixes #2759

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Allow specifying SSH key for the Git repository where used to fetch private Helm charts
```
