### PR TITLE
Fix launcher to use valid Printf verbs

### DIFF
--- a/pkg/app/launcher/cmd/launcher/binary.go
+++ b/pkg/app/launcher/cmd/launcher/binary.go
@@ -123,7 +123,7 @@ func downloadBinary(url, destDir, destFile string, logger *zap.Logger) (string, 
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("HTTP GET %s failed with error %w", url, resp.StatusCode)
+		return "", fmt.Errorf("HTTP GET %s failed with error %d", url, resp.StatusCode)
 	}
 
 	if _, err = io.Copy(tmpFile, resp.Body); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
To prevent from being:
```
failed with error %!w(int=404))
```
**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
