### PR TITLE
Change the default app config name to "app.pipecd.yaml"

### DIFF
--- a/docs/content/en/docs-dev/concepts/_index.md
+++ b/docs/content/en/docs-dev/concepts/_index.md
@@ -47,11 +47,11 @@ When the deployment is success, it means the running state is synced with the de
 
 A yaml file that contains configuration data to define how to deploy the application.
 Each application requires one application configuration file at application directory in the Git repository.
-The default file name is `.pipe.yaml`.
+The default file name is `app.pipecd.yaml`.
 
 ### Application Directory
 
-A directory in Git repository containing application configuration file (`.pipe.yaml`) and application manifests.
+A directory in Git repository containing application configuration file and application manifests.
 Each application must have one application directory.
 
 ### Quick Sync

--- a/docs/content/en/docs-dev/operator-manual/piped/adding-a-git-repository.md
+++ b/docs/content/en/docs-dev/operator-manual/piped/adding-a-git-repository.md
@@ -8,7 +8,7 @@ description: >
 
 In the `piped` configuration file, we specify the list of Git repositories should be handled by the `piped`.
 A Git repository contains one or more deployable applications where each application is put inside a directory called as [application directory](/docs/concepts/#application-configuration-directory).
-That directory contains a application configuration file (.pipe.yaml) as well as application manifests.
+That directory contains an application configuration file as well as application manifests.
 The `piped` periodically checks the new commits and fetches the needed manifests from those repositories for executing the deployment.
 
 A single `piped` can be configured to handle one or more Git repositories.

--- a/docs/content/en/docs-dev/operator-manual/piped/adding-helm-chart-repository.md
+++ b/docs/content/en/docs-dev/operator-manual/piped/adding-helm-chart-repository.md
@@ -24,7 +24,7 @@ spec:
 For example, the above snippet enables the official chart repository of PipeCD project. After that, you can configure the Kubernetes application to load a chart from that chart repository for executing the deployment.
 
 ``` yaml
-# .pipe.yaml
+# Application configuration file.
 apiVersion: pipecd.dev/v1beta1
 kind: KubernetesApp
 spec:

--- a/docs/content/en/docs-dev/user-guide/command-line-tool.md
+++ b/docs/content/en/docs-dev/user-guide/command-line-tool.md
@@ -114,7 +114,7 @@ Flags:
       --app-kind string           The kind of application. (KUBERNETES|TERRAFORM|LAMBDA|CLOUDRUN)
       --app-name string           The application name.
       --cloud-provider string     The cloud provider name. One of the registered providers in the piped configuration.
-      --config-file-name string   The configuration file name. Default is .pipe.yaml (default ".pipe.yaml")
+      --config-file-name string   The configuration file name. (default "app.pipecd.yaml")
       --env-id string             The ID of environment where this application should belong to.
   -h, --help                      help for add
       --piped-id string           The ID of piped that should handle this applicaiton.

--- a/docs/content/en/docs-dev/user-guide/event-watcher.md
+++ b/docs/content/en/docs-dev/user-guide/event-watcher.md
@@ -128,7 +128,7 @@ spec:
         env: dev
         appName: helloworld
       replacements:
-        - file: helloworld/.pipe.yaml
+        - file: helloworld/app.pipecd.yaml
           yamlField: $.spec.input.helmChart.version
 ```
 

--- a/docs/content/en/docs-dev/user-guide/examples/k8s-app-bluegreen-with-istio.md
+++ b/docs/content/en/docs-dev/user-guide/examples/k8s-app-bluegreen-with-istio.md
@@ -62,7 +62,7 @@ spec:
 
 ## Enabling blue-green strategy
 
-- Add the following `.pipe.yaml` file into the application directory in the Git repository.
+- Add the following application configuration file into the application directory in the Git repository.
 
 ``` yaml
 apiVersion: pipecd.dev/v1beta1
@@ -99,7 +99,7 @@ Deployment Details Page
 
 ## Understanding what happened
 
-In this example, you configured the application configuration file (`.pipe.yaml`) to switch all traffic from an old to a new version of the application using Istio's weighted routing feature.
+In this example, you configured the application configuration file to switch all traffic from an old to a new version of the application using Istio's weighted routing feature.
 
 - Stage 1: `K8S_CANARY_ROLLOUT` ensures that the workloads of canary variant (new version) should be deployed. But at this time, they still handle nothing, all traffic is handled by workloads of primary variant.
 The number of workloads (e.g. pod) for canary variant is configured to be 100% of the replicas number of primary varant.

--- a/docs/content/en/docs-dev/user-guide/examples/k8s-app-canary-with-istio.md
+++ b/docs/content/en/docs-dev/user-guide/examples/k8s-app-canary-with-istio.md
@@ -60,7 +60,7 @@ spec:
 
 ## Enabling canary strategy
 
-- Add the following `.pipe.yaml` file into the application directory in Git.
+- Add the following application configuration file into the application directory in Git.
 
 ``` yaml
 apiVersion: pipecd.dev/v1beta1
@@ -98,7 +98,7 @@ Deployment Details Page
 
 ## Understanding what happened
 
-In this example, you configured the application configuration file (`.pipe.yaml`) to migrate traffic from an old to a new version of the application using Istio's weighted routing feature.
+In this example, you configured the application configuration file to migrate traffic from an old to a new version of the application using Istio's weighted routing feature.
 
 - Stage 1: `K8S_CANARY_ROLLOUT` ensures that the workloads of canary variant (new version) should be deployed. But at this time, they still handle nothing, all traffic are handled by workloads of primary variant.
 The number of workloads (e.g. pod) for canary variant is configured to be 50% of the replicas number of primary varant.

--- a/docs/content/en/docs-dev/user-guide/examples/k8s-app-canary-with-pod-selector.md
+++ b/docs/content/en/docs-dev/user-guide/examples/k8s-app-canary-with-pod-selector.md
@@ -63,7 +63,7 @@ spec:
 
 In PipeCD context, manifests defined in Git are the manifests for primary variant, so please note to ensure that your deployment manifest contains `pipecd.dev/variant: primary` label and selector in the spec.
 
-To enable canary strategy for this Kubernetes application, you will update your `.pipe.yaml` file to be as below:
+To enable canary strategy for this Kubernetes application, you will update your application configuration file to be as below:
 
 ``` yaml
 apiVersion: pipecd.dev/v1beta1

--- a/docs/content/en/docs-dev/user-guide/secret-management.md
+++ b/docs/content/en/docs-dev/user-guide/secret-management.md
@@ -66,7 +66,7 @@ The form for encrypting secret data
 
 ## Storing encrypted secrets in Git
 
-To make encrypted secrets available to an application, they must be specified in the `.pipe.yaml` file of that application.
+To make encrypted secrets available to an application, they must be specified in the application configuration file of that application.
 
 - `encryptedSecrets` contains a list of the encrypted secrets.
 - `decryptionTargets` contains a list of files that are using one of the encrypted secrets and should be decrypted by `Piped`.
@@ -85,7 +85,7 @@ spec:
 
 ## Accessing encrypted secrets
 
-Any file in the application directory can use `.encryptedSecrets` context to access secrets you have encrypted and stored in `.pipe.yaml`.
+Any file in the application directory can use `.encryptedSecrets` context to access secrets you have encrypted and stored in the application configuration.
 
 For example,
 

--- a/pkg/app/pipectl/cmd/application/add.go
+++ b/pkg/app/pipectl/cmd/application/add.go
@@ -59,7 +59,7 @@ func newAddCommand(root *command) *cobra.Command {
 
 	cmd.Flags().StringVar(&c.repoID, "repo-id", c.repoID, "The repository ID. One the registered repositories in the piped configuration.")
 	cmd.Flags().StringVar(&c.appDir, "app-dir", c.appDir, "The relative path from the root of repository to the application directory.")
-	cmd.Flags().StringVar(&c.configFileName, "config-file-name", c.configFileName, "The configuration file name. Default is .pipe.yaml")
+	cmd.Flags().StringVar(&c.configFileName, "config-file-name", c.configFileName, "The configuration file name")
 	cmd.Flags().StringVar(&c.description, "description", c.description, "The description of the application.")
 
 	cmd.MarkFlagRequired("app-name")

--- a/pkg/app/piped/appconfigreporter/appconfigreporter_test.go
+++ b/pkg/app/piped/appconfigreporter/appconfigreporter_test.go
@@ -62,7 +62,8 @@ func TestReporter_findRegisteredApps(t *testing.T) {
 			name: "no app registered in the repo",
 			reporter: &Reporter{
 				applicationLister: &fakeApplicationLister{apps: []*model.Application{
-					{Id: "id-1", Name: "app-1", Labels: map[string]string{"key-1": "value-1"}, GitPath: &model.ApplicationGitPath{Repo: &model.ApplicationGitRepository{Id: "different-repo"}, Path: "app-1", ConfigFilename: ".pipe.yaml"}},
+					{Id: "id-1", Name: "app-1", Labels: map[string]string{"key-1": "value-1"}, GitPath: &model.ApplicationGitPath{Repo: &model.ApplicationGitRepository{Id: "different-repo"}, Path: "app-1", ConfigFilename: "app.pipecd.yaml" +
+						""}},
 				}},
 				logger: zap.NewNop(),
 			},
@@ -77,10 +78,12 @@ func TestReporter_findRegisteredApps(t *testing.T) {
 			name: "invalid app config is contained",
 			reporter: &Reporter{
 				applicationLister: &fakeApplicationLister{apps: []*model.Application{
-					{Id: "id-1", Name: "app-1", Labels: map[string]string{"key-1": "value-1"}, GitPath: &model.ApplicationGitPath{Repo: &model.ApplicationGitRepository{Id: "repo-1"}, Path: "app-1", ConfigFilename: ".pipe.yaml"}},
+					{Id: "id-1", Name: "app-1", Labels: map[string]string{"key-1": "value-1"}, GitPath: &model.ApplicationGitPath{Repo: &model.ApplicationGitRepository{Id: "repo-1"}, Path: "app-1", ConfigFilename: "app.pipecd.yaml" +
+						""}},
 				}},
 				fileSystem: fstest.MapFS{
-					"path/to/repo-1/app-1/.pipe.yaml": &fstest.MapFile{Data: []byte("invalid-text")},
+					"path/to/repo-1/app-1/app.pipecd.yaml" +
+						"": &fstest.MapFile{Data: []byte("invalid-text")},
 				},
 				logger: zap.NewNop(),
 			},
@@ -96,10 +99,12 @@ func TestReporter_findRegisteredApps(t *testing.T) {
 			reporter: &Reporter{
 				config: &config.PipedSpec{PipedID: "piped-1"},
 				applicationLister: &fakeApplicationLister{apps: []*model.Application{
-					{Id: "id-1", Name: "app-1", Labels: map[string]string{"key-1": "value-1"}, GitPath: &model.ApplicationGitPath{Repo: &model.ApplicationGitRepository{Id: "repo-1"}, Path: "app-1", ConfigFilename: ".pipe.yaml"}},
+					{Id: "id-1", Name: "app-1", Labels: map[string]string{"key-1": "value-1"}, GitPath: &model.ApplicationGitPath{Repo: &model.ApplicationGitRepository{Id: "repo-1"}, Path: "app-1", ConfigFilename: "app.pipecd.yaml" +
+						""}},
 				}},
 				fileSystem: fstest.MapFS{
-					"path/to/repo-1/app-1/.pipe.yaml": &fstest.MapFile{Data: []byte(`
+					"path/to/repo-1/app-1/app.pipecd.yaml" +
+						"": &fstest.MapFile{Data: []byte(`
 apiVersion: pipecd.dev/v1beta1
 kind: KubernetesApp
 spec:
@@ -122,10 +127,12 @@ spec:
 			reporter: &Reporter{
 				config: &config.PipedSpec{PipedID: "piped-1"},
 				applicationLister: &fakeApplicationLister{apps: []*model.Application{
-					{Id: "id-1", Name: "app-1", Labels: map[string]string{"key-1": "value-1"}, GitPath: &model.ApplicationGitPath{Repo: &model.ApplicationGitRepository{Id: "repo-1"}, Path: "app-1", ConfigFilename: ".pipe.yaml"}},
+					{Id: "id-1", Name: "app-1", Labels: map[string]string{"key-1": "value-1"}, GitPath: &model.ApplicationGitPath{Repo: &model.ApplicationGitRepository{Id: "repo-1"}, Path: "app-1", ConfigFilename: "app.pipecd.yaml" +
+						""}},
 				}},
 				fileSystem: fstest.MapFS{
-					"path/to/repo-1/app-1/.pipe.yaml": &fstest.MapFile{Data: []byte(`
+					"path/to/repo-1/app-1/app.pipecd.yaml" +
+						"": &fstest.MapFile{Data: []byte(`
 apiVersion: pipecd.dev/v1beta1
 kind: KubernetesApp
 spec:
@@ -142,14 +149,15 @@ spec:
 			},
 			want: []*model.ApplicationInfo{
 				{
-					Id:             "id-1",
-					Name:           "new-app-1",
-					Labels:         map[string]string{"key-1": "value-1"},
-					RepoId:         "repo-1",
-					Path:           "app-1",
-					ConfigFilename: ".pipe.yaml",
-					PipedId:        "piped-1",
-					EnvName:        "dev",
+					Id:     "id-1",
+					Name:   "new-app-1",
+					Labels: map[string]string{"key-1": "value-1"},
+					RepoId: "repo-1",
+					Path:   "app-1",
+					ConfigFilename: "app.pipecd.yaml" +
+						"",
+					PipedId: "piped-1",
+					EnvName: "dev",
 				},
 			},
 			wantErr: false,
@@ -181,7 +189,8 @@ func TestReporter_findUnregisteredApps(t *testing.T) {
 			reporter: &Reporter{
 				applicationLister: &fakeApplicationLister{},
 				fileSystem: fstest.MapFS{
-					"path/to/repo-1/app-1/.pipe.yaml": &fstest.MapFile{Data: []byte("")},
+					"path/to/repo-1/app-1/app.pipecd.yaml" +
+						"": &fstest.MapFile{Data: []byte("")},
 				},
 				logger: zap.NewNop(),
 			},
@@ -198,7 +207,8 @@ func TestReporter_findUnregisteredApps(t *testing.T) {
 			reporter: &Reporter{
 				applicationLister: &fakeApplicationLister{},
 				fileSystem: fstest.MapFS{
-					"path/to/repo-1/app-1/.pipe.yaml": &fstest.MapFile{Data: []byte("")},
+					"path/to/repo-1/app-1/app.pipecd.yaml" +
+						"": &fstest.MapFile{Data: []byte("")},
 				},
 				logger: zap.NewNop(),
 			},
@@ -206,7 +216,8 @@ func TestReporter_findUnregisteredApps(t *testing.T) {
 				repoPath: "path/to/repo-1",
 				repoID:   "repo-1",
 				registeredAppPaths: map[string]string{
-					"repo-1:app-1/.pipe.yaml": "id-1",
+					"repo-1:app-1/app.pipecd.yaml" +
+						"": "id-1",
 				},
 			},
 			want:    []*model.ApplicationInfo{},
@@ -217,7 +228,8 @@ func TestReporter_findUnregisteredApps(t *testing.T) {
 			reporter: &Reporter{
 				applicationLister: &fakeApplicationLister{},
 				fileSystem: fstest.MapFS{
-					"path/to/repo-1/app-1/.pipe.yaml": &fstest.MapFile{Data: []byte("invalid-text")},
+					"path/to/repo-1/app-1/app.pipecd.yaml" +
+						"": &fstest.MapFile{Data: []byte("invalid-text")},
 				},
 				logger: zap.NewNop(),
 			},
@@ -235,7 +247,8 @@ func TestReporter_findUnregisteredApps(t *testing.T) {
 				config:            &config.PipedSpec{PipedID: "piped-1"},
 				applicationLister: &fakeApplicationLister{},
 				fileSystem: fstest.MapFS{
-					"path/to/repo-1/app-1/.pipe.yaml": &fstest.MapFile{Data: []byte(`
+					"path/to/repo-1/app-1/app.pipecd.yaml" +
+						"": &fstest.MapFile{Data: []byte(`
 apiVersion: pipecd.dev/v1beta1
 kind: KubernetesApp
 spec:
@@ -253,13 +266,14 @@ spec:
 			},
 			want: []*model.ApplicationInfo{
 				{
-					Name:           "app-1",
-					Labels:         map[string]string{"key-1": "value-1"},
-					RepoId:         "repo-1",
-					Path:           "app-1",
-					ConfigFilename: ".pipe.yaml",
-					PipedId:        "piped-1",
-					EnvName:        "dev",
+					Name:   "app-1",
+					Labels: map[string]string{"key-1": "value-1"},
+					RepoId: "repo-1",
+					Path:   "app-1",
+					ConfigFilename: "app.pipecd.yaml" +
+						"",
+					PipedId: "piped-1",
+					EnvName: "dev",
 				},
 			},
 			wantErr: false,

--- a/pkg/app/piped/appconfigreporter/appconfigreporter_test.go
+++ b/pkg/app/piped/appconfigreporter/appconfigreporter_test.go
@@ -62,8 +62,7 @@ func TestReporter_findRegisteredApps(t *testing.T) {
 			name: "no app registered in the repo",
 			reporter: &Reporter{
 				applicationLister: &fakeApplicationLister{apps: []*model.Application{
-					{Id: "id-1", Name: "app-1", Labels: map[string]string{"key-1": "value-1"}, GitPath: &model.ApplicationGitPath{Repo: &model.ApplicationGitRepository{Id: "different-repo"}, Path: "app-1", ConfigFilename: "app.pipecd.yaml" +
-						""}},
+					{Id: "id-1", Name: "app-1", Labels: map[string]string{"key-1": "value-1"}, GitPath: &model.ApplicationGitPath{Repo: &model.ApplicationGitRepository{Id: "different-repo"}, Path: "app-1", ConfigFilename: "app.pipecd.yaml"}},
 				}},
 				logger: zap.NewNop(),
 			},
@@ -78,12 +77,10 @@ func TestReporter_findRegisteredApps(t *testing.T) {
 			name: "invalid app config is contained",
 			reporter: &Reporter{
 				applicationLister: &fakeApplicationLister{apps: []*model.Application{
-					{Id: "id-1", Name: "app-1", Labels: map[string]string{"key-1": "value-1"}, GitPath: &model.ApplicationGitPath{Repo: &model.ApplicationGitRepository{Id: "repo-1"}, Path: "app-1", ConfigFilename: "app.pipecd.yaml" +
-						""}},
+					{Id: "id-1", Name: "app-1", Labels: map[string]string{"key-1": "value-1"}, GitPath: &model.ApplicationGitPath{Repo: &model.ApplicationGitRepository{Id: "repo-1"}, Path: "app-1", ConfigFilename: "app.pipecd.yaml"}},
 				}},
 				fileSystem: fstest.MapFS{
-					"path/to/repo-1/app-1/app.pipecd.yaml" +
-						"": &fstest.MapFile{Data: []byte("invalid-text")},
+					"path/to/repo-1/app-1/app.pipecd.yaml": &fstest.MapFile{Data: []byte("invalid-text")},
 				},
 				logger: zap.NewNop(),
 			},
@@ -99,12 +96,10 @@ func TestReporter_findRegisteredApps(t *testing.T) {
 			reporter: &Reporter{
 				config: &config.PipedSpec{PipedID: "piped-1"},
 				applicationLister: &fakeApplicationLister{apps: []*model.Application{
-					{Id: "id-1", Name: "app-1", Labels: map[string]string{"key-1": "value-1"}, GitPath: &model.ApplicationGitPath{Repo: &model.ApplicationGitRepository{Id: "repo-1"}, Path: "app-1", ConfigFilename: "app.pipecd.yaml" +
-						""}},
+					{Id: "id-1", Name: "app-1", Labels: map[string]string{"key-1": "value-1"}, GitPath: &model.ApplicationGitPath{Repo: &model.ApplicationGitRepository{Id: "repo-1"}, Path: "app-1", ConfigFilename: "app.pipecd.yaml"}},
 				}},
 				fileSystem: fstest.MapFS{
-					"path/to/repo-1/app-1/app.pipecd.yaml" +
-						"": &fstest.MapFile{Data: []byte(`
+					"path/to/repo-1/app-1/app.pipecd.yaml": &fstest.MapFile{Data: []byte(`
 apiVersion: pipecd.dev/v1beta1
 kind: KubernetesApp
 spec:
@@ -127,12 +122,10 @@ spec:
 			reporter: &Reporter{
 				config: &config.PipedSpec{PipedID: "piped-1"},
 				applicationLister: &fakeApplicationLister{apps: []*model.Application{
-					{Id: "id-1", Name: "app-1", Labels: map[string]string{"key-1": "value-1"}, GitPath: &model.ApplicationGitPath{Repo: &model.ApplicationGitRepository{Id: "repo-1"}, Path: "app-1", ConfigFilename: "app.pipecd.yaml" +
-						""}},
+					{Id: "id-1", Name: "app-1", Labels: map[string]string{"key-1": "value-1"}, GitPath: &model.ApplicationGitPath{Repo: &model.ApplicationGitRepository{Id: "repo-1"}, Path: "app-1", ConfigFilename: "app.pipecd.yaml"}},
 				}},
 				fileSystem: fstest.MapFS{
-					"path/to/repo-1/app-1/app.pipecd.yaml" +
-						"": &fstest.MapFile{Data: []byte(`
+					"path/to/repo-1/app-1/app.pipecd.yaml": &fstest.MapFile{Data: []byte(`
 apiVersion: pipecd.dev/v1beta1
 kind: KubernetesApp
 spec:
@@ -149,15 +142,14 @@ spec:
 			},
 			want: []*model.ApplicationInfo{
 				{
-					Id:     "id-1",
-					Name:   "new-app-1",
-					Labels: map[string]string{"key-1": "value-1"},
-					RepoId: "repo-1",
-					Path:   "app-1",
-					ConfigFilename: "app.pipecd.yaml" +
-						"",
-					PipedId: "piped-1",
-					EnvName: "dev",
+					Id:             "id-1",
+					Name:           "new-app-1",
+					Labels:         map[string]string{"key-1": "value-1"},
+					RepoId:         "repo-1",
+					Path:           "app-1",
+					ConfigFilename: "app.pipecd.yaml",
+					PipedId:        "piped-1",
+					EnvName:        "dev",
 				},
 			},
 			wantErr: false,
@@ -189,8 +181,7 @@ func TestReporter_findUnregisteredApps(t *testing.T) {
 			reporter: &Reporter{
 				applicationLister: &fakeApplicationLister{},
 				fileSystem: fstest.MapFS{
-					"path/to/repo-1/app-1/app.pipecd.yaml" +
-						"": &fstest.MapFile{Data: []byte("")},
+					"path/to/repo-1/app-1/app.pipecd.yaml": &fstest.MapFile{Data: []byte("")},
 				},
 				logger: zap.NewNop(),
 			},
@@ -207,8 +198,7 @@ func TestReporter_findUnregisteredApps(t *testing.T) {
 			reporter: &Reporter{
 				applicationLister: &fakeApplicationLister{},
 				fileSystem: fstest.MapFS{
-					"path/to/repo-1/app-1/app.pipecd.yaml" +
-						"": &fstest.MapFile{Data: []byte("")},
+					"path/to/repo-1/app-1/app.pipecd.yaml": &fstest.MapFile{Data: []byte("")},
 				},
 				logger: zap.NewNop(),
 			},
@@ -216,8 +206,7 @@ func TestReporter_findUnregisteredApps(t *testing.T) {
 				repoPath: "path/to/repo-1",
 				repoID:   "repo-1",
 				registeredAppPaths: map[string]string{
-					"repo-1:app-1/app.pipecd.yaml" +
-						"": "id-1",
+					"repo-1:app-1/app.pipecd.yaml": "id-1",
 				},
 			},
 			want:    []*model.ApplicationInfo{},
@@ -228,8 +217,7 @@ func TestReporter_findUnregisteredApps(t *testing.T) {
 			reporter: &Reporter{
 				applicationLister: &fakeApplicationLister{},
 				fileSystem: fstest.MapFS{
-					"path/to/repo-1/app-1/app.pipecd.yaml" +
-						"": &fstest.MapFile{Data: []byte("invalid-text")},
+					"path/to/repo-1/app-1/app.pipecd.yaml": &fstest.MapFile{Data: []byte("invalid-text")},
 				},
 				logger: zap.NewNop(),
 			},
@@ -247,8 +235,7 @@ func TestReporter_findUnregisteredApps(t *testing.T) {
 				config:            &config.PipedSpec{PipedID: "piped-1"},
 				applicationLister: &fakeApplicationLister{},
 				fileSystem: fstest.MapFS{
-					"path/to/repo-1/app-1/app.pipecd.yaml" +
-						"": &fstest.MapFile{Data: []byte(`
+					"path/to/repo-1/app-1/app.pipecd.yaml": &fstest.MapFile{Data: []byte(`
 apiVersion: pipecd.dev/v1beta1
 kind: KubernetesApp
 spec:
@@ -266,14 +253,13 @@ spec:
 			},
 			want: []*model.ApplicationInfo{
 				{
-					Name:   "app-1",
-					Labels: map[string]string{"key-1": "value-1"},
-					RepoId: "repo-1",
-					Path:   "app-1",
-					ConfigFilename: "app.pipecd.yaml" +
-						"",
-					PipedId: "piped-1",
-					EnvName: "dev",
+					Name:           "app-1",
+					Labels:         map[string]string{"key-1": "value-1"},
+					RepoId:         "repo-1",
+					Path:           "app-1",
+					ConfigFilename: "app.pipecd.yaml",
+					PipedId:        "piped-1",
+					EnvName:        "dev",
 				},
 			},
 			wantErr: false,

--- a/pkg/app/piped/cloudprovider/kubernetes/manifest.go
+++ b/pkg/app/piped/cloudprovider/kubernetes/manifest.go
@@ -183,7 +183,7 @@ func LoadPlainYAMLManifests(dir string, names []string, configFileName string) (
 			if ext != ".yaml" && ext != ".yml" && ext != ".json" {
 				return nil
 			}
-			if f.Name() == model.DefaultApplicationConfigFilename {
+			if model.IsApplicationConfigFile(f.Name()) {
 				return nil
 			}
 			if f.Name() == configFileName {

--- a/pkg/app/web/src/components/application-form/index.tsx
+++ b/pkg/app/web/src/components/application-form/index.tsx
@@ -286,7 +286,7 @@ export const emptyFormValues: ApplicationFormValue = {
   kind: ApplicationKind.KUBERNETES,
   pipedId: "",
   repoPath: "",
-  configFilename: ".pipe.yaml",
+  configFilename: "app.pipecd.yaml",
   cloudProvider: "",
   repo: {
     id: "",

--- a/pkg/app/web/src/components/applications-page/add-application-drawer/index.test.tsx
+++ b/pkg/app/web/src/components/applications-page/add-application-drawer/index.test.tsx
@@ -71,7 +71,7 @@ describe("AddApplicationDrawer", () => {
             meta: expect.objectContaining({
               arg: {
                 cloudProvider: "terraform-default",
-                configFilename: ".pipe.yaml",
+                configFilename: "app.pipecd.yaml",
                 env: dummyEnv.id,
                 kind: ApplicationKind.TERRAFORM,
                 name: "App",

--- a/pkg/model/application.go
+++ b/pkg/model/application.go
@@ -21,13 +21,16 @@ import (
 )
 
 const (
-	DefaultApplicationConfigFilename = ".pipe.yaml"
-	applicationConfigFileExtention   = ".pipecd.yaml"
+	DefaultApplicationConfigFilename    = "app.pipecd.yaml"
+	oldDefaultApplicationConfigFilename = ".pipe.yaml"
+	applicationConfigFileExtention      = ".pipecd.yaml"
 )
 
 // GetApplicationConfigFilePath returns the path to application configuration file.
 func (p ApplicationGitPath) GetApplicationConfigFilePath() string {
-	filename := DefaultApplicationConfigFilename
+	// The config file name used to allow to be empty until the default name got changed.
+	// So empty means the old default name.
+	filename := oldDefaultApplicationConfigFilename
 	if n := p.ConfigFilename; n != "" {
 		filename = n
 	}
@@ -79,5 +82,5 @@ func (a *Application) IsOutOfSync() bool {
 }
 
 func IsApplicationConfigFile(filename string) bool {
-	return filename == DefaultApplicationConfigFilename || strings.HasSuffix(filename, applicationConfigFileExtention)
+	return filename == DefaultApplicationConfigFilename || strings.HasSuffix(filename, applicationConfigFileExtention) || filename == oldDefaultApplicationConfigFilename
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Since there is a function that considers the filename as `.pipe.yaml` if it is empty, it is necessary to keep `oldDefaultApplicationConfigFilename` internally.

Let me rename the application files in examples in another PR.

The new default name will be used on the application form as well as `pipectl application add`.
![image](https://user-images.githubusercontent.com/19730728/146146069-594ce309-d808-4d4f-bb92-4d59e2bce9a6.png)

**Which issue(s) this PR fixes**:

Fixes https://github.com/pipe-cd/pipe/issues/2931

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
The default application configuration name to "app.pipecd.yaml" from ".pipe.yaml"
```
