### PR TITLE
Disable onChain trigger by default

### DIFF
--- a/pkg/app/piped/trigger/determiner.go
+++ b/pkg/app/piped/trigger/determiner.go
@@ -77,7 +77,7 @@ func NewOnChainDeterminer() *OnChainDeterminer {
 }
 
 func (d *OnChainDeterminer) ShouldTrigger(_ context.Context, _ *model.Application, appCfg *config.GenericApplicationSpec) (bool, error) {
-	if appCfg.Trigger.OnChain.Disabled {
+	if *appCfg.Trigger.OnChain.Disabled {
 		return false, nil
 	}
 	return true, nil

--- a/pkg/config/application.go
+++ b/pkg/config/application.go
@@ -110,8 +110,8 @@ type OnOutOfSync struct {
 type OnChain struct {
 	// Whether to exclude application from triggering target
 	// when received a new CHAIN_SYNC command.
-	// Default is false.
-	Disabled bool `json:"disabled,omitempty"`
+	// Default is true.
+	Disabled *bool `json:"disabled,omitempty" default:"true"`
 }
 
 func (s *GenericApplicationSpec) Validate() error {

--- a/pkg/config/application_cloudrun_test.go
+++ b/pkg/config/application_cloudrun_test.go
@@ -48,6 +48,9 @@ func TestCloudRunApplicationConfig(t *testing.T) {
 							Disabled:  newBoolPointer(true),
 							MinWindow: Duration(5 * time.Minute),
 						},
+						OnChain: OnChain{
+							Disabled: newBoolPointer(true),
+						},
 					},
 				},
 				Input: CloudRunDeploymentInput{

--- a/pkg/config/application_ecs_test.go
+++ b/pkg/config/application_ecs_test.go
@@ -49,6 +49,9 @@ func TestECSApplicationConfig(t *testing.T) {
 							Disabled:  newBoolPointer(true),
 							MinWindow: Duration(5 * time.Minute),
 						},
+						OnChain: OnChain{
+							Disabled: newBoolPointer(true),
+						},
 					},
 				},
 				Input: ECSDeploymentInput{

--- a/pkg/config/application_kubernetes_test.go
+++ b/pkg/config/application_kubernetes_test.go
@@ -90,6 +90,9 @@ func TestKubernetesApplicationConfig(t *testing.T) {
 							Disabled:  newBoolPointer(true),
 							MinWindow: Duration(5 * time.Minute),
 						},
+						OnChain: OnChain{
+							Disabled: newBoolPointer(true),
+						},
 					},
 				},
 				Input: KubernetesDeploymentInput{

--- a/pkg/config/application_lambda_test.go
+++ b/pkg/config/application_lambda_test.go
@@ -50,6 +50,9 @@ func TestLambdaApplicationConfig(t *testing.T) {
 							Disabled:  newBoolPointer(true),
 							MinWindow: Duration(5 * time.Minute),
 						},
+						OnChain: OnChain{
+							Disabled: newBoolPointer(true),
+						},
 					},
 				},
 				Input: LambdaDeploymentInput{
@@ -97,6 +100,9 @@ func TestLambdaApplicationConfig(t *testing.T) {
 							Disabled:  newBoolPointer(true),
 							MinWindow: Duration(5 * time.Minute),
 						},
+						OnChain: OnChain{
+							Disabled: newBoolPointer(true),
+						},
 					},
 				},
 				Input: LambdaDeploymentInput{
@@ -134,6 +140,9 @@ func TestLambdaApplicationConfig(t *testing.T) {
 						OnOutOfSync: OnOutOfSync{
 							Disabled:  newBoolPointer(true),
 							MinWindow: Duration(5 * time.Minute),
+						},
+						OnChain: OnChain{
+							Disabled: newBoolPointer(true),
 						},
 					},
 				},

--- a/pkg/config/application_terraform_test.go
+++ b/pkg/config/application_terraform_test.go
@@ -50,6 +50,9 @@ func TestTerraformApplicationtConfig(t *testing.T) {
 							Disabled:  newBoolPointer(true),
 							MinWindow: Duration(5 * time.Minute),
 						},
+						OnChain: OnChain{
+							Disabled: newBoolPointer(true),
+						},
 					},
 				},
 				Input: TerraformDeploymentInput{},
@@ -73,6 +76,9 @@ func TestTerraformApplicationtConfig(t *testing.T) {
 						OnOutOfSync: OnOutOfSync{
 							Disabled:  newBoolPointer(true),
 							MinWindow: Duration(5 * time.Minute),
+						},
+						OnChain: OnChain{
+							Disabled: newBoolPointer(true),
 						},
 					},
 				},
@@ -100,6 +106,9 @@ func TestTerraformApplicationtConfig(t *testing.T) {
 						OnOutOfSync: OnOutOfSync{
 							Disabled:  newBoolPointer(false),
 							MinWindow: Duration(5 * time.Minute),
+						},
+						OnChain: OnChain{
+							Disabled: newBoolPointer(true),
 						},
 					},
 					Encryption: &SecretEncryption{
@@ -156,6 +165,9 @@ func TestTerraformApplicationtConfig(t *testing.T) {
 						OnOutOfSync: OnOutOfSync{
 							Disabled:  newBoolPointer(true),
 							MinWindow: Duration(5 * time.Minute),
+						},
+						OnChain: OnChain{
+							Disabled: newBoolPointer(true),
 						},
 					},
 				},

--- a/pkg/config/application_test.go
+++ b/pkg/config/application_test.go
@@ -308,6 +308,9 @@ func TestGenericTriggerConfiguration(t *testing.T) {
 							Disabled:  newBoolPointer(true),
 							MinWindow: Duration(5 * time.Minute),
 						},
+						OnChain: OnChain{
+							Disabled: newBoolPointer(true),
+						},
 					},
 				},
 				Input: KubernetesDeploymentInput{
@@ -350,6 +353,9 @@ func TestTrueByDefaultBoolConfiguration(t *testing.T) {
 							Disabled:  newBoolPointer(true),
 							MinWindow: Duration(5 * time.Minute),
 						},
+						OnChain: OnChain{
+							Disabled: newBoolPointer(true),
+						},
 					},
 				},
 				Input: KubernetesDeploymentInput{
@@ -370,6 +376,9 @@ func TestTrueByDefaultBoolConfiguration(t *testing.T) {
 							Disabled:  newBoolPointer(false),
 							MinWindow: Duration(5 * time.Minute),
 						},
+						OnChain: OnChain{
+							Disabled: newBoolPointer(true),
+						},
 					},
 				},
 				Input: KubernetesDeploymentInput{
@@ -389,6 +398,9 @@ func TestTrueByDefaultBoolConfiguration(t *testing.T) {
 						OnOutOfSync: OnOutOfSync{
 							Disabled:  newBoolPointer(true),
 							MinWindow: Duration(5 * time.Minute),
+						},
+						OnChain: OnChain{
+							Disabled: newBoolPointer(true),
 						},
 					},
 				},
@@ -431,6 +443,9 @@ func TestGenericPostSyncConfiguration(t *testing.T) {
 						OnOutOfSync: OnOutOfSync{
 							Disabled:  newBoolPointer(true),
 							MinWindow: Duration(5 * time.Minute),
+						},
+						OnChain: OnChain{
+							Disabled: newBoolPointer(true),
 						},
 					},
 					PostSync: &PostSync{


### PR DESCRIPTION
**What this PR does / why we need it**:

To avoid unexpected triggering deployments in chain, should make this `onChain` trigger as disabled by default.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
