### PR TITLE
Add DeploymentChain gRPCs

### DIFF
--- a/pkg/app/api/grpcapi/web_api.go
+++ b/pkg/app/api/grpcapi/web_api.go
@@ -1852,7 +1852,7 @@ func (a *WebAPI) GetDeploymentChain(ctx context.Context, req *webservice.GetDepl
 	}
 
 	if claims.Role.ProjectId != dc.ProjectId {
-		return nil, status.Error(codes.InvalidArgument, "Requested deployment chain does not belong to your project")
+		return nil, status.Error(codes.PermissionDenied, "Requested deployment chain does not belong to your project")
 	}
 
 	return &webservice.GetDeploymentChainResponse{

--- a/pkg/app/api/grpcapi/web_api.go
+++ b/pkg/app/api/grpcapi/web_api.go
@@ -1781,3 +1781,11 @@ func (a *WebAPI) GetInsightApplicationCount(ctx context.Context, req *webservice
 		UpdatedAt: c.UpdatedAt,
 	}, nil
 }
+
+func (a *WebAPI) ListDeploymentChains(ctx context.Context, req *webservice.ListDeploymentChainsRequest) (*webservice.ListDeploymentChainsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not yet implemented")
+}
+
+func (a *WebAPI) GetDeploymentChain(ctx context.Context, req *webservice.GetDeploymentChainRequest) (*webservice.GetDeploymentChainResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not yet implemented")
+}

