### PR TITLE
Revert SealedSecrets field in configuration to keep old config able to be loaded

### DIFF
--- a/pkg/app/piped/trigger/trigger.go
+++ b/pkg/app/piped/trigger/trigger.go
@@ -224,7 +224,12 @@ func (t *Trigger) checkRepoCandidates(ctx context.Context, repoID string, cs []c
 
 		appCfg, err := loadDeploymentConfiguration(gitRepo.GetPath(), app)
 		if err != nil {
-			t.logger.Error("failed to load application config file", zap.Error(err))
+			t.logger.Error("failed to load application config file",
+				zap.String("app", app.Name),
+				zap.String("app-id", app.Id),
+				zap.String("commit", headCommit.Hash),
+				zap.Error(err),
+			)
 			// Do not notify this event to external services because it may cause annoying
 			// when one application is missing or having an invalid configuration file.
 			// So instead of notifying this as a notification,

--- a/pkg/config/deployment.go
+++ b/pkg/config/deployment.go
@@ -54,6 +54,9 @@ type GenericDeploymentSpec struct {
 	Encryption *SecretEncryption `json:"encryption"`
 	// Additional configuration used while sending notification to external services.
 	DeploymentNotification *DeploymentNotification `json:"notification"`
+	// The list of sealed secrets that should be decrypted.
+	// Deprecated.
+	SealedSecrets []SealedSecretMapping `json:"sealedSecrets"`
 }
 
 type DeploymentPlanner struct {


### PR DESCRIPTION

**What this PR does / why we need it**:

That field and all its related stuff have been deleted by https://github.com/pipe-cd/pipe/pull/2784 but let me keep only this field at this time to avoid `unknown` field error while loading the config file in our dev environment.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
