### PR TITLE
Using piped stat info to determine connection status

### DIFF
--- a/cmd/pipecd/server.go
+++ b/cmd/pipecd/server.go
@@ -271,7 +271,7 @@ func (s *server) run(ctx context.Context, input cli.Input) error {
 			return err
 		}
 
-		service := grpcapi.NewWebAPI(ctx, ds, fs, sls, alss, cmds, is, rd, cfg.ProjectMap(), encryptDecrypter, input.Logger)
+		service := grpcapi.NewWebAPI(ctx, ds, fs, sls, alss, cmds, is, statCache, rd, cfg.ProjectMap(), encryptDecrypter, input.Logger)
 		opts := []rpc.Option{
 			rpc.WithPort(s.webAPIPort),
 			rpc.WithGracePeriod(s.gracePeriod),

--- a/pkg/app/api/grpcapi/piped_api.go
+++ b/pkg/app/api/grpcapi/piped_api.go
@@ -137,9 +137,7 @@ func (a *PipedAPI) ReportPipedMeta(ctx context.Context, req *pipedservice.Report
 	}
 
 	now := time.Now().Unix()
-	connStatus := model.Piped_ONLINE
-
-	if err = a.pipedStore.UpdatePiped(ctx, pipedID, datastore.PipedMetadataUpdater(req.CloudProviders, req.Repositories, connStatus, req.SecretEncryption, req.Version, now)); err != nil {
+	if err = a.pipedStore.UpdatePiped(ctx, pipedID, datastore.PipedMetadataUpdater(req.CloudProviders, req.Repositories, req.SecretEncryption, req.Version, now)); err != nil {
 		switch err {
 		case datastore.ErrNotFound:
 			return nil, status.Error(codes.InvalidArgument, "piped is not found")

--- a/pkg/app/api/grpcapi/web_api.go
+++ b/pkg/app/api/grpcapi/web_api.go
@@ -538,8 +538,13 @@ func (a *WebAPI) ListPipeds(ctx context.Context, req *webservice.ListPipedsReque
 	// The connection status of piped determined by its submitted stat in pipedStatCache.
 	if req.WithStatus {
 		for i := range pipeds {
-			if _, err := a.pipedStatCache.Get(pipeds[i].Id); err != nil {
+			_, err := a.pipedStatCache.Get(pipeds[i].Id)
+			if errors.Is(err, cache.ErrNotFound) {
 				pipeds[i].Status = model.Piped_OFFLINE
+				continue
+			}
+			if err != nil {
+				pipeds[i].Status = model.Piped_UNKNOWN
 				continue
 			}
 			pipeds[i].Status = model.Piped_ONLINE

--- a/pkg/app/api/grpcapi/web_api.go
+++ b/pkg/app/api/grpcapi/web_api.go
@@ -545,6 +545,7 @@ func (a *WebAPI) ListPipeds(ctx context.Context, req *webservice.ListPipedsReque
 			}
 			if err != nil {
 				pipeds[i].Status = model.Piped_UNKNOWN
+				a.logger.Error("failed to get piped stat from the cache", zap.Error(err))
 				continue
 			}
 

--- a/pkg/app/api/grpcapi/web_api.go
+++ b/pkg/app/api/grpcapi/web_api.go
@@ -555,6 +555,7 @@ func (a *WebAPI) ListPipeds(ctx context.Context, req *webservice.ListPipedsReque
 			}
 			if model.IsConnectingPiped(&ps) {
 				pipeds[i].Status = model.Piped_ONLINE
+				continue
 			}
 			pipeds[i].Status = model.Piped_OFFLINE
 		}

--- a/pkg/app/api/grpcapi/web_api.go
+++ b/pkg/app/api/grpcapi/web_api.go
@@ -552,6 +552,7 @@ func (a *WebAPI) ListPipeds(ctx context.Context, req *webservice.ListPipedsReque
 			ps := model.PipedStat{}
 			if err = model.UnmarshalPipedStat(sv, &ps); err != nil {
 				pipeds[i].Status = model.Piped_UNKNOWN
+				a.logger.Error("unable to unmarshal the piped stat", zap.Error(err))
 				continue
 			}
 			if ps.IsStaled(model.PipedStatsRetention) {

--- a/pkg/app/api/grpcapi/web_api.go
+++ b/pkg/app/api/grpcapi/web_api.go
@@ -553,11 +553,11 @@ func (a *WebAPI) ListPipeds(ctx context.Context, req *webservice.ListPipedsReque
 				pipeds[i].Status = model.Piped_UNKNOWN
 				continue
 			}
-			if model.IsConnectingPiped(&ps) {
-				pipeds[i].Status = model.Piped_ONLINE
+			if ps.IsStaled(model.PipedStatsRetention) {
+				pipeds[i].Status = model.Piped_OFFLINE
 				continue
 			}
-			pipeds[i].Status = model.Piped_OFFLINE
+			pipeds[i].Status = model.Piped_ONLINE
 		}
 	}
 

--- a/pkg/app/ops/pipedstatsbuilder/builder.go
+++ b/pkg/app/ops/pipedstatsbuilder/builder.go
@@ -57,7 +57,7 @@ func (b *PipedStatsBuilder) Build() (io.Reader, error) {
 
 		// Ignore piped stat metrics if passed time from its last committed
 		// timestamp longer than limit live state check.
-		if !model.IsConnectingPiped(&ps) {
+		if ps.IsStaled(model.PipedStatsRetention) {
 			continue
 		}
 		data = append(data, ps.Metrics)

--- a/pkg/app/ops/pipedstatsbuilder/builder.go
+++ b/pkg/app/ops/pipedstatsbuilder/builder.go
@@ -16,19 +16,13 @@ package pipedstatsbuilder
 
 import (
 	"bytes"
-	"encoding/json"
 	"errors"
 	"io"
-	"time"
 
 	"go.uber.org/zap"
 
 	"github.com/pipe-cd/pipe/pkg/cache"
 	"github.com/pipe-cd/pipe/pkg/model"
-)
-
-const (
-	pipedStatsRetention = 2 * time.Minute
 )
 
 type PipedStatsBuilder struct {
@@ -55,20 +49,15 @@ func (b *PipedStatsBuilder) Build() (io.Reader, error) {
 	}
 	data := make([][]byte, 0, len(res))
 	for _, v := range res {
-		value, okValue := v.([]byte)
-		if !okValue {
-			err = errors.New("error value not a bulk of string value")
-			b.logger.Error("failed to unmarshal piped stat data", zap.Error(err))
-			return nil, err
-		}
 		ps := model.PipedStat{}
-		if err = json.Unmarshal(value, &ps); err != nil {
+		if err = model.UnmarshalPipedStat(v, &ps); err != nil {
 			b.logger.Error("failed to unmarshal piped stat data", zap.Error(err))
 			return nil, err
 		}
+
 		// Ignore piped stat metrics if passed time from its last committed
 		// timestamp longer than limit live state check.
-		if time.Since(time.Unix(ps.Timestamp, 0)) > pipedStatsRetention {
+		if !model.IsConnectingPiped(&ps) {
 			continue
 		}
 		data = append(data, ps.Metrics)

--- a/pkg/app/ops/staledpipedstatcleaner/cleaner.go
+++ b/pkg/app/ops/staledpipedstatcleaner/cleaner.go
@@ -27,7 +27,8 @@ import (
 )
 
 const (
-	interval = 24 * time.Hour
+	pipedStatStaledTimeout = 24 * time.Hour
+	interval               = 24 * time.Hour
 )
 
 type StaledPipedStatCleaner struct {
@@ -80,7 +81,7 @@ func (s *StaledPipedStatCleaner) flushStaledPipedStat() error {
 		if err = model.UnmarshalPipedStat(v, &ps); err != nil {
 			return fmt.Errorf("failed to unmarshal piped stat data: %w", err)
 		}
-		if ps.IsStaled() {
+		if ps.IsStaled(pipedStatStaledTimeout) {
 			staled = append(staled, k)
 		}
 	}

--- a/pkg/datastore/pipedstore.go
+++ b/pkg/datastore/pipedstore.go
@@ -30,7 +30,6 @@ var (
 	PipedMetadataUpdater = func(
 		cloudProviders []*model.Piped_CloudProvider,
 		repos []*model.ApplicationGitRepository,
-		status model.Piped_ConnectionStatus,
 		se *model.Piped_SecretEncryption,
 		version string,
 		startedAt int64,
@@ -39,7 +38,6 @@ var (
 		return func(piped *model.Piped) error {
 			piped.CloudProviders = cloudProviders
 			piped.Repositories = repos
-			piped.Status = status
 
 			piped.SecretEncryption = se
 			// Remove the legacy data.

--- a/pkg/model/BUILD.bazel
+++ b/pkg/model/BUILD.bazel
@@ -63,6 +63,7 @@ go_library(
         "model.go",
         "notificationevent.go",
         "piped.go",
+        "piped_stat.go",
         "planpreview.go",
         "project.go",
         "stage.go",

--- a/pkg/model/piped.proto
+++ b/pkg/model/piped.proto
@@ -33,8 +33,9 @@ message Piped {
     }
 
     enum ConnectionStatus {
-        ONLINE = 0;
-        OFFLINE = 1;
+        UNKNOWN = 0;
+        ONLINE = 1;
+        OFFLINE = 2;
     }
 
     // The generated unique identifier.

--- a/pkg/model/piped_stat.go
+++ b/pkg/model/piped_stat.go
@@ -21,8 +21,7 @@ import (
 )
 
 const (
-	pipedStatsRetention    = 2 * time.Minute
-	pipedStatStaledTimeout = 24 * time.Hour
+	PipedStatsRetention = 2 * time.Minute
 )
 
 func UnmarshalPipedStat(data interface{}, ps *PipedStat) error {
@@ -36,10 +35,6 @@ func UnmarshalPipedStat(data interface{}, ps *PipedStat) error {
 	return nil
 }
 
-func (ps *PipedStat) IsStaled() bool {
-	return time.Since(time.Unix(ps.Timestamp, 0)) > pipedStatStaledTimeout
-}
-
-func IsConnectingPiped(ps *PipedStat) bool {
-	return time.Since(time.Unix(ps.Timestamp, 0)) < pipedStatsRetention
+func (ps *PipedStat) IsStaled(d time.Duration) bool {
+	return time.Since(time.Unix(ps.Timestamp, 0)) > d
 }

--- a/pkg/model/piped_stat.go
+++ b/pkg/model/piped_stat.go
@@ -1,0 +1,45 @@
+// Copyright 2021 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"encoding/json"
+	"errors"
+	"time"
+)
+
+const (
+	pipedStatsRetention    = 2 * time.Minute
+	pipedStatStaledTimeout = 24 * time.Hour
+)
+
+func UnmarshalPipedStat(data interface{}, ps *PipedStat) error {
+	value, okValue := data.([]byte)
+	if !okValue {
+		return errors.New("error value not a bulk of string value")
+	}
+	if err := json.Unmarshal(value, ps); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (ps *PipedStat) IsStaled() bool {
+	return time.Since(time.Unix(ps.Timestamp, 0)) > pipedStatStaledTimeout
+}
+
+func IsConnectingPiped(ps *PipedStat) bool {
+	return time.Since(time.Unix(ps.Timestamp, 0)) < pipedStatsRetention
+}

--- a/pkg/model/piped_stat.go
+++ b/pkg/model/piped_stat.go
@@ -29,10 +29,7 @@ func UnmarshalPipedStat(data interface{}, ps *PipedStat) error {
 	if !okValue {
 		return errors.New("error value not a bulk of string value")
 	}
-	if err := json.Unmarshal(value, ps); err != nil {
-		return err
-	}
-	return nil
+	return json.Unmarshal(value, ps)
 }
 
 func (ps *PipedStat) IsStaled(d time.Duration) bool {


### PR DESCRIPTION
**What this PR does / why we need it**:

By this PR
- Add `Piped_UNKNOWN` as the default value for Piped ConnectionStatus type instead of `Piped_ONLINE` as currently
- Instead of hard code set the piped status one time when the piped reports its metadata (via `pipedservice.ReportPipedMeta`, the status of piped which is stored in datastore will always be marked as default value (`UNKNOWN`, basically we don't use the piped.Status value which stored in the datastore) and only when we request for the piped and ask for it status, check its status via submitted stat in pipedStatStore. 

I checked once and we don't use this `piped.Status` anywhere other than on the controlplane so adding a new piped status UNKNOWN as default value should be fine.

**Which issue(s) this PR fixes**:

Fixes #593

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
