### PR TITLE
Make sure appconfigreporter to scan configs first

### DIFF
--- a/pkg/app/piped/appconfigreporter/appconfigreporter.go
+++ b/pkg/app/piped/appconfigreporter/appconfigreporter.go
@@ -111,6 +111,11 @@ func (r *Reporter) Run(ctx context.Context) error {
 		r.gitRepos[repoCfg.RepoID] = repo
 	}
 
+	// Scan them once first.
+	if err := r.scanAppConfigs(ctx); err != nil {
+		r.logger.Error("failed to check application configurations defined in Git", zap.Error(err))
+	}
+
 	ticker := time.NewTicker(r.config.AppConfigSyncInterval.Duration())
 	defer ticker.Stop()
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This will allow us to add applications as soon as you register Piped.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
