### PR TITLE
Fetch piped list in setting page intervally

### DIFF
--- a/pkg/app/web/src/components/settings-page/piped/index.tsx
+++ b/pkg/app/web/src/components/settings-page/piped/index.tsx
@@ -33,6 +33,7 @@ import {
   UI_TEXT_UPGRADE,
 } from "~/constants/ui-text";
 import { useAppDispatch, useAppSelector } from "~/hooks/redux";
+import { useInterval } from "~/hooks/use-interval";
 import {
   clearRegisteredPipedInfo,
   disablePiped,
@@ -79,6 +80,8 @@ const selectFilteredPipeds = createSelector<
 
 const OLD_KEY_ALERT_MESSAGE =
   "The old key is still there.\nDo not forget to delete it once you update your Piped to use this new key.";
+
+const FETCH_INTERVAL = 30000;
 
 export const SettingsPipedPage: FC = memo(function SettingsPipedPage() {
   const classes = useStyles();
@@ -134,6 +137,10 @@ export const SettingsPipedPage: FC = memo(function SettingsPipedPage() {
   const handleEditClose = useCallback(() => {
     setEditPipedId(null);
   }, []);
+
+  useInterval(() => {
+    dispatch(fetchPipeds(true));
+  }, FETCH_INTERVAL);
 
   return (
     <>


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, we don't have any way to refetch piped list in the setting page except refresh the page directly. Since we introduce the piped live connection status showing feature already, the list should be auto refetch as well to ensure the piped connection status shown on the setting page is the latest.

The current piped list interval fetching time is set to 30s.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
