### PR TITLE
Add status and reason to deployment ref in deployment chain model

### DIFF
--- a/docs/content/en/blog/news/migrate-control-plane-datastore-to-mysql.md
+++ b/docs/content/en/blog/news/migrate-control-plane-datastore-to-mysql.md
@@ -5,6 +5,7 @@ linkTitle: "Migrate Control Plane datastore from MongoDB to MySQL"
 weight: 999
 description: "This page describes how to migrate Control Plane' datastore from MongoDB to MySQL."
 author: Khanh Tran ([@khanhtc1202](https://twitter.com/khanhtc1202))
+toc_hide: true
 ---
 
 Since PipeCD release [v0.9.8](/blog/2021/03/25/release-v0.9.8) which introduces MySQL as PipeCD control-plane datastore, we plan to drop the support for MongoDB datastore in the near future.

--- a/pkg/app/api/grpcapi/piped_api.go
+++ b/pkg/app/api/grpcapi/piped_api.go
@@ -1169,17 +1169,13 @@ func (a *PipedAPI) InChainDeploymentPlannable(ctx context.Context, req *pipedser
 		return nil, status.Error(codes.InvalidArgument, "invalid deployment with chain block index provided")
 	}
 
-	prevBlock := dc.Blocks[req.DeploymentChainBlockIndex-1]
-	plannable := true
-	for _, node := range prevBlock.Nodes {
-		if !model.IsSuccessfullyCompletedDeployment(node.DeploymentRef.Status) {
-			plannable = false
-			break
-		}
+	prevBlockSuccessfullyCompleted, err := dc.IsSuccessfullyCompletedBlock(req.DeploymentChainBlockIndex - 1)
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, "unable to process the previous block of this deployment in chain")
 	}
 
 	return &pipedservice.InChainDeploymentPlannableResponse{
-		Plannable: plannable,
+		Plannable: prevBlockSuccessfullyCompleted,
 	}, nil
 }
 

--- a/pkg/app/api/grpcapi/piped_api.go
+++ b/pkg/app/api/grpcapi/piped_api.go
@@ -1170,29 +1170,9 @@ func (a *PipedAPI) InChainDeploymentPlannable(ctx context.Context, req *pipedser
 	}
 
 	prevBlock := dc.Blocks[req.DeploymentChainBlockIndex-1]
-	deploymentIds := make([]string, 0, len(prevBlock.Nodes))
-	for _, node := range prevBlock.Nodes {
-		deploymentIds = append(deploymentIds, node.DeploymentRef.DeploymentId)
-	}
-
-	// TODO: Consider add deployment status to the deployment ref in the deployment chain model
-	// instead of fetching deployment model here.
-	blockDeployments, _, err := a.deploymentStore.ListDeployments(ctx, datastore.ListOptions{
-		Filters: []datastore.ListFilter{
-			{
-				Field:    "Id",
-				Operator: datastore.OperatorIn,
-				Value:    deploymentIds,
-			},
-		},
-	})
-	if err != nil {
-		return nil, status.Error(codes.Internal, "unable to process previous block nodes in deployment chain")
-	}
-
 	plannable := true
