### PR TITLE
Remove an RPC that no longer exist from the auth list

### DIFF
--- a/pkg/app/api/service/webservice/service.pb.auth.go
+++ b/pkg/app/api/service/webservice/service.pb.auth.go
@@ -106,8 +106,6 @@ func (a *authorizer) Authorize(method string, r model.Role) bool {
 		return isAdmin(r) || isEditor(r) || isViewer(r)
 	case "/pipe.api.service.webservice.WebService/GetCommand":
 		return isAdmin(r) || isEditor(r) || isViewer(r)
-	case "/pipe.api.service.webservice.WebService/ListDeploymentConfigTemplates":
-		return isAdmin(r) || isEditor(r) || isViewer(r)
 	case "/pipe.api.service.webservice.WebService/ListEnvironments":
 		return isAdmin(r) || isEditor(r) || isViewer(r)
 	case "/pipe.api.service.webservice.WebService/ListPipeds":


### PR DESCRIPTION
**What this PR does / why we need it**:
`ListDeploymentConfigTemplates` has already been removed.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
