### PR TITLE
Avoid trigger disabled application in chain

### DIFF
--- a/pkg/app/api/grpcapi/piped_api.go
+++ b/pkg/app/api/grpcapi/piped_api.go
@@ -1123,6 +1123,11 @@ func (a *PipedAPI) CreateDeploymentChain(ctx context.Context, req *pipedservice.
 				Operator: datastore.OperatorEqual,
 				Value:    projectID,
 			},
+			{
+				Field:    "Disabled",
+				Operator: datastore.OperatorEqual,
+				Value:    false,
+			},
 		}
 
 		if matcher.Name != "" {


### PR DESCRIPTION
**What this PR does / why we need it**:

Should ignore disabled applications from being triggered via deployment chain application filters

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
