### PR TITLE
Apply tabs to app adding form to add from Git

### DIFF
--- a/pkg/app/web/src/components/application-form/index.tsx
+++ b/pkg/app/web/src/components/application-form/index.tsx
@@ -100,7 +100,7 @@ function TabPanel(props: TabPanelProps): ReactElement {
           aria-labelledby={`simple-tab-${props.index}`}
       >
         {props.selected && (
-            <Box >
+            <Box>
               <Typography>{props.children}</Typography>
             </Box>
         )}
@@ -124,7 +124,7 @@ export const ApplicationFormTabs: React.FC<ApplicationFormProps> = (props) => {
 
   return (
       <Box width={600}>
-        <Box >
+        <Box>
           <Tabs value={selectedTabIndex} onChange={handleChange} aria-label="basic tabs example">
             <Tab label="Add manually" {...a11yProps(0)} />
             <Tab label="Add from Git (Alpha)" {...a11yProps(1)} />
@@ -137,7 +137,7 @@ export const ApplicationFormTabs: React.FC<ApplicationFormProps> = (props) => {
           Coming soon...
           {/** TODO: Show unregistered applications on the ADD FROM GIT tab */}
         </TabPanel>
-      </Box >
+      </Box>
   );
 }
 

--- a/pkg/app/web/src/components/application-form/index.tsx
+++ b/pkg/app/web/src/components/application-form/index.tsx
@@ -92,7 +92,6 @@ interface TabPanelProps {
 }
 
 function TabPanel(props: TabPanelProps) {
-
   return (
       <div
           role="tabpanel"
@@ -109,8 +108,6 @@ function TabPanel(props: TabPanelProps) {
   );
 }
 
-
-
 function a11yProps(index: number) {
   return {
     id: `simple-tab-${index}`,
@@ -119,10 +116,10 @@ function a11yProps(index: number) {
 }
 
 export const ApplicationFormTabs: React.FC<ApplicationFormProps> = (props) => {
-  const [selectedTabIndex, setValue] = useState(0);
+  const [selectedTabIndex, setSelectedTabIndex] = useState(0);
 
   const handleChange = (event: React.ChangeEvent<{}>, newValue: number) => {
-    setValue(newValue);
+    setSelectedTabIndex(newValue);
   };
 
   return (

--- a/pkg/app/web/src/components/application-form/index.tsx
+++ b/pkg/app/web/src/components/application-form/index.tsx
@@ -7,10 +7,13 @@ import {
   MenuItem,
   TextField,
   Typography,
+  Tabs,
+  Tab,
 } from "@material-ui/core";
 import { FormikProps } from "formik";
-import { FC, memo, ReactElement } from "react";
+import { FC, memo, ReactElement, useState } from "react";
 import * as yup from "yup";
+import PropTypes from "prop-types";
 import { APPLICATION_KIND_TEXT } from "~/constants/application-kind";
 import { UI_TEXT_CANCEL, UI_TEXT_SAVE } from "~/constants/ui-text";
 import { useAppSelector } from "~/hooks/redux";
@@ -82,6 +85,65 @@ const useStyles = makeStyles((theme) => ({
     marginLeft: -12,
   },
 }));
+
+type TabPanelProps = {
+  children: any
+  value: any
+  index: any
+}
+
+function TabPanel(props: TabPanelProps) {
+  return (
+      <Typography
+          component="div"
+          role="tabpanel"
+          hidden={props.value !== props.index}
+          id={`scrollable-auto-tabpanel-${props.index}`}
+          aria-labelledby={`scrollable-auto-tab-${props.index}`}
+      >
+        <Box p={3}>{props.children}</Box>
+      </Typography>
+  );
+}
+
+TabPanel.propTypes = {
+  children: PropTypes.node,
+  index: PropTypes.any.isRequired,
+  value: PropTypes.any.isRequired
+};
+
+
+function a11yProps(index: number) {
+  return {
+    id: `simple-tab-${index}`,
+    'aria-controls': `simple-tabpanel-${index}`,
+  };
+}
+
+export const ApplicationFormTabs: React.FC<ApplicationFormProps> = (props) => {
+  const [value, setValue] = useState(0);
+
+  const handleChange = (event: React.ChangeEvent<{}>, newValue: any) => {
+    setValue(newValue);
+  };
+
+  return (
+      <Box width={600}>
+        <Box >
+          <Tabs value={value} onChange={handleChange} aria-label="basic tabs example">
+            <Tab label="Add manually" {...a11yProps(0)} />
+            <Tab label="Add from Git (Alpha)" {...a11yProps(1)} />
+          </Tabs>
+        </Box>
+        <TabPanel value={value} index={0}>
+          <ApplicationForm {...props} />
+        </TabPanel>
+        <TabPanel value={value} index={1}>
+          Comming soon...
+        </TabPanel>
+      </Box >
+  );
+}
 
 function FormSelectInput<T extends { name: string; value: string }>({
   id,

--- a/pkg/app/web/src/components/application-form/index.tsx
+++ b/pkg/app/web/src/components/application-form/index.tsx
@@ -88,18 +88,18 @@ const useStyles = makeStyles((theme) => ({
 interface TabPanelProps {
   children?: React.ReactNode;
   index: number;
-  value: number;
+  selected: boolean;
 }
 
 function TabPanel(props: TabPanelProps) {
   return (
       <div
           role="tabpanel"
-          hidden={props.value !== props.index}
+          hidden={!props.selected}
           id={`simple-tabpanel-${props.index}`}
           aria-labelledby={`simple-tab-${props.index}`}
       >
-        {props.value === props.index && (
+        {props.selected && (
             <Box >
               <Typography>{props.children}</Typography>
             </Box>
@@ -130,10 +130,10 @@ export const ApplicationFormTabs: React.FC<ApplicationFormProps> = (props) => {
             <Tab label="Add from Git (Alpha)" {...a11yProps(1)} />
           </Tabs>
         </Box>
-        <TabPanel value={selectedTabIndex} index={0}>
+        <TabPanel selected={selectedTabIndex === 0} index={0}>
           <ApplicationForm {...props} />
         </TabPanel>
-        <TabPanel value={selectedTabIndex} index={1}>
+          <TabPanel selected={selectedTabIndex === 1} index={1}>
           Comming soon...
           {/** TODO: Show unregistered applications on the ADD FROM GIT tab */}
         </TabPanel>

--- a/pkg/app/web/src/components/application-form/index.tsx
+++ b/pkg/app/web/src/components/application-form/index.tsx
@@ -140,6 +140,7 @@ export const ApplicationFormTabs: React.FC<ApplicationFormProps> = (props) => {
         </TabPanel>
         <TabPanel value={value} index={1}>
           Comming soon...
+          {/** TODO: Show unregistered applications on the ADD FROM GIT tab */}
         </TabPanel>
       </Box >
   );
@@ -274,7 +275,7 @@ export const ApplicationForm: FC<ApplicationFormProps> = memo(
     const repositories = createRepoListFromPiped(selectedPiped);
 
     return (
-      <Box width={600}>
+      <Box width="100%">
         <Typography className={classes.title} variant="h6">
           {title}
         </Typography>

--- a/pkg/app/web/src/components/application-form/index.tsx
+++ b/pkg/app/web/src/components/application-form/index.tsx
@@ -91,7 +91,7 @@ interface TabPanelProps {
   selected: boolean;
 }
 
-function TabPanel(props: TabPanelProps) {
+function TabPanel(props: TabPanelProps): ReactElement {
   return (
       <div
           role="tabpanel"
@@ -134,7 +134,7 @@ export const ApplicationFormTabs: React.FC<ApplicationFormProps> = (props) => {
           <ApplicationForm {...props} />
         </TabPanel>
           <TabPanel selected={selectedTabIndex === 1} index={1}>
-          Comming soon...
+          Coming soon...
           {/** TODO: Show unregistered applications on the ADD FROM GIT tab */}
         </TabPanel>
       </Box >

--- a/pkg/app/web/src/components/application-form/index.tsx
+++ b/pkg/app/web/src/components/application-form/index.tsx
@@ -13,7 +13,6 @@ import {
 import { FormikProps } from "formik";
 import { FC, memo, ReactElement, useState } from "react";
 import * as yup from "yup";
-import PropTypes from "prop-types";
 import { APPLICATION_KIND_TEXT } from "~/constants/application-kind";
 import { UI_TEXT_CANCEL, UI_TEXT_SAVE } from "~/constants/ui-text";
 import { useAppSelector } from "~/hooks/redux";
@@ -86,31 +85,30 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-type TabPanelProps = {
-  children: any
-  value: any
-  index: any
+interface TabPanelProps {
+  children?: React.ReactNode;
+  index: number;
+  value: number;
 }
 
 function TabPanel(props: TabPanelProps) {
+
   return (
-      <Typography
-          component="div"
+      <div
           role="tabpanel"
           hidden={props.value !== props.index}
-          id={`scrollable-auto-tabpanel-${props.index}`}
-          aria-labelledby={`scrollable-auto-tab-${props.index}`}
+          id={`simple-tabpanel-${props.index}`}
+          aria-labelledby={`simple-tab-${props.index}`}
       >
-        <Box p={3}>{props.children}</Box>
-      </Typography>
+        {props.value === props.index && (
+            <Box >
+              <Typography>{props.children}</Typography>
+            </Box>
+        )}
+      </div>
   );
 }
 
-TabPanel.propTypes = {
-  children: PropTypes.node,
-  index: PropTypes.any.isRequired,
-  value: PropTypes.any.isRequired
-};
 
 
 function a11yProps(index: number) {
@@ -121,24 +119,24 @@ function a11yProps(index: number) {
 }
 
 export const ApplicationFormTabs: React.FC<ApplicationFormProps> = (props) => {
-  const [value, setValue] = useState(0);
+  const [selectedTabIndex, setValue] = useState(0);
 
-  const handleChange = (event: React.ChangeEvent<{}>, newValue: any) => {
+  const handleChange = (event: React.ChangeEvent<{}>, newValue: number) => {
     setValue(newValue);
   };
 
   return (
       <Box width={600}>
         <Box >
-          <Tabs value={value} onChange={handleChange} aria-label="basic tabs example">
+          <Tabs value={selectedTabIndex} onChange={handleChange} aria-label="basic tabs example">
             <Tab label="Add manually" {...a11yProps(0)} />
             <Tab label="Add from Git (Alpha)" {...a11yProps(1)} />
           </Tabs>
         </Box>
-        <TabPanel value={value} index={0}>
+        <TabPanel value={selectedTabIndex} index={0}>
           <ApplicationForm {...props} />
         </TabPanel>
-        <TabPanel value={value} index={1}>
+        <TabPanel value={selectedTabIndex} index={1}>
           Comming soon...
           {/** TODO: Show unregistered applications on the ADD FROM GIT tab */}
         </TabPanel>

--- a/pkg/app/web/src/components/applications-page/add-application-drawer/index.tsx
+++ b/pkg/app/web/src/components/applications-page/add-application-drawer/index.tsx
@@ -13,7 +13,7 @@ import { useAppDispatch, useAppSelector } from "~/hooks/redux";
 import { addApplication } from "~/modules/applications";
 import { selectProjectName } from "~/modules/me";
 import {
-  ApplicationForm,
+  ApplicationFormTabs,
   ApplicationFormValue,
   emptyFormValues,
   validationSchema,
@@ -68,7 +68,7 @@ export const AddApplicationDrawer: FC<AddApplicationDrawerProps> = memo(
           onClose={handleClose}
           ModalProps={{ disableBackdropClick: formik.isSubmitting }}
         >
-          <ApplicationForm
+          <ApplicationFormTabs
             {...formik}
             title={`Add a new application to "${projectName}" project`}
             onClose={handleClose}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds Tabs to the application adding form so that we can support adding an app from config files defined in Git.
You can give it a try by simply using `make web-dev`.

![Kapture 2021-12-01 at 19 05 08](https://user-images.githubusercontent.com/19730728/144214298-1a03f38a-3278-4fa5-b743-50a9839292e3.gif)

**Which issue(s) this PR fixes**:

Ref: https://github.com/pipe-cd/pipe/issues/2778

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
