### PR TITLE
Make sure to use the helper method to get app config file path

### DIFF
--- a/pkg/app/api/grpcapi/web_api.go
+++ b/pkg/app/api/grpcapi/web_api.go
@@ -643,8 +643,6 @@ func (a *WebAPI) ListUnregisteredApplications(ctx context.Context, _ *webservice
 		return &webservice.ListUnregisteredApplicationsResponse{}, nil
 	}
 
-	// TODO: Eliminate apps registered by another Piped
-	//   In case that multiple Pipeds watches the same repo, it could be happen that one Piped report App-1 as an unregistered app even though another Piped register that app.
 	sort.Slice(allApps, func(i, j int) bool {
 		return allApps[i].Path < allApps[j].Path
 	})

--- a/pkg/app/api/grpcapi/web_api.go
+++ b/pkg/app/api/grpcapi/web_api.go
@@ -643,6 +643,8 @@ func (a *WebAPI) ListUnregisteredApplications(ctx context.Context, _ *webservice
 		return &webservice.ListUnregisteredApplicationsResponse{}, nil
 	}
 
+	// TODO: Eliminate apps registered by another Piped
+	//   In case that multiple Pipeds watches the same repo, it could be happen that one Piped report App-1 as an unregistered app even though another Piped register that app.
 	sort.Slice(allApps, func(i, j int) bool {
 		return allApps[i].Path < allApps[j].Path
 	})

--- a/pkg/app/piped/appconfigreporter/appconfigreporter.go
+++ b/pkg/app/piped/appconfigreporter/appconfigreporter.go
@@ -261,8 +261,7 @@ func (r *Reporter) findRegisteredApps(repoPath, repoID string) ([]*model.Applica
 			// For historical reasons, we need to treat applications that don't define app config in a file as normal.
 			r.logger.Warn("found a registered application config file that is missing a required field",
 				zap.String("repo-id", repoID),
-				zap.String("git-path", app.GitPath.Path),
-				zap.String("config-file-path", app.GitPath.ConfigFilename),
+				zap.String("config-file-path", app.GitPath.GetDeploymentConfigFilePath()),
 				zap.Error(err),
 			)
 			continue
@@ -270,8 +269,7 @@ func (r *Reporter) findRegisteredApps(repoPath, repoID string) ([]*model.Applica
 		if err != nil {
 			r.logger.Error("failed to read registered application config file",
 				zap.String("repo-id", repoID),
-				zap.String("git-path", app.GitPath.Path),
-				zap.String("config-file-path", app.GitPath.ConfigFilename),
+				zap.String("config-file-path", app.GitPath.GetDeploymentConfigFilePath()),
 				zap.Error(err),
 			)
 			// Continue reading so that it can return apps as much as possible.
@@ -292,8 +290,7 @@ func (r *Reporter) isSynced(appInfo *model.ApplicationInfo, app *model.Applicati
 		r.logger.Warn("kind in application config has been changed which isn't allowed",
 			zap.String("app-id", app.Id),
 			zap.String("repo-id", app.GitPath.Repo.Id),
-			zap.String("path", app.GitPath.Path),
-			zap.String("config-filename", app.GitPath.ConfigFilename),
+			zap.String("config-file-path", app.GitPath.GetDeploymentConfigFilePath()),
 		)
 	}
 
@@ -322,7 +319,7 @@ func (r *Reporter) findUnregisteredApps(repoPath, repoID string) ([]*model.Appli
 		if app.GitPath.Repo.Id != repoID {
 			continue
 		}
-		registeredAppPaths[filepath.Join(app.GitPath.Path, app.GitPath.ConfigFilename)] = struct{}{}
+		registeredAppPaths[app.GitPath.GetDeploymentConfigFilePath()] = struct{}{}
 	}
 
 	out := make([]*model.ApplicationInfo, 0)

--- a/pkg/model/application.go
+++ b/pkg/model/application.go
@@ -26,6 +26,7 @@ const (
 )
 
 // GetDeploymentConfigFilePath returns the path to deployment configuration file.
+// TODO: Rename all identifiers named DeploymentConfig to ApplicationConfig
 func (p ApplicationGitPath) GetDeploymentConfigFilePath() string {
 	filename := DefaultApplicationConfigFilename
 	if n := p.ConfigFilename; n != "" {


### PR DESCRIPTION
**What this PR does / why we need it**:
Sometimes ConfigFilename can be empty, so we need to fill it by the default name using this helper function.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
