### PR TITLE
Add name field to all example app configs

### DIFF
--- a/examples/cloudrun/analysis/.pipe.yaml
+++ b/examples/cloudrun/analysis/.pipe.yaml
@@ -1,6 +1,7 @@
 apiVersion: pipecd.dev/v1beta1
 kind: CloudRunApp
 spec:
+  name: analysis
   pipeline:
     stages:
       # Promote new version to receive amount of traffic.

--- a/examples/cloudrun/canary/.pipe.yaml
+++ b/examples/cloudrun/canary/.pipe.yaml
@@ -2,6 +2,7 @@
 apiVersion: pipecd.dev/v1beta1
 kind: CloudRunApp
 spec:
+  name: canary
   pipeline:
     stages:
       # Promote new version to receive amount of traffic.

--- a/examples/cloudrun/secret-management/.pipe.yaml
+++ b/examples/cloudrun/secret-management/.pipe.yaml
@@ -1,6 +1,7 @@
 apiVersion: pipecd.dev/v1beta1
 kind: CloudRunApp
 spec:
+  name: secret-management
   encryption:
     encryptedSecrets:
       key: {ENCRYPTED_DATA_GENERATED_FROM_WEB}

--- a/examples/cloudrun/simple/.pipe.yaml
+++ b/examples/cloudrun/simple/.pipe.yaml
@@ -1,3 +1,5 @@
 # Quick sync by rolling out the new version and switching all traffic to it.
 apiVersion: pipecd.dev/v1beta1
 kind: CloudRunApp
+spec:
+  name: simple

--- a/examples/cloudrun/wait-approval/.pipe.yaml
+++ b/examples/cloudrun/wait-approval/.pipe.yaml
@@ -2,6 +2,7 @@
 apiVersion: pipecd.dev/v1beta1
 kind: CloudRunApp
 spec:
+  name: wait-approval
   pipeline:
     stages:
       # Promote new version to receive amount of traffic.

--- a/examples/deployment-chain/simple/.pipe.yaml
+++ b/examples/deployment-chain/simple/.pipe.yaml
@@ -1,6 +1,7 @@
 apiVersion: pipecd.dev/v1beta1
 kind: KubernetesApp
 spec:
+  name: simple
   input:
     manifests:
       - deployment.yaml

--- a/examples/ecs/bluegreen/.pipe.yaml
+++ b/examples/ecs/bluegreen/.pipe.yaml
@@ -1,6 +1,7 @@
 apiVersion: pipecd.dev/v1beta1
 kind: ECSApp
 spec:
+  name: bluegreen
   input:
     serviceDefinitionFile: servicedef.yaml
     taskDefinitionFile: taskdef.yaml

--- a/examples/ecs/canary/.pipe.yaml
+++ b/examples/ecs/canary/.pipe.yaml
@@ -1,6 +1,7 @@
 apiVersion: pipecd.dev/v1beta1
 kind: ECSApp
 spec:
+  name: canary
   input:
     serviceDefinitionFile: servicedef.yaml
     taskDefinitionFile: taskdef.yaml

--- a/examples/ecs/secret-management/.pipe.yaml
+++ b/examples/ecs/secret-management/.pipe.yaml
@@ -1,6 +1,7 @@
 apiVersion: pipecd.dev/v1beta1
 kind: ECSApp
 spec:
+  name: secret-management
   input:
     serviceDefinitionFile: servicedef.yaml
     taskDefinitionFile: taskdef.yaml

--- a/examples/ecs/simple/.pipe.yaml
+++ b/examples/ecs/simple/.pipe.yaml
@@ -1,6 +1,7 @@
 apiVersion: pipecd.dev/v1beta1
 kind: ECSApp
 spec:
+  name: simple
   input:
     serviceDefinitionFile: servicedef.yaml
     taskDefinitionFile: taskdef.yaml

--- a/examples/ecs/wait-approval/.pipe.yaml
+++ b/examples/ecs/wait-approval/.pipe.yaml
@@ -2,6 +2,7 @@
 apiVersion: pipecd.dev/v1beta1
 kind: ECSApp
 spec:
+  name: wait-approval
   pipeline:
     stages:
       # Rollout CANARY variant's workload.

