### PR TITLE
Revise piped connection status UI color

### DIFF
--- a/pkg/app/web/src/components/settings-page/piped/components/piped-table-row.tsx
+++ b/pkg/app/web/src/components/settings-page/piped/components/piped-table-row.tsx
@@ -56,6 +56,21 @@ const useStyles = makeStyles((theme) => ({
   connectionStatus: {
     paddingLeft: theme.spacing(1.5),
   },
+  onlineStatus: {
+    "& span": {
+      backgroundColor: "green",
+    },
+  },
+  offlineStatus: {
+    "& span": {
+      backgroundColor: "red",
+    },
+  },
+  unknownStatus: {
+    "& span": {
+      backgroundColor: "grey",
+    },
+  },
 }));
 
 interface Props {
@@ -138,20 +153,6 @@ export const PipedTableRow: FC<Props> = memo(function PipedTableRow({
     onDisable(pipedId);
   }, [pipedId, onDisable]);
 
-  const connectionStatusColor = useCallback(
-    (status: Piped.ConnectionStatus) => {
-      switch (status) {
-        case Piped.ConnectionStatus.UNKNOWN:
-          return "secondary";
-        case Piped.ConnectionStatus.ONLINE:
-          return "primary";
-        case Piped.ConnectionStatus.OFFLINE:
-          return "error";
-      }
-    },
-    [piped?.status]
-  );
-
   if (!piped) {
     return null;
   }
@@ -172,7 +173,14 @@ export const PipedTableRow: FC<Props> = memo(function PipedTableRow({
             >
               <Badge
                 variant="dot"
-                color={connectionStatusColor(piped.status)}
+                className={clsx({
+                  [classes.onlineStatus]:
+                    piped.status === Piped.ConnectionStatus.ONLINE,
+                  [classes.offlineStatus]:
+                    piped.status === Piped.ConnectionStatus.OFFLINE,
+                  [classes.unknownStatus]:
+                    piped.status === Piped.ConnectionStatus.UNKNOWN,
+                })}
               />
             </Tooltip>
           </Typography>


### PR DESCRIPTION
**What this PR does / why we need it**:

Change the dot which shows piped connection status color as below

![Screen Shot 2021-12-18 at 0 27 35](https://user-images.githubusercontent.com/32532742/146568206-6a9a2605-4f2f-4957-b1f9-6ef05beea641.png)

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
