### PR TITLE
Cancel deployments of the same block in case the block finished with FAILURE or CANCELLED status

### DIFF
--- a/pkg/model/deployment_chain.go
+++ b/pkg/model/deployment_chain.go
@@ -14,10 +14,22 @@
 
 package model
 
+import "fmt"
+
 func (b *ChainBlock) IsCompleted() bool {
 	switch b.Status {
 	case ChainBlockStatus_DEPLOYMENT_BLOCK_SUCCESS,
 		ChainBlockStatus_DEPLOYMENT_BLOCK_FAILURE,
+		ChainBlockStatus_DEPLOYMENT_BLOCK_CANCELLED:
+		return true
+	default:
+		return false
+	}
+}
+
+func (b *ChainBlock) IsUnsuccessfullyCompleted() bool {
+	switch b.Status {
+	case ChainBlockStatus_DEPLOYMENT_BLOCK_FAILURE,
 		ChainBlockStatus_DEPLOYMENT_BLOCK_CANCELLED:
 		return true
 	default:
@@ -73,4 +85,16 @@ func (b *ChainBlock) DesiredStatus() ChainBlockStatus {
 	}
 	// Otherwise, the block status is remained.
 	return b.Status
+}
+
+func (b *ChainBlock) GetNodeByDeploymentID(deploymentID string) (*ChainNode, error) {
+	for _, node := range b.Nodes {
+		if node.DeploymentRef == nil {
+			continue
+		}
+		if node.DeploymentRef.DeploymentId == deploymentID {
+			return node, nil
+		}
+	}
+	return nil, fmt.Errorf("unable to find node with the given deployment id (%s)", deploymentID)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

In case the deployments are in the same block with a FAILURE or CANCELLED deployment, we should stop those deployments too. By this PR, I added a method to check whether a deployment should be stopped or not when its piped sync the on processing deployment via `ReportDeploymentPlanned` and `ReportDeploymentStatusChanged`, at that point of time, deployment is still on processing and if the current block which contains that deployment finished with FAILURE | CANCELLED status, we sill stop the current deployment too by sending CANCEL_DEPLOYMENT command so that the handling piped will be aware and stop its deployment.
Note: I don't use the same method (add `cancel` flag to those gRPC responses) as we do with `InChainDeploymentPlannable` since
- This time, the gRPC which be updated is called once, not intervally as check plannable RPC.
- I want to keep the deployment handling mechanism in piped side simple (reuse the cancelling by command flow in planner and scheduler codebase)

**Which issue(s) this PR fixes**:

Fixes #2888 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
