### PR TITLE
Make all environment in input form optional

### DIFF
--- a/pkg/app/pipectl/cmd/application/add.go
+++ b/pkg/app/pipectl/cmd/application/add.go
@@ -64,7 +64,6 @@ func newAddCommand(root *command) *cobra.Command {
 
 	cmd.MarkFlagRequired("app-name")
 	cmd.MarkFlagRequired("app-kind")
-	cmd.MarkFlagRequired("env-id")
 	cmd.MarkFlagRequired("piped-id")
 	cmd.MarkFlagRequired("cloud-provider")
 	cmd.MarkFlagRequired("repo-id")

--- a/pkg/app/web/src/components/application-form/index.tsx
+++ b/pkg/app/web/src/components/application-form/index.tsx
@@ -380,7 +380,7 @@ export const ApplicationForm: FC<ApplicationFormProps> = memo(
                   ...emptyFormValues,
                   name: values.name,
                   kind: values.kind,
-                  env: item.value == emptyEnvName ? "" : item.value,
+                  env: item.value === emptyEnvName ? "" : item.value,
                 });
               }}
               disabled={isSubmitting || disableApplicationInfo}

--- a/pkg/app/web/src/components/application-form/index.tsx
+++ b/pkg/app/web/src/components/application-form/index.tsx
@@ -203,7 +203,7 @@ function FormSelectInput<T extends { name: string; value: string }>({
   label,
   value,
   items,
-  required,
+  required = true,
   onChange,
   disabled = false,
 }: {
@@ -211,7 +211,7 @@ function FormSelectInput<T extends { name: string; value: string }>({
   label: string;
   value: string;
   items: T[];
-  required: boolean;
+  required?: boolean;
   onChange: (value: T) => void;
   disabled?: boolean;
 }): ReactElement {
@@ -315,12 +315,11 @@ export const ApplicationForm: FC<ApplicationFormProps> = memo(
     const environments = useAppSelector(selectAllEnvs);
 
     const ps = useAppSelector((state) => selectAllPipeds(state));
-    const allPipeds = ps.filter((piped) => !piped.disabled);
 
     const pipeds = useAppSelector<Piped.AsObject[]>((state) =>
       values.env !== ""
         ? selectPipedsByEnv(state.pipeds, values.env)
-        : allPipeds
+        : ps.filter((piped) => !piped.disabled)
     );
 
     const selectedPiped = useAppSelector(selectPipedById(values.pipedId));
@@ -365,7 +364,6 @@ export const ApplicationForm: FC<ApplicationFormProps> = memo(
               name: APPLICATION_KIND_TEXT[(key as unknown) as ApplicationKind],
               value: key,
             }))}
-            required={true}
             onChange={({ value }) => setFieldValue("kind", parseInt(value, 10))}
             disabled={isSubmitting || disableApplicationInfo}
           />
@@ -378,12 +376,11 @@ export const ApplicationForm: FC<ApplicationFormProps> = memo(
               items={envItems}
               required={false}
               onChange={(item) => {
-                const value = item.value == emptyEnvName ? "" : item.value;
                 setValues({
                   ...emptyFormValues,
                   name: values.name,
                   kind: values.kind,
-                  env: value,
+                  env: item.value == emptyEnvName ? "" : item.value,
                 });
               }}
               disabled={isSubmitting || disableApplicationInfo}
@@ -406,7 +403,6 @@ export const ApplicationForm: FC<ApplicationFormProps> = memo(
                 name: `${piped.name} (${piped.id})`,
                 value: piped.id,
               }))}
-              required={true}
               disabled={isSubmitting || pipeds.length === 0}
             />
           </div>
@@ -424,7 +420,6 @@ export const ApplicationForm: FC<ApplicationFormProps> = memo(
                 })
               }
               items={repositories}
-              required={true}
               disabled={
                 selectedPiped === undefined ||
                 repositories.length === 0 ||
@@ -477,7 +472,6 @@ export const ApplicationForm: FC<ApplicationFormProps> = memo(
             value={values.cloudProvider}
             onChange={({ value }) => setFieldValue("cloudProvider", value)}
             items={cloudProviders}
-            required={true}
             disabled={
               selectedPiped === undefined ||
               cloudProviders.length === 0 ||

--- a/pkg/app/web/src/components/settings-page/piped/components/piped-form/index.tsx
+++ b/pkg/app/web/src/components/settings-page/piped/components/piped-form/index.tsx
@@ -32,7 +32,6 @@ const useStyles = makeStyles((theme) => ({
 export const validationSchema = yup.object().shape({
   name: yup.string().required(),
   desc: yup.string().required(),
-  envIds: yup.array().required().min(1),
 });
 
 export interface PipedFormValues {


### PR DESCRIPTION
**What this PR does / why we need it**:
Now we can register an Application and Piped without environments.

![image](https://user-images.githubusercontent.com/19730728/146109847-12fa573b-0588-46f4-b2e2-e0a877160d44.png)

![image](https://user-images.githubusercontent.com/19730728/146109888-ca044441-af1b-4c97-b723-835d850c10c8.png)

I've confirmed Piped works well without env.
Now the environment is just a label to identify applications and Pipeds (that means easier to replace than before).

**Which issue(s) this PR fixes**:

Fixes https://github.com/pipe-cd/pipe/issues/2813

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Environment is no longer required for Piped and application registration
```