--- a/examples/kubernetes/analysis-by-http/.pipe.yaml
+++ b/examples/kubernetes/analysis-by-http/.pipe.yaml
@@ -1,6 +1,7 @@
 apiVersion: pipecd.dev/v1beta1
 kind: KubernetesApp
 spec:
+  name: analysis-by-http
   pipeline:
     stages:
       - name: K8S_CANARY_ROLLOUT

--- a/examples/kubernetes/analysis-by-log/.pipe.yaml
+++ b/examples/kubernetes/analysis-by-log/.pipe.yaml
@@ -1,6 +1,7 @@
 apiVersion: pipecd.dev/v1beta1
 kind: KubernetesApp
 spec:
+  name: analysis-by-log
   pipeline:
     stages:
       - name: K8S_CANARY_ROLLOUT

--- a/examples/kubernetes/analysis-by-metrics/.pipe.yaml
+++ b/examples/kubernetes/analysis-by-metrics/.pipe.yaml
@@ -2,6 +2,7 @@ apiVersion: pipecd.dev/v1beta1
 kind: KubernetesApp
 spec:
   pipeline:
+  name: analysis-by-metrics
     stages:
       - name: K8S_CANARY_ROLLOUT
         with:

--- a/examples/kubernetes/analysis-with-baseline/.pipe.yaml
+++ b/examples/kubernetes/analysis-with-baseline/.pipe.yaml
@@ -1,6 +1,7 @@
 apiVersion: pipecd.dev/v1beta1
 kind: KubernetesApp
 spec:
+  name: analysis-with-baseline
   pipeline:
     stages:
       - name: K8S_CANARY_ROLLOUT

--- a/examples/kubernetes/bluegreen/.pipe.yaml
+++ b/examples/kubernetes/bluegreen/.pipe.yaml
@@ -2,6 +2,7 @@
 apiVersion: pipecd.dev/v1beta1
 kind: KubernetesApp
 spec:
+  name: bluegreen
   pipeline:
     stages:
       # Deploy the workloads of CANARY variant. In this case, the number of

--- a/examples/kubernetes/canary-by-config-change/.pipe.yaml
+++ b/examples/kubernetes/canary-by-config-change/.pipe.yaml
@@ -2,6 +2,7 @@
 apiVersion: pipecd.dev/v1beta1
 kind: KubernetesApp
 spec:
+  name: canary-by-config-change
   input:
     autoRollback: true
   pipeline:

--- a/examples/kubernetes/canary-patch/.pipe.yaml
+++ b/examples/kubernetes/canary-patch/.pipe.yaml
@@ -1,6 +1,7 @@
 apiVersion: pipecd.dev/v1beta1
 kind: KubernetesApp
 spec:
+  name: canary-patch
   pipeline:
     stages:
       # Deploy the workloads of CANARY variant. In this case, the replicas number

--- a/examples/kubernetes/canary/.pipe.yaml
+++ b/examples/kubernetes/canary/.pipe.yaml
@@ -2,6 +2,7 @@
 apiVersion: pipecd.dev/v1beta1
 kind: KubernetesApp
 spec:
+  name: canary
   pipeline:
     stages:
       # Deploy the workloads of CANARY variant. In this case, the number of

--- a/examples/kubernetes/helm-local-chart/.pipe.yaml
+++ b/examples/kubernetes/helm-local-chart/.pipe.yaml
@@ -3,8 +3,11 @@
 apiVersion: pipecd.dev/v1beta1
 kind: KubernetesApp
 spec:
