### PR TITLE
Revert "Temporarily disable appconfig reporter in Piped"

### DIFF
--- a/pkg/app/piped/appconfigreporter/BUILD.bazel
+++ b/pkg/app/piped/appconfigreporter/BUILD.bazel
@@ -21,7 +21,6 @@ go_test(
     srcs = ["appconfigreporter_test.go"],
     embed = [":go_default_library"],
     deps = [
-        "//pkg/config:go_default_library",
         "//pkg/model:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",
         "@org_uber_go_zap//:go_default_library",

--- a/pkg/app/piped/cmd/piped/piped.go
+++ b/pkg/app/piped/cmd/piped/piped.go
@@ -45,7 +45,7 @@ import (
 	"github.com/pipe-cd/pipe/pkg/app/piped/apistore/deploymentstore"
 	"github.com/pipe-cd/pipe/pkg/app/piped/apistore/environmentstore"
 	"github.com/pipe-cd/pipe/pkg/app/piped/apistore/eventstore"
-	_ "github.com/pipe-cd/pipe/pkg/app/piped/appconfigreporter"
+	"github.com/pipe-cd/pipe/pkg/app/piped/appconfigreporter"
 	"github.com/pipe-cd/pipe/pkg/app/piped/chartrepo"
 	k8scloudprovidermetrics "github.com/pipe-cd/pipe/pkg/app/piped/cloudprovider/kubernetes/kubernetesmetrics"
 	"github.com/pipe-cd/pipe/pkg/app/piped/controller"
@@ -448,20 +448,20 @@ func (p *piped) run(ctx context.Context, input cli.Input) (runErr error) {
 	}
 
 	// Start running app-config-reporter.
-	// {
-	// 	r := appconfigreporter.NewReporter(
-	// 		apiClient,
-	// 		gitClient,
-	// 		applicationLister,
-	// 		cfg,
-	// 		p.gracePeriod,
-	// 		input.Logger,
-	// 	)
+	{
+		r := appconfigreporter.NewReporter(
+			apiClient,
+			gitClient,
+			applicationLister,
+			cfg,
+			p.gracePeriod,
+			input.Logger,
+		)
 
-	// 	group.Go(func() error {
-	// 		return r.Run(ctx)
-	// 	})
-	// }
+		group.Go(func() error {
+			return r.Run(ctx)
+		})
+	}
 
 	// Wait until all piped components have finished.
 	// A terminating signal or a finish of any components


### PR DESCRIPTION
This reverts commit 585bfe75f69b9a8484836c0229eb10dcf31459a8.

I've confirmed it goes well with conventional application configuration files.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
