### PR TITLE
Make environment fields optional

### DIFF
--- a/pkg/app/api/service/webservice/service.proto
+++ b/pkg/app/api/service/webservice/service.proto
@@ -223,7 +223,7 @@ message AddEnvironmentRequest {
 
 message AddApplicationRequest {
     string name = 1 [(validate.rules).string.min_len = 1];
-    string env_id = 2 [(validate.rules).string.min_len = 1];
+    string env_id = 2;
     string piped_id = 3 [(validate.rules).string.min_len = 1];
     model.ApplicationGitPath git_path = 4 [(validate.rules).message.required = true];
     model.ApplicationKind kind = 5 [(validate.rules).enum.defined_only = true];

--- a/pkg/model/application.proto
+++ b/pkg/model/application.proto
@@ -27,7 +27,7 @@ message Application {
     // The name of the application.
     string name = 2 [(validate.rules).string.min_len = 1];
     // The id of environment this application belongs to.
-    string env_id = 3 [(validate.rules).string.min_len = 1];
+    string env_id = 3;
     // The ID of the piped that should handle this application.
     string piped_id = 4 [(validate.rules).string.min_len = 1];
     // The ID of the project this environment belongs to.

--- a/pkg/model/common.proto
+++ b/pkg/model/common.proto
@@ -70,5 +70,5 @@ message ApplicationInfo {
     string config_filename = 7;
     string piped_id = 8 [(validate.rules).string.min_len = 1];
     // This field will be no longer needed as labels can be an alternative.
-    string env_name = 14 [(validate.rules).string.min_len = 1, deprecated=true];
+    string env_name = 14 [deprecated=true];
 }

--- a/pkg/model/notificationevent.proto
+++ b/pkg/model/notificationevent.proto
@@ -52,52 +52,52 @@ enum NotificationEventGroup {
 
 message NotificationEventDeploymentTriggered {
     Deployment deployment = 1 [(validate.rules).message.required = true];
-    string env_name = 2 [(validate.rules).string.min_len = 1];
+    string env_name = 2;
     repeated string mentioned_accounts = 3;
 }
 
 message NotificationEventDeploymentPlanned {
     Deployment deployment = 1 [(validate.rules).message.required = true];
-    string env_name = 2 [(validate.rules).string.min_len = 1];
+    string env_name = 2;
     string summary = 3;
     repeated string mentioned_accounts = 4;
 }
 
 message NotificationEventDeploymentApproved {
     Deployment deployment = 1 [(validate.rules).message.required = true];
-    string env_name = 2 [(validate.rules).string.min_len = 1];
+    string env_name = 2;
     string approver = 3;
     repeated string mentioned_accounts = 4;
 }
 
 message NotificationEventDeploymentRollingBack {
     Deployment deployment = 1 [(validate.rules).message.required = true];
-    string env_name = 2 [(validate.rules).string.min_len = 1];
+    string env_name = 2;
 }
 
 message NotificationEventDeploymentSucceeded {
     Deployment deployment = 1 [(validate.rules).message.required = true];
-    string env_name = 2 [(validate.rules).string.min_len = 1];
+    string env_name = 2;
     repeated string mentioned_accounts = 3;
 }
 
 message NotificationEventDeploymentFailed {
     Deployment deployment = 1 [(validate.rules).message.required = true];
-    string env_name = 2 [(validate.rules).string.min_len = 1];
+    string env_name = 2;
     string reason = 3;
     repeated string mentioned_accounts = 4;
 }
 
 message NotificationEventDeploymentCancelled {
     Deployment deployment = 1 [(validate.rules).message.required = true];
-    string env_name = 2 [(validate.rules).string.min_len = 1];
+    string env_name = 2;
     string commander = 3;
     repeated string mentioned_accounts = 4;
 }
 
 message NotificationEventDeploymentWaitApproval {
     Deployment deployment = 1 [(validate.rules).message.required = true];
-    string env_name = 2 [(validate.rules).string.min_len = 1];
+    string env_name = 2;
     repeated string mentioned_accounts = 3;
 }
 
@@ -111,13 +111,13 @@ message NotificationEventDeploymentTriggerFailed {
 
 message NotificationEventApplicationSynced {
     Application application = 1 [(validate.rules).message.required = true];
-    string env_name = 2 [(validate.rules).string.min_len = 1];
+    string env_name = 2;
     ApplicationSyncState state = 3 [(validate.rules).message.required = true];
 }
 
 message NotificationEventApplicationOutOfSync {
     Application application = 1 [(validate.rules).message.required = true];
-    string env_name = 2 [(validate.rules).string.min_len = 1];
+    string env_name = 2;
     ApplicationSyncState state = 3 [(validate.rules).message.required = true];
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR just removes the validations to make sure an application has the `env_id` field.
This got temporarily disabled at https://github.com/pipe-cd/pipe/pull/2918 as a workaround. While I'm in the middle of https://github.com/pipe-cd/pipe/issues/2915, this makes debugging in dev cluster easier.

**Which issue(s) this PR fixes**:

Ref https://github.com/pipe-cd/pipe/issues/2915

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
