### PR TITLE
Ensure to list unregistered apps whenever the add from git form got shown

### DIFF
--- a/pkg/app/web/src/modules/index.ts
+++ b/pkg/app/web/src/modules/index.ts
@@ -18,6 +18,7 @@ import { sealedSecretSlice } from "./sealed-secret";
 import { stageLogsSlice } from "./stage-logs";
 import { toastsSlice } from "./toasts";
 import { updateApplicationSlice } from "./update-application";
+import { unregisteredApplicationsSlice } from "./unregistered-applications";
 
 export const reducers = combineReducers({
   deployments: deploymentsSlice.reducer,
@@ -39,4 +40,5 @@ export const reducers = combineReducers({
   deploymentFrequency: deploymentFrequencySlice.reducer,
   applicationCounts: applicationCountsSlice.reducer,
   deletingEnv: deletingEnvSlice.reducer,
+  unregisteredApplications: unregisteredApplicationsSlice.reducer,
 });

--- a/pkg/app/web/src/modules/unregistered-applications/index.ts
+++ b/pkg/app/web/src/modules/unregistered-applications/index.ts
@@ -1,8 +1,23 @@
-import { createAsyncThunk } from "@reduxjs/toolkit";
+import {
+  createAsyncThunk,
+  createSlice,
+  createEntityAdapter,
+} from "@reduxjs/toolkit";
 import { ApplicationInfo } from "pipe/pkg/app/web/model/common_pb";
+import type { AppState } from "~/store";
 import * as applicationsAPI from "~/api/applications";
 
 const MODULE_NAME = "unregistered-applications";
+
+export const unregisteredApplicationsAdapter = createEntityAdapter<
+  ApplicationInfo.AsObject
+>({});
+
+const { selectAll } = unregisteredApplicationsAdapter.getSelectors();
+
+export const selectAllUnregisteredApplications = (
+  state: AppState
+): ApplicationInfo.AsObject[] => selectAll(state.unregisteredApplications);
 
 export const fetchUnregisteredApplications = createAsyncThunk<
   ApplicationInfo.AsObject[]
@@ -14,3 +29,22 @@ export const fetchUnregisteredApplications = createAsyncThunk<
 });
 
 export { ApplicationInfo } from "pipe/pkg/app/web/model/common_pb";
+
+export const unregisteredApplicationsSlice = createSlice({
+  name: MODULE_NAME,
+  initialState: unregisteredApplicationsAdapter.getInitialState<{
+    apps: ApplicationInfo | null;
+  }>({
+    apps: null,
+  }),
+  reducers: {},
+  extraReducers: (builder) => {
+    builder.addCase(
+      fetchUnregisteredApplications.fulfilled,
+      (state, action) => {
+        unregisteredApplicationsAdapter.removeAll(state);
+        unregisteredApplicationsAdapter.addMany(state, action.payload);
+      }
+    );
+  },
+});


### PR DESCRIPTION
**What this PR does / why we need it**:
With this PR, it actually fetches the unregistered apps whenever you click on the `ADD FROM GIT` tab.
I confirmed it worked as well as we'd like on the dev cluster.

**Which issue(s) this PR fixes**:

Fixes https://github.com/pipe-cd/pipe/issues/2898

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
