### PR TITLE
Fix what only one unregistered application is shown

### DIFF
--- a/pkg/app/web/src/components/application-form/index.tsx
+++ b/pkg/app/web/src/components/application-form/index.tsx
@@ -705,6 +705,7 @@ const UnregisteredApplicationList: FC<ApplicationFormProps> = memo(
                               pipedId: app.pipedId,
                               repo: {
                                 id: app.repoId,
+                                // TODO: Populate repo info from state
                                 remote: "",
                                 branch: "",
                               } as ApplicationGitRepository.AsObject,

--- a/pkg/app/web/src/modules/unregistered-applications/index.ts
+++ b/pkg/app/web/src/modules/unregistered-applications/index.ts
@@ -13,11 +13,11 @@ export const unregisteredApplicationsAdapter = createEntityAdapter<
   ApplicationInfo.AsObject
 >({});
 
-const { selectAll } = unregisteredApplicationsAdapter.getSelectors();
-
 export const selectAllUnregisteredApplications = (
   state: AppState
-): ApplicationInfo.AsObject[] => selectAll(state.unregisteredApplications);
+): ApplicationInfo.AsObject[] => {
+  return state.unregisteredApplications.apps;
+};
 
 export const fetchUnregisteredApplications = createAsyncThunk<
   ApplicationInfo.AsObject[]
@@ -32,10 +32,8 @@ export { ApplicationInfo } from "pipe/pkg/app/web/model/common_pb";
 
 export const unregisteredApplicationsSlice = createSlice({
   name: MODULE_NAME,
-  initialState: unregisteredApplicationsAdapter.getInitialState<{
-    apps: ApplicationInfo | null;
-  }>({
-    apps: null,
+  initialState: unregisteredApplicationsAdapter.getInitialState({
+    apps: [] as ApplicationInfo.AsObject[],
   }),
   reducers: {},
   extraReducers: (builder) => {
@@ -43,7 +41,7 @@ export const unregisteredApplicationsSlice = createSlice({
       fetchUnregisteredApplications.fulfilled,
       (state, action) => {
         unregisteredApplicationsAdapter.removeAll(state);
-        unregisteredApplicationsAdapter.addMany(state, action.payload);
+        state.apps = action.payload;
       }
     );
   },


### PR DESCRIPTION
**What this PR does / why we need it**:
Since unregistered applications don't have an id, all entities in the state have been overwritten because id is used as a record key by default.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