-  triggerPaths:
-    - local-modules/helm-charts/helloworld/*
+  name: helm-local-chart
+  trigger:
+    onCommit:
+      paths:
+        - local-modules/helm-charts/helloworld/*
   input:
     # Helm chart sourced from current Git repo.
     helmChart:

--- a/examples/kubernetes/helm-remote-chart/.pipe.yaml
+++ b/examples/kubernetes/helm-remote-chart/.pipe.yaml
@@ -2,6 +2,7 @@
 apiVersion: pipecd.dev/v1beta1
 kind: KubernetesApp
 spec:
+  name: helm-remote-chart
   input:
     # Helm chart sourced from a Helm Chart Repository.
     helmChart:

--- a/examples/kubernetes/helm-remote-git-chart/.pipe.yaml
+++ b/examples/kubernetes/helm-remote-git-chart/.pipe.yaml
@@ -3,6 +3,7 @@
 apiVersion: pipecd.dev/v1beta1
 kind: KubernetesApp
 spec:
+  name: helm-remote-git-chart
   input:
     # Helm chart sourced from another Git repository.
     helmChart:

--- a/examples/kubernetes/kustomize-local-base/.pipe.yaml
+++ b/examples/kubernetes/kustomize-local-base/.pipe.yaml
@@ -3,7 +3,10 @@
 apiVersion: pipecd.dev/v1beta1
 kind: KubernetesApp
 spec:
-  triggerPaths:
-    - local-modules/kustomize-bases/helloworld/*
+  name: kustomize-local-base
+  trigger:
+    onCommit:
+      paths:
+        - local-modules/kustomize-bases/helloworld/*
   input:
     kustomizeVersion: 3.5.5

--- a/examples/kubernetes/kustomize-remote-base/.pipe.yaml
+++ b/examples/kubernetes/kustomize-remote-base/.pipe.yaml
@@ -3,5 +3,6 @@
 apiVersion: pipecd.dev/v1beta1
 kind: KubernetesApp
 spec:
+  name: kustomize-remote-base
   input:
     kustomizeVersion: 3.5.5

--- a/examples/kubernetes/mesh-istio-bluegreen/.pipe.yaml
+++ b/examples/kubernetes/mesh-istio-bluegreen/.pipe.yaml
@@ -1,6 +1,7 @@
 apiVersion: pipecd.dev/v1beta1
 kind: KubernetesApp
 spec:
+  name: mesh-istio-bluegreen
   pipeline:
     stages:
       # Deploy the workloads of CANARY variant. In this case, the number of

--- a/examples/kubernetes/mesh-istio-canary/.pipe.yaml
+++ b/examples/kubernetes/mesh-istio-canary/.pipe.yaml
@@ -1,6 +1,7 @@
 apiVersion: pipecd.dev/v1beta1
 kind: KubernetesApp
 spec:
+  name: mesh-istio-canary
   pipeline:
     stages:
       # Deploy the workloads of CANARY variant. In this case, the number of

--- a/examples/kubernetes/multi-steps-canary/.pipe.yaml
+++ b/examples/kubernetes/multi-steps-canary/.pipe.yaml
@@ -4,6 +4,7 @@
 apiVersion: pipecd.dev/v1beta1
 kind: KubernetesApp
 spec:
+  name: multi-steps-canary
   pipeline:
     stages:
       - name: K8S_CANARY_ROLLOUT

--- a/examples/kubernetes/secret-management/.pipe.yaml
+++ b/examples/kubernetes/secret-management/.pipe.yaml
@@ -1,6 +1,7 @@
 apiVersion: pipecd.dev/v1beta1
 kind: KubernetesApp
 spec:
+  name: secret-management
   input:
     manifests:
       - deployment.yaml

--- a/examples/kubernetes/simple/.pipe.yaml
+++ b/examples/kubernetes/simple/.pipe.yaml
@@ -3,6 +3,7 @@
 apiVersion: pipecd.dev/v1beta1
 kind: KubernetesApp
 spec:
+  name: simple
   input:
     manifests:
       - deployment.yaml

--- a/examples/kubernetes/wait-approval/.pipe.yaml
+++ b/examples/kubernetes/wait-approval/.pipe.yaml
@@ -3,6 +3,7 @@
 apiVersion: pipecd.dev/v1beta1
 kind: KubernetesApp
 spec:
+  name: wait-approval
   pipeline:
     stages:
       - name: K8S_CANARY_ROLLOUT

--- a/examples/lambda/analysis/.pipe.yaml
+++ b/examples/lambda/analysis/.pipe.yaml
@@ -4,6 +4,7 @@
 apiVersion: pipecd.dev/v1beta1
 kind: LambdaApp
 spec:
+  name: analysis
   pipeline:
     stages:
       # Deploy workloads of the new version.

--- a/examples/lambda/canary/.pipe.yaml
+++ b/examples/lambda/canary/.pipe.yaml
@@ -4,6 +4,7 @@
 apiVersion: pipecd.dev/v1beta1
 kind: LambdaApp
 spec:
+  name: canary
   pipeline:
     stages:
       # Deploy workloads of the new version.

--- a/examples/lambda/remote-git/.pipe.yaml
+++ b/examples/lambda/remote-git/.pipe.yaml
@@ -2,3 +2,5 @@
 # https://docs.aws.amazon.com/lambda/latest/dg/configuration-versions.html
 apiVersion: pipecd.dev/v1beta1
 kind: LambdaApp
+spec:
+  name: remote-git

--- a/examples/lambda/secret-management/.pipe.yaml
+++ b/examples/lambda/secret-management/.pipe.yaml
@@ -1,6 +1,7 @@
 apiVersion: pipecd.dev/v1beta1
 kind: LambdaApp
 spec:
+  name: secret-management
   encryption:
     encryptedSecrets:
       key: {ENCRYPTED_DATA_GENERATED_FROM_WEB}

--- a/examples/lambda/simple/.pipe.yaml
+++ b/examples/lambda/simple/.pipe.yaml
@@ -2,3 +2,5 @@
 # https://docs.aws.amazon.com/lambda/latest/dg/configuration-versions.html
 apiVersion: pipecd.dev/v1beta1
 kind: LambdaApp
+spec:
+  name: simple

--- a/examples/lambda/wait-approval/.pipe.yaml
+++ b/examples/lambda/wait-approval/.pipe.yaml
@@ -2,6 +2,7 @@
 apiVersion: pipecd.dev/v1beta1
 kind: LambdaApp
 spec:
+  name: wait-approval
   pipeline:
     stages:
       # Deploy workloads of the new version.

--- a/examples/lambda/zip-packing-s3/.pipe.yaml
+++ b/examples/lambda/zip-packing-s3/.pipe.yaml
@@ -2,3 +2,5 @@
 # https://docs.aws.amazon.com/lambda/latest/dg/configuration-versions.html
 apiVersion: pipecd.dev/v1beta1
 kind: LambdaApp
+spec:
+  name: zip-packing-s3

--- a/examples/terraform/autorollback/.pipe.yaml
+++ b/examples/terraform/autorollback/.pipe.yaml
@@ -2,6 +2,7 @@
 apiVersion: pipecd.dev/v1beta1
 kind: TerraformApp
 spec:
+  name: autorollback
   input:
     autoRollback: true
   encryption:

--- a/examples/terraform/local-module/.pipe.yaml
+++ b/examples/terraform/local-module/.pipe.yaml
@@ -1,3 +1,5 @@
 # Deploy applicaiton that using local terraform models from the same Git repository.
 apiVersion: pipecd.dev/v1beta1
 kind: TerraformApp
+spec:
+  name: local-module

--- a/examples/terraform/remote-module/.pipe.yaml
+++ b/examples/terraform/remote-module/.pipe.yaml
@@ -1,3 +1,5 @@
 # Deploy application that using remote terraform modules from other Git repositories.
 apiVersion: pipecd.dev/v1beta1
 kind: TerraformApp
+spec:
+  name: remote-module

--- a/examples/terraform/secret-management/.pipe.yaml
+++ b/examples/terraform/secret-management/.pipe.yaml
@@ -1,6 +1,7 @@
 apiVersion: pipecd.dev/v1beta1
 kind: TerraformApp
 spec:
+  name: secret-management
   encryption:
     encryptedSecrets:
       serviceAccount: {ENCRYPTED_DATA_GENERATED_FROM_WEB}

--- a/examples/terraform/simple/.pipe.yaml
+++ b/examples/terraform/simple/.pipe.yaml
@@ -2,6 +2,7 @@
 apiVersion: pipecd.dev/v1beta1
 kind: TerraformApp
 spec:
+  name: simple
   input:
     terraformVersion: 1.0.10
   encryption:

--- a/examples/terraform/wait-approval/.pipe.yaml
+++ b/examples/terraform/wait-approval/.pipe.yaml
@@ -2,6 +2,7 @@
 apiVersion: pipecd.dev/v1beta1
 kind: TerraformApp
 spec:
+  name: wait-approval
   input:
     workspace: dev
     terraformVersion: 1.0.10


### PR DESCRIPTION
**What this PR does / why we need it**:
With it, those who try PipeCD using examples can register an app without manual input.
This PR also fixes places where use deprecated fields like `triggerPaths`.

**Which issue(s) this PR fixes**:

Ref https://github.com/pipe-cd/pipe/pull/2935#issuecomment-993399168

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