-	for _, dp := range blockDeployments {
-		if !model.IsSuccessfullyCompletedDeployment(dp.Status) {
+	for _, node := range prevBlock.Nodes {
+		if !model.IsSuccessfullyCompletedDeployment(node.DeploymentRef.Status) {
 			plannable = false
 			break
 		}

--- a/pkg/app/api/service/pipedservice/service.proto
+++ b/pkg/app/api/service/pipedservice/service.proto
@@ -300,6 +300,12 @@ message ReportDeploymentPlannedRequest {
     // The planned stages.
     // Empty means nothing has changed compared to when the deployment was created.
     repeated pipe.model.PipelineStage stages = 6;
+    // DeploymentChainId represents the deployment chain id which the deployment
+    // belongs to. Empty means this deployment does not belong to any chain.
+    string deployment_chain_id = 7;
+    // DeploymentChainBlockIndex represents the block in deployment chain which
+    // the deployment assigned to.
+    uint32 deployment_chain_block_index = 8;
 }
 
 message ReportDeploymentPlannedResponse {
@@ -311,6 +317,12 @@ message ReportDeploymentStatusChangedRequest {
     pipe.model.DeploymentStatus status = 2 [(validate.rules).enum = {in: [2,3]}];
     // The human-readable description why the deployment is at current status.
     string status_reason = 3;
+    // DeploymentChainId represents the deployment chain id which the deployment
+    // belongs to. Empty means this deployment does not belong to any chain.
+    string deployment_chain_id = 4;
+    // DeploymentChainBlockIndex represents the block in deployment chain which
+    // the deployment assigned to.
+    uint32 deployment_chain_block_index = 5;
 }
 
 message ReportDeploymentStatusChangedResponse {
@@ -324,6 +336,12 @@ message ReportDeploymentCompletedRequest {
     string status_reason = 3;
     // The completed statuses of all stages.
     map<string,model.StageStatus> stage_statuses = 4;
+    // DeploymentChainId represents the deployment chain id which the deployment
+    // belongs to. Empty means this deployment does not belong to any chain.
+    string deployment_chain_id = 5;
+    // DeploymentChainBlockIndex represents the block in deployment chain which
+    // the deployment assigned to.
+    uint32 deployment_chain_block_index = 6;
     // The completion time of deployment.
     int64 completed_at = 13 [(validate.rules).int64.gt = 0];
 }

--- a/pkg/app/piped/controller/planner.go
+++ b/pkg/app/piped/controller/planner.go
@@ -220,12 +220,14 @@ func (p *planner) reportDeploymentPlanned(ctx context.Context, runningCommitHash
 		err   error
 		retry = pipedservice.NewRetry(10)
 		req   = &pipedservice.ReportDeploymentPlannedRequest{
-			DeploymentId:      p.deployment.Id,
-			Summary:           out.Summary,
-			StatusReason:      "The deployment has been planned",
-			RunningCommitHash: runningCommitHash,
-			Version:           out.Version,
-			Stages:            out.Stages,
+			DeploymentId:              p.deployment.Id,
+			Summary:                   out.Summary,
+			StatusReason:              "The deployment has been planned",
+			RunningCommitHash:         runningCommitHash,
+			Version:                   out.Version,
+			Stages:                    out.Stages,
+			DeploymentChainId:         p.deployment.DeploymentChainId,
+			DeploymentChainBlockIndex: p.deployment.DeploymentChainBlockIndex,
 		}
 	)
 
@@ -264,11 +266,13 @@ func (p *planner) reportDeploymentFailed(ctx context.Context, reason string) err
 		err error
 		now = p.nowFunc()
 		req = &pipedservice.ReportDeploymentCompletedRequest{
-			DeploymentId:  p.deployment.Id,
-			Status:        model.DeploymentStatus_DEPLOYMENT_FAILURE,
-			StatusReason:  reason,
-			StageStatuses: nil,
-			CompletedAt:   now.Unix(),
+			DeploymentId:              p.deployment.Id,
+			Status:                    model.DeploymentStatus_DEPLOYMENT_FAILURE,
+			StatusReason:              reason,
+			StageStatuses:             nil,
+			DeploymentChainId:         p.deployment.DeploymentChainId,
+			DeploymentChainBlockIndex: p.deployment.DeploymentChainBlockIndex,
+			CompletedAt:               now.Unix(),
 		}
 		retry = pipedservice.NewRetry(10)
 	)
@@ -308,11 +312,13 @@ func (p *planner) reportDeploymentCancelled(ctx context.Context, commander, reas
 		err error
 		now = p.nowFunc()
 		req = &pipedservice.ReportDeploymentCompletedRequest{
-			DeploymentId:  p.deployment.Id,
-			Status:        model.DeploymentStatus_DEPLOYMENT_CANCELLED,
-			StatusReason:  reason,
-			StageStatuses: nil,
-			CompletedAt:   now.Unix(),
+			DeploymentId:              p.deployment.Id,
+			Status:                    model.DeploymentStatus_DEPLOYMENT_CANCELLED,
+			StatusReason:              reason,
+			StageStatuses:             nil,
+			DeploymentChainId:         p.deployment.DeploymentChainId,
+			DeploymentChainBlockIndex: p.deployment.DeploymentChainBlockIndex,
+			CompletedAt:               now.Unix(),
 		}
 		retry = pipedservice.NewRetry(10)
 	)

--- a/pkg/app/piped/controller/scheduler.go
+++ b/pkg/app/piped/controller/scheduler.go
@@ -560,9 +560,11 @@ func (s *scheduler) reportDeploymentStatusChanged(ctx context.Context, status mo
 		err   error
 		retry = pipedservice.NewRetry(10)
 		req   = &pipedservice.ReportDeploymentStatusChangedRequest{
-			DeploymentId: s.deployment.Id,
-			Status:       status,
-			StatusReason: desc,
+			DeploymentId:              s.deployment.Id,
+			Status:                    status,
+			StatusReason:              desc,
+			DeploymentChainId:         s.deployment.DeploymentChainId,
+			DeploymentChainBlockIndex: s.deployment.DeploymentChainBlockIndex,
 		}
 	)
 
@@ -582,11 +584,13 @@ func (s *scheduler) reportDeploymentCompleted(ctx context.Context, status model.
 		err error
 		now = s.nowFunc()
 		req = &pipedservice.ReportDeploymentCompletedRequest{
-			DeploymentId:  s.deployment.Id,
-			Status:        status,
-			StatusReason:  desc,
-			StageStatuses: s.stageStatuses,
-			CompletedAt:   now.Unix(),
+			DeploymentId:              s.deployment.Id,
+			Status:                    status,
+			StatusReason:              desc,
+			StageStatuses:             s.stageStatuses,
+			DeploymentChainId:         s.deployment.DeploymentChainId,
+			DeploymentChainBlockIndex: s.deployment.DeploymentChainBlockIndex,
+			CompletedAt:               now.Unix(),
 		}
 		retry = pipedservice.NewRetry(10)
 	)

--- a/pkg/datastore/deploymentchainstore.go
+++ b/pkg/datastore/deploymentchainstore.go
@@ -62,10 +62,10 @@ var (
 			block := dc.Blocks[blockIndex]
 			var updated bool
 			for _, node := range block.Nodes {
-				if node.DeploymentRef.DeploymentId != deploymentID {
+				if node.DeploymentRef == nil {
 					continue
 				}
-				if node.DeploymentRef == nil {
+				if node.DeploymentRef.DeploymentId != deploymentID {
 					continue
 				}
 				node.DeploymentRef.Status = status

--- a/pkg/datastore/deploymentchainstore.go
+++ b/pkg/datastore/deploymentchainstore.go
@@ -42,7 +42,34 @@ var (
 				}
 				node.DeploymentRef = &model.ChainDeploymentRef{
 					DeploymentId: deployment.Id,
+					Status:       deployment.Status,
+					StatusReason: deployment.StatusReason,
 				}
+				updated = true
+			}
+			if !updated {
+				return fmt.Errorf("unable to find the right node in chain to assign deployment to")
+			}
+			return nil
+		}
+	}
+
+	DeploymentChainNodeDeploymentStatusUpdater = func(blockIndex uint32, deploymentID string, status model.DeploymentStatus, reason string) func(*model.DeploymentChain) error {
+		return func(dc *model.DeploymentChain) error {
+			if blockIndex >= uint32(len(dc.Blocks)) {
+				return fmt.Errorf("invalid block index provided")
+			}
+			block := dc.Blocks[blockIndex]
+			var updated bool
+			for _, node := range block.Nodes {
+				if node.DeploymentRef.DeploymentId != deploymentID {
+					continue
+				}
+				if node.DeploymentRef == nil {
+					continue
+				}
+				node.DeploymentRef.Status = status
+				node.DeploymentRef.StatusReason = reason
 				updated = true
 			}
 			if !updated {

--- a/pkg/datastore/deploymentchainstore.go
+++ b/pkg/datastore/deploymentchainstore.go
@@ -57,7 +57,7 @@ var (
 	DeploymentChainNodeDeploymentStatusUpdater = func(blockIndex uint32, deploymentID string, status model.DeploymentStatus, reason string) func(*model.DeploymentChain) error {
 		return func(dc *model.DeploymentChain) error {
 			if blockIndex >= uint32(len(dc.Blocks)) {
-				return fmt.Errorf("invalid block index provided")
+				return fmt.Errorf("invalid block index %d provided", blockIndex)
 			}
 			block := dc.Blocks[blockIndex]
 			var updated bool

--- a/pkg/model/BUILD.bazel
+++ b/pkg/model/BUILD.bazel
@@ -55,6 +55,7 @@ go_library(
         "common.go",
         "datastore.go",
         "deployment.go",
+        "deployment_chain.go",
         "docs.go",
         "environment.go",
         "event.go",

--- a/pkg/model/deployment_chain.go
+++ b/pkg/model/deployment_chain.go
@@ -1,0 +1,33 @@
+// Copyright 2021 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"errors"
+)
+
+func (dc *DeploymentChain) IsSuccessfullyCompletedBlock(blockIndex uint32) (bool, error) {
+	if blockIndex >= uint32(len(dc.Blocks)) {
+		return false, errors.New("invalid block index given")
+	}
+
+	block := dc.Blocks[blockIndex]
+	for _, node := range block.Nodes {
+		if !IsSuccessfullyCompletedDeployment(node.DeploymentRef.Status) {
+			return false, nil
+		}
+	}
+	return true, nil
+}

--- a/pkg/model/deployment_chain.go
+++ b/pkg/model/deployment_chain.go
@@ -14,9 +14,7 @@
 
 package model
 
-import (
-	"errors"
-)
+import "fmt"
 
 func (dc *DeploymentChain) IsSuccessfullyCompletedBlock(blockIndex uint32) (bool, error) {
 	if blockIndex >= uint32(len(dc.Blocks)) {

--- a/pkg/model/deployment_chain.proto
+++ b/pkg/model/deployment_chain.proto
@@ -18,6 +18,7 @@ package pipe.model;
 option go_package = "github.com/pipe-cd/pipe/pkg/model";
 
 import "validate/validate.proto";
+import "pkg/model/deployment.proto";
 
 message DeploymentChain {
     // The generated unique identifier.
@@ -42,6 +43,8 @@ message ChainApplicationRef {
 
 message ChainDeploymentRef {
     string deployment_id = 1 [(validate.rules).string.min_len = 1];
+    DeploymentStatus status = 2 [(validate.rules).enum.defined_only = true];
+    string status_reason = 3;
 }
 
 message ChainNode {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds deployment's status and status reason to the deployment ref in the deployment chain model. It will reduce the datastore read in case we want to use those values to determine deployment chain behaviours, besides, we will use those values to show in the client too.

**Which issue(s) this PR fixes**:

Fixes #2836

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
