### PR TITLE
Update ApplicationForm to register apps using configs in Git

### DIFF
--- a/pkg/app/web/src/components/applications-page/add-application-drawer/index.tsx
+++ b/pkg/app/web/src/components/applications-page/add-application-drawer/index.tsx
@@ -8,11 +8,7 @@ import {
 } from "@material-ui/core";
 import { useFormik } from "formik";
 import { FC, memo, useCallback, useState } from "react";
-import {
-  UI_TEXT_CANCEL,
-  UI_TEXT_DISCARD,
-  UI_TEXT_SAVE,
-} from "~/constants/ui-text";
+import { UI_TEXT_CANCEL, UI_TEXT_DISCARD } from "~/constants/ui-text";
 import { useAppDispatch, useAppSelector } from "~/hooks/redux";
 import { addApplication } from "~/modules/applications";
 import { selectProjectName } from "~/modules/me";
@@ -32,10 +28,6 @@ export interface AddApplicationDrawerProps {
 const CONFIRM_DIALOG_TITLE = "Quit adding application?";
 const CONFIRM_DIALOG_DESCRIPTION =
   "Form values inputs so far will not be saved.";
-
-const ADD_FROM_GIT_CONFIRM_DIALOG_TITLE = "Add Application";
-const ADD_FROM_GIT_CONFIRM_DIALOG_DESCRIPTION =
-  "Are you sure you want to add the application?";
 
 export const AddApplicationDrawer: FC<AddApplicationDrawerProps> = memo(
   function AddApplicationDrawer({
@@ -68,10 +60,6 @@ export const AddApplicationDrawer: FC<AddApplicationDrawerProps> = memo(
       }
     }, [onClose, formik]);
 
-    const [showConfirmToAddFromGit, setShowConfirmToAddFromGit] = useState(
-      false
-    );
-
     return (
       <>
         <Drawer
@@ -84,7 +72,6 @@ export const AddApplicationDrawer: FC<AddApplicationDrawerProps> = memo(
             {...formik}
             title={`Add a new application to "${projectName}" project`}
             onClose={handleClose}
-            onAddFromGit={() => setShowConfirmToAddFromGit(true)}
           />
         </Drawer>
         <Dialog open={showConfirm}>
@@ -103,27 +90,6 @@ export const AddApplicationDrawer: FC<AddApplicationDrawerProps> = memo(
               }}
             >
               {UI_TEXT_DISCARD}
-            </Button>
-          </DialogActions>
-        </Dialog>
-        <Dialog open={showConfirmToAddFromGit}>
-          <DialogTitle>{ADD_FROM_GIT_CONFIRM_DIALOG_TITLE}</DialogTitle>
-          <DialogContent>
-            {ADD_FROM_GIT_CONFIRM_DIALOG_DESCRIPTION}
-          </DialogContent>
-          <DialogActions>
-            <Button onClick={() => setShowConfirmToAddFromGit(false)}>
-              {UI_TEXT_CANCEL}
-            </Button>
-            <Button
-              color="primary"
-              onClick={() => {
-                // TODO: Save the given app actually
-                setShowConfirmToAddFromGit(false);
-                onClose();
-              }}
-            >
-              {UI_TEXT_SAVE}
             </Button>
           </DialogActions>
         </Dialog>

--- a/pkg/app/web/src/components/applications-page/edit-application-drawer/index.tsx
+++ b/pkg/app/web/src/components/applications-page/edit-application-drawer/index.tsx
@@ -70,13 +70,6 @@ export const EditApplicationDrawer: FC<EditApplicationDrawerProps> = memo(
           {...formik}
           title={`Edit "${app?.name}"`}
           onClose={handleClose}
-          onAddFromGit={() =>
-            void (
-              {
-                /** NOTE: Give noop function for now as the edit form will be removed soon */
-              }
-            )
-          }
           disableGitPath
         />
       </Drawer>

--- a/pkg/app/web/src/modules/applications/index.ts
+++ b/pkg/app/web/src/modules/applications/index.ts
@@ -268,4 +268,5 @@ export {
 export {
   ApplicationKind,
   ApplicationActiveStatus,
+  ApplicationGitRepository,
 } from "pipe/pkg/app/web/model/common_pb";


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes sure to dispatch the unregistered application selected on the form to save it.

Review points:
- The confirmation dialog is now a part of `UnregisteredApplicationList`, but is it alright?
- It uses State to inform the Dialog from Accordion about the selected ApplicationInfo, are there any other simpler ways?

**Which issue(s) this PR fixes**:

Fixes https://github.com/pipe-cd/pipe/issues/2900
Fixes https://github.com/pipe-cd/pipe/issues/2885
Fixes https://github.com/pipe-cd/pipe/issues/2899

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Allow you to add a new application using an application config defined in a Git repository
```
