### PR TITLE
Make Environment optional when adding an app from Git

### DIFF
--- a/pkg/app/piped/appconfigreporter/appconfigreporter.go
+++ b/pkg/app/piped/appconfigreporter/appconfigreporter.go
@@ -391,9 +391,6 @@ func (r *Reporter) readApplicationInfo(repoDir, repoID, cfgRelPath string) (*mod
 	if spec.Name == "" {
 		return nil, fmt.Errorf("missing application name: %w", errMissingRequiredField)
 	}
-	if spec.EnvName == "" {
-		return nil, fmt.Errorf("missing environment name: %w", errMissingRequiredField)
-	}
 	return &model.ApplicationInfo{
 		Name:           spec.Name,
 		Kind:           kind,

--- a/pkg/app/piped/controller/controller.go
+++ b/pkg/app/piped/controller/controller.go
@@ -465,14 +465,18 @@ func (c *controller) startNewPlanner(ctx context.Context, d *model.Deployment) (
 		}
 	}
 
-	env, err := c.environmentLister.Get(ctx, d.EnvId)
-	if err != nil {
-		return nil, err
+	var envName string
+	if d.EnvId != "" {
+		env, err := c.environmentLister.Get(ctx, d.EnvId)
+		if err != nil {
+			return nil, err
+		}
+		envName = env.Name
 	}
 
 	planner := newPlanner(
 		d,
-		env.Name,
+		envName,
 		commit,
 		workingDir,
 		c.apiClient,
@@ -611,15 +615,19 @@ func (c *controller) startNewScheduler(ctx context.Context, d *model.Deployment)
 	}
 	logger.Info("created working directory for scheduler", zap.String("working-dir", workingDir))
 
-	env, err := c.environmentLister.Get(ctx, d.EnvId)
-	if err != nil {
-		return nil, err
+	var envName string
+	if d.EnvId != "" {
+		env, err := c.environmentLister.Get(ctx, d.EnvId)
+		if err != nil {
+			return nil, err
+		}
+		envName = env.Name
 	}
 
 	// Create a new scheduler and append to the list for tracking.
 	scheduler := newScheduler(
 		d,
-		env.Name,
+		envName,
 		workingDir,
 		c.apiClient,
 		c.gitClient,

--- a/pkg/app/web/src/components/application-form/index.tsx
+++ b/pkg/app/web/src/components/application-form/index.tsx
@@ -640,8 +640,7 @@ const UnregisteredApplicationList: FC<ApplicationFormProps> = memo(
                 .filter(
                   (app) =>
                     app.pipedId === selectedPipedId &&
-                    app.kind === APPLICATION_KIND_BY_NAME[selectedKind] &&
-                    envsMap.has(app.envName)
+                    app.kind === APPLICATION_KIND_BY_NAME[selectedKind]
                 )
                 .map((app, i) => (
                   <Accordion key={app.repoId + app.path + app.configFilename}>
@@ -718,10 +717,13 @@ const UnregisteredApplicationList: FC<ApplicationFormProps> = memo(
                           color="primary"
                           type="submit"
                           onClick={() => {
+                            const envId = envsMap.has(app.envName)
+                              ? (envsMap.get(app.envName) as string)
+                              : "";
                             // NOTE: Repo remote and branch aren't needed because they are populated by API.
                             setAppToAdd({
                               name: app.name,
-                              env: envsMap.get(app.envName) as string,
+                              env: envId,
                               pipedId: app.pipedId,
                               repo: {
                                 id: app.repoId,

--- a/pkg/app/web/src/components/application-form/index.tsx
+++ b/pkg/app/web/src/components/application-form/index.tsx
@@ -717,13 +717,10 @@ const UnregisteredApplicationList: FC<ApplicationFormProps> = memo(
                           color="primary"
                           type="submit"
                           onClick={() => {
-                            const envId = envsMap.has(app.envName)
-                              ? (envsMap.get(app.envName) as string)
-                              : "";
                             // NOTE: Repo remote and branch aren't needed because they are populated by API.
                             setAppToAdd({
                               name: app.name,
-                              env: envId,
+                              env: envsMap.get(app.envName) as string | "",
                               pipedId: app.pipedId,
                               repo: {
                                 id: app.repoId,

--- a/pkg/app/web/src/components/deployments-detail-page/deployment-detail/index.tsx
+++ b/pkg/app/web/src/components/deployments-detail-page/deployment-detail/index.tsx
@@ -109,7 +109,7 @@ export const DeploymentDetail: FC<DeploymentDetailProps> = memo(
         : null
     );
 
-    if (!deployment || !env || !piped) {
+    if (!deployment || !piped) {
       return (
         <Box
           flex={1}
@@ -132,7 +132,7 @@ export const DeploymentDetail: FC<DeploymentDetailProps> = memo(
                 {DEPLOYMENT_STATE_TEXT[deployment.status]}
               </Typography>
               <Typography variant="subtitle1" className={classes.env}>
-                {env.name}
+                {env ? env.name : ""}
               </Typography>
               <Typography variant="body1" className={classes.age}>
                 {dayjs(deployment.createdAt * 1000).fromNow()}

--- a/pkg/app/web/src/components/deployments-detail-page/deployment-detail/index.tsx
+++ b/pkg/app/web/src/components/deployments-detail-page/deployment-detail/index.tsx
@@ -131,9 +131,11 @@ export const DeploymentDetail: FC<DeploymentDetailProps> = memo(
               <Typography className={classes.textMargin} variant="h6">
                 {DEPLOYMENT_STATE_TEXT[deployment.status]}
               </Typography>
-              <Typography variant="subtitle1" className={classes.env}>
-                {env ? env.name : ""}
-              </Typography>
+              {env && (
+                <Typography variant="subtitle1" className={classes.env}>
+                  {env.name}
+                </Typography>
+              )}
               <Typography variant="body1" className={classes.age}>
                 {dayjs(deployment.createdAt * 1000).fromNow()}
               </Typography>


### PR DESCRIPTION
**What this PR does / why we need it**:
With this PR, we don't need to set `envName` when adding from Git.
I've confirmed all cases where depend on env works well, except for issues that make the UI a little dirty (it can be fixed later):
![image](https://user-images.githubusercontent.com/19730728/145953600-906b79a8-f404-4790-839a-9e062839dd28.png)
![image](https://user-images.githubusercontent.com/19730728/145953654-478a8f69-316d-4f2e-a14e-8cfdb4f112d7.png)

Env is still required when registering an application from a form or Piped, but I will handle it https://github.com/pipe-cd/pipe/issues/2813.

**Which issue(s) this PR fixes**:

Ref https://github.com/pipe-cd/pipe/issues/2915

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