--- a/pkg/app/api/grpcapi/web_api.go
+++ b/pkg/app/api/grpcapi/web_api.go
@@ -54,6 +54,7 @@ type encrypter interface {
 type WebAPI struct {
 	applicationStore          datastore.ApplicationStore
 	environmentStore          datastore.EnvironmentStore
+	deploymentChainStore      datastore.DeploymentChainStore
 	deploymentStore           datastore.DeploymentStore
 	pipedStore                datastore.PipedStore
 	projectStore              datastore.ProjectStore
@@ -94,6 +95,7 @@ func NewWebAPI(
 	a := &WebAPI{
 		applicationStore:          datastore.NewApplicationStore(ds),
 		environmentStore:          datastore.NewEnvironmentStore(ds),
+		deploymentChainStore:      datastore.NewDeploymentChainStore(ds),
 		deploymentStore:           datastore.NewDeploymentStore(ds),
 		pipedStore:                datastore.NewPipedStore(ds),
 		projectStore:              datastore.NewProjectStore(ds),
@@ -1783,9 +1785,77 @@ func (a *WebAPI) GetInsightApplicationCount(ctx context.Context, req *webservice
 }
 
 func (a *WebAPI) ListDeploymentChains(ctx context.Context, req *webservice.ListDeploymentChainsRequest) (*webservice.ListDeploymentChainsResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "not yet implemented")
+	claims, err := rpcauth.ExtractClaims(ctx)
+	if err != nil {
+		a.logger.Error("failed to authenticate the current user", zap.Error(err))
+		return nil, err
+	}
+
+	orders := []datastore.Order{
+		{
+			Field:     "UpdatedAt",
+			Direction: datastore.Desc,
+		},
+		{
+			Field:     "Id",
+			Direction: datastore.Asc,
+		},
+	}
+	filters := []datastore.ListFilter{
+		{
+			Field:    "ProjectId",
+			Operator: datastore.OperatorEqual,
+			Value:    claims.Role.ProjectId,
+		},
+		{
+			Field:    "UpdatedAt",
+			Operator: datastore.OperatorGreaterThan,
+			Value:    req.PageMinUpdatedAt,
+		},
+	}
+	// TODO: Support filter list deployment chain with options.
+
+	pageSize := int(req.PageSize)
+	options := datastore.ListOptions{
+		Filters: filters,
+		Orders:  orders,
+		Limit:   pageSize,
+		Cursor:  req.Cursor,
+	}
+
+	deploymentChains, cursor, err := a.deploymentChainStore.ListDeploymentChains(ctx, options)
+	if err != nil {
+		a.logger.Error("failed to list deployment chains", zap.Error(err))
+		return nil, status.Error(codes.Internal, "Failed to list deployment chains")
+	}
+
+	return &webservice.ListDeploymentChainsResponse{
+		DeploymentChains: deploymentChains,
+		Cursor:           cursor,
+	}, nil
 }
 
 func (a *WebAPI) GetDeploymentChain(ctx context.Context, req *webservice.GetDeploymentChainRequest) (*webservice.GetDeploymentChainResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "not yet implemented")
+	claims, err := rpcauth.ExtractClaims(ctx)
+	if err != nil {
+		a.logger.Error("failed to authenticate the current user", zap.Error(err))
+		return nil, err
+	}
+
+	dc, err := a.deploymentChainStore.GetDeploymentChain(ctx, req.DeploymentChainId)
+	if errors.Is(err, datastore.ErrNotFound) {
+		return nil, status.Error(codes.NotFound, "Deployment chain is not found")
+	}
+	if err != nil {
+		a.logger.Error("failed to get deployment chain", zap.Error(err))
+		return nil, status.Error(codes.Internal, "Failed to get deployment chain")
+	}
+
+	if claims.Role.ProjectId != dc.ProjectId {
+		return nil, status.Error(codes.InvalidArgument, "Requested deployment chain does not belong to your project")
+	}
+
+	return &webservice.GetDeploymentChainResponse{
+		DeploymentChain: dc,
+	}, nil
 }

--- a/pkg/app/api/service/webservice/service.proto
+++ b/pkg/app/api/service/webservice/service.proto
@@ -25,6 +25,7 @@ import "pkg/model/application_live_state.proto";
 import "pkg/model/command.proto";
 import "pkg/model/environment.proto";
 import "pkg/model/deployment.proto";
+import "pkg/model/deployment_chain.proto";
 import "pkg/model/logblock.proto";
 import "pkg/model/piped.proto";
 import "pkg/model/role.proto";
@@ -97,6 +98,10 @@ service WebService {
     // Insights
     rpc GetInsightData(GetInsightDataRequest) returns (GetInsightDataResponse) {}
     rpc GetInsightApplicationCount(GetInsightApplicationCountRequest) returns (GetInsightApplicationCountResponse) {}
+
+    // DeploymentChain
+    rpc ListDeploymentChains(ListDeploymentChainsRequest) returns (ListDeploymentChainsResponse) {}
+    rpc GetDeploymentChain(GetDeploymentChainRequest) returns (GetDeploymentChainResponse) {}
 }
 
 message AddEnvironmentResponse {
@@ -505,4 +510,20 @@ message GetInsightApplicationCountRequest {
 message GetInsightApplicationCountResponse {
     int64 updated_at = 1;
     repeated pipe.model.InsightApplicationCount counts = 2;
+}
+
+message ListDeploymentChainsRequest {
+}
+
+message ListDeploymentChainsResponse {
+    repeated pipe.model.DeploymentChain deployment_chains = 1;
+    string cursor = 2;
+}
+
+message GetDeploymentChainRequest {
+    string deployment_chain_id = 1 [(validate.rules).string.min_len = 1];
+}
+
+message GetDeploymentChainResponse {
+    pipe.model.DeploymentChain deployment_chain = 1;
 }

--- a/pkg/app/api/service/webservice/service.proto
+++ b/pkg/app/api/service/webservice/service.proto
@@ -513,6 +513,14 @@ message GetInsightApplicationCountResponse {
 }
 
 message ListDeploymentChainsRequest {
+    message Options {
+    }
+    Options options = 1;
+    int32 page_size = 2;
+    string cursor = 3;
+    // It will not return any data older than this timestamp, even if it does not meet the page size.
+    // This aims to prevent the server from scanning the entire database to look for deployments that have the specified fields in spite of nothing.
+    int64 page_min_updated_at = 4;
 }
 
 message ListDeploymentChainsResponse {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds:
- ListDeploymentChains gRPC, used to fetch all deployment chains to show on list deployment chains page. There will be no options to filter deployment chain currently, just simply list all objects page by page.
- GetDeploymentChain gRPC, used to fetch a specified deployment chain by id to show on the deployment chain detailed page.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
