### PR TITLE
Add Piped installation link to user guide index

### DIFF
--- a/docs/content/en/docs-dev/user-guide/_index.md
+++ b/docs/content/en/docs-dev/user-guide/_index.md
@@ -5,3 +5,5 @@ weight: 4
 description: >
   This guide is for developers who have PipeCD installed for them and are using PipeCD to deploy their applications.
 ---
+
+> Note: You must have at least one activated/running Piped to enable using any of the following features of PipeCD. Please refer to [Piped installation docs](/docs/operator-manual/piped/installation/) if you do not have any Piped in your pocket.


### PR DESCRIPTION
**What this PR does / why we need it**:

Add the link to piped installation guide to user guide index page

![Screen Shot 2021-12-20 at 12 46 21](https://user-images.githubusercontent.com/32532742/146709092-c4d24d11-55dd-4688-9dac-6b30f73079a2.png)

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
