### PR TITLE
Make config file name required when adding app

### DIFF
--- a/pkg/app/web/src/components/application-form/index.tsx
+++ b/pkg/app/web/src/components/application-form/index.tsx
@@ -256,6 +256,7 @@ export const validationSchema = yup.object().shape({
     })
     .required(),
   repoPath: yup.string().required(),
+  configFilename: yup.string().required(),
   cloudProvider: yup.string().required(),
 });
 
@@ -452,6 +453,7 @@ export const ApplicationForm: FC<ApplicationFormProps> = memo(
             onChange={handleChange}
             value={values.configFilename}
             fullWidth
+            required
             className={classes.textInput}
           />
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, an empty config file name is considered as `.pipe.yaml` implicitly.

https://github.com/pipe-cd/pipe/blob/dd5064f2b9dfbc6fda4bee08467e4e473d4b8fa9/pkg/model/application.go#L30-L33

There are applications that configFilename is empty. In order to change the default file name (https://github.com/pipe-cd/pipe/pull/2950) while implicitly entering `.pipe.yaml` into these, we need to ensure that any future applications will always have a configFilename.

If we make `ApplicationGitPath.ConfigFilename` required at proto level, the existing ones can't used at all. 
There are three ways to add an application, from pipectl, the web UI, and app config defined in Git. Other than the first one, we can guarantee the configFilename is filled, but for the first one, it's still likely to be empty. That is why this PR does it.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
The config filename is now required when you add an app on the web UI.
```
