### PR TITLE
Show the piped connecting status on the setting page

### DIFF
--- a/pkg/app/web/src/components/settings-page/piped/components/piped-table-row.tsx
+++ b/pkg/app/web/src/components/settings-page/piped/components/piped-table-row.tsx
@@ -54,7 +54,7 @@ const useStyles = makeStyles((theme) => ({
     },
   },
   connectionStatus: {
-    paddingLeft: "10px",
+    paddingLeft: theme.spacing(1.5),
   },
 }));
 

--- a/pkg/app/web/src/components/settings-page/piped/components/piped-table-row.tsx
+++ b/pkg/app/web/src/components/settings-page/piped/components/piped-table-row.tsx
@@ -1,6 +1,7 @@
 import {
   Box,
   Button,
+  Badge,
   Dialog,
   DialogActions,
   DialogContent,
@@ -13,6 +14,7 @@ import {
   TableCell,
   TableRow,
   Typography,
+  Tooltip,
 } from "@material-ui/core";
 import { MoreVert as MoreVertIcon } from "@material-ui/icons";
 import clsx from "clsx";
@@ -20,6 +22,7 @@ import dayjs from "dayjs";
 import * as React from "react";
 import { FC, memo, useCallback, useState } from "react";
 import { CopyIconButton } from "~/components/copy-icon-button";
+import { PIPED_CONNECTION_STATUS_TEXT } from "~/constants/piped-connection-status-text";
 import { DELETE_OLD_PIPED_KEY_SUCCESS } from "~/constants/toast-text";
 import {
   UI_TEXT_ADD_NEW_KEY,
@@ -33,6 +36,7 @@ import {
   addNewPipedKey,
   deleteOldKey,
   fetchPipeds,
+  Piped,
   selectPipedById,
 } from "~/modules/pipeds";
 import { addToast } from "~/modules/toasts";
@@ -48,6 +52,9 @@ const useStyles = makeStyles((theme) => ({
     "&:hover button": {
       visibility: "visible",
     },
+  },
+  connectionStatus: {
+    paddingLeft: "10px",
   },
 }));
 
@@ -131,6 +138,17 @@ export const PipedTableRow: FC<Props> = memo(function PipedTableRow({
     onDisable(pipedId);
   }, [pipedId, onDisable]);
 
+  const connectionStatusColor = useCallback((status: Piped.ConnectionStatus) => {
+    switch (status) {
+      case Piped.ConnectionStatus.UNKNOWN:
+        return "secondary";
+      case Piped.ConnectionStatus.ONLINE:
+        return "primary";
+      case Piped.ConnectionStatus.OFFLINE:
+        return "error";
+    }
+  }, [piped?.status]);
+
   if (!piped) {
     return null;
   }
@@ -142,7 +160,19 @@ export const PipedTableRow: FC<Props> = memo(function PipedTableRow({
         className={clsx({ [classes.disabledItem]: piped.disabled })}
       >
         <TableCell>
-          <Typography variant="subtitle2">{piped.name}</Typography>
+          <Typography variant="subtitle2">
+            {piped.name}
+            <Tooltip
+              className={classes.connectionStatus}
+              placement="top"
+              title={PIPED_CONNECTION_STATUS_TEXT[piped.status]}
+            >
+              <Badge
+                variant="dot"
+                color={connectionStatusColor(piped.status)}
+              />
+            </Tooltip>
+          </Typography>
         </TableCell>
         <TableCell title={piped.id} className={classes.idCell}>
           <Box display="flex" alignItems="center" fontFamily="fontFamilyMono">

--- a/pkg/app/web/src/constants/piped-connection-status-text.ts
+++ b/pkg/app/web/src/constants/piped-connection-status-text.ts
@@ -1,0 +1,7 @@
+import { Piped } from "pipe/pkg/app/web/model/piped_pb";
+
+export const PIPED_CONNECTION_STATUS_TEXT: Record<Piped.ConnectionStatus, string> = {
+  [Piped.ConnectionStatus.UNKNOWN]: "Unknown",
+  [Piped.ConnectionStatus.ONLINE]: "Online",
+  [Piped.ConnectionStatus.OFFLINE]: "Offline",
+};

--- a/pkg/app/web/src/routes.tsx
+++ b/pkg/app/web/src/routes.tsx
@@ -86,7 +86,7 @@ export const Routes: FC = () => {
   useEffect(() => {
     if (me?.isLogin) {
       dispatch(fetchEnvironments());
-      dispatch(fetchPipeds(false));
+      dispatch(fetchPipeds(true));
     }
   }, [dispatch, me]);
   useCommandsStatusChecking();


### PR DESCRIPTION
**What this PR does / why we need it**:

https://user-images.githubusercontent.com/32532742/144983200-b7c37948-e669-461f-bcbd-d6e5677a34aa.mp4

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
The Piped connection status is now showing in the piped tab on the setting page
```
