### PR TITLE
Undo Env to mandatory again in App config

### DIFF
--- a/pkg/app/api/service/webservice/service.proto
+++ b/pkg/app/api/service/webservice/service.proto
@@ -223,7 +223,7 @@ message AddEnvironmentRequest {
 
 message AddApplicationRequest {
     string name = 1 [(validate.rules).string.min_len = 1];
-    string env_id = 2;
+    string env_id = 2 [(validate.rules).string.min_len = 1];
     string piped_id = 3 [(validate.rules).string.min_len = 1];
     model.ApplicationGitPath git_path = 4 [(validate.rules).message.required = true];
     model.ApplicationKind kind = 5 [(validate.rules).enum.defined_only = true];

--- a/pkg/app/piped/appconfigreporter/appconfigreporter.go
+++ b/pkg/app/piped/appconfigreporter/appconfigreporter.go
@@ -384,12 +384,15 @@ func (r *Reporter) readApplicationInfo(repoDir, repoID, cfgRelPath string) (*mod
 		return nil, fmt.Errorf("unsupported application kind %q", cfg.Kind)
 	}
 
-	if spec.Name == "" {
-		return nil, fmt.Errorf("missing application name: %w", errMissingRequiredField)
-	}
 	kind, ok := cfg.Kind.ToApplicationKind()
 	if !ok {
 		return nil, fmt.Errorf("%q is not application config kind", cfg.Kind)
+	}
+	if spec.Name == "" {
+		return nil, fmt.Errorf("missing application name: %w", errMissingRequiredField)
+	}
+	if spec.EnvName == "" {
+		return nil, fmt.Errorf("missing environment name: %w", errMissingRequiredField)
 	}
 	return &model.ApplicationInfo{
 		Name:           spec.Name,
@@ -399,5 +402,6 @@ func (r *Reporter) readApplicationInfo(repoDir, repoID, cfgRelPath string) (*mod
 		Path:           filepath.Dir(cfgRelPath),
 		ConfigFilename: filepath.Base(cfgRelPath),
 		PipedId:        r.config.PipedID,
+		EnvName:        spec.EnvName,
 	}, nil
 }

--- a/pkg/app/piped/appconfigreporter/appconfigreporter_test.go
+++ b/pkg/app/piped/appconfigreporter/appconfigreporter_test.go
@@ -104,6 +104,7 @@ apiVersion: pipecd.dev/v1beta1
 kind: KubernetesApp
 spec:
   name: app-1
+  envName: dev
   labels:
     key-1: value-1`)},
 				},
@@ -129,6 +130,7 @@ apiVersion: pipecd.dev/v1beta1
 kind: KubernetesApp
 spec:
   name: new-app-1
+  envName: dev
   labels:
     key-1: value-1`)},
 				},
@@ -147,6 +149,7 @@ spec:
 					Path:           "app-1",
 					ConfigFilename: ".pipe.yaml",
 					PipedId:        "piped-1",
+					EnvName:        "dev",
 				},
 			},
 			wantErr: false,
@@ -237,6 +240,7 @@ apiVersion: pipecd.dev/v1beta1
 kind: KubernetesApp
 spec:
   name: app-1
+  envName: dev
   labels:
     key-1: value-1`)},
 				},
@@ -255,6 +259,7 @@ spec:
 					Path:           "app-1",
 					ConfigFilename: ".pipe.yaml",
 					PipedId:        "piped-1",
+					EnvName:        "dev",
 				},
 			},
 			wantErr: false,
@@ -270,6 +275,7 @@ apiVersion: pipecd.dev/v1beta1
 kind: KubernetesApp
 spec:
   name: app-1
+  envName: dev
   labels:
     key-1: value-1`)},
 				},
@@ -288,6 +294,7 @@ spec:
 					Path:           "app-1",
 					ConfigFilename: "dev.pipecd.yaml",
 					PipedId:        "piped-1",
+					EnvName:        "dev",
 				},
 			},
 			wantErr: false,

--- a/pkg/app/web/src/components/application-form/index.tsx
+++ b/pkg/app/web/src/components/application-form/index.tsx
@@ -610,6 +610,13 @@ const UnregisteredApplicationList: FC<ApplicationFormProps> = memo(
       },
       []
     );
+
+    const environments = useAppSelector(selectAllEnvs);
+    const envsMap = new Map<string, string>();
+    environments.forEach((env) => {
+      envsMap.set(env.name, env.id);
+    });
+
     return (
       <>
         <Box width="100%">
@@ -633,7 +640,8 @@ const UnregisteredApplicationList: FC<ApplicationFormProps> = memo(
                 .filter(
                   (app) =>
                     app.pipedId === selectedPipedId &&
-                    app.kind === APPLICATION_KIND_BY_NAME[selectedKind]
+                    app.kind === APPLICATION_KIND_BY_NAME[selectedKind] &&
+                    envsMap.has(app.envName)
                 )
                 .map((app, i) => (
                   <Accordion key={app.repoId + app.path + app.configFilename}>
@@ -657,6 +665,18 @@ const UnregisteredApplicationList: FC<ApplicationFormProps> = memo(
                             variant="outlined"
                             disabled
                             value={APPLICATION_KIND_TEXT[app.kind]}
+                            className={classes.textInput}
+                          />
+                        </div>
+                        <div className={classes.inputGroup}>
+                          <TextField
+                            id={"env-" + i}
+                            label="Environment"
+                            margin="dense"
+                            fullWidth
+                            variant="outlined"
+                            disabled
+                            value={app.envName}
                             className={classes.textInput}
                           />
                         </div>
@@ -701,7 +721,7 @@ const UnregisteredApplicationList: FC<ApplicationFormProps> = memo(
                             // TODO: Enable to register labels via dispatch
                             setAppToAdd({
                               name: app.name,
-                              env: "",
+                              env: envsMap.get(app.envName) as string,
                               pipedId: app.pipedId,
                               repo: {
                                 id: app.repoId,

--- a/pkg/model/application.proto
+++ b/pkg/model/application.proto
@@ -27,7 +27,7 @@ message Application {
     // The name of the application.
     string name = 2 [(validate.rules).string.min_len = 1];
     // The id of environment this application belongs to.
-    string env_id = 3;
+    string env_id = 3 [(validate.rules).string.min_len = 1];
     // The ID of the piped that should handle this application.
     string piped_id = 4 [(validate.rules).string.min_len = 1];
     // The ID of the project this environment belongs to.

--- a/pkg/model/common.proto
+++ b/pkg/model/common.proto
@@ -69,4 +69,6 @@ message ApplicationInfo {
     // This field is not allowed to be changed.
     string config_filename = 7;
     string piped_id = 8 [(validate.rules).string.min_len = 1];
+    // This field will be no longer needed as labels can be an alternative.
+    string env_name = 14 [(validate.rules).string.min_len = 1, deprecated=true];
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR reverts to making EnvId a required field when registering an application, and also makes envName a required field in Application config.

The point is, the web front is going to check if the EnvName is valid or not.
Obviously, it would be better to check this when Piped reports an unregistered application, but it needs a little bit more code change.
Since [this is a workaround that will get removed as soon as the ACL feature](https://github.com/pipe-cd/pipe/issues/2915) is supported in the near future, I settled on adapting this way which requires less code modification and does not cause unnecessary communication.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
