### PR TITLE
Change default interval to scan app config files

### DIFF
--- a/docs/content/en/docs-dev/operator-manual/piped/configuration-reference.md
+++ b/docs/content/en/docs-dev/operator-manual/piped/configuration-reference.md
@@ -25,7 +25,7 @@ spec:
 | pipedKeyData | string | Base64 encoded string of Piped key. Either pipedKeyFile or pipedKeyData must be set. | Yes |
 | apiAddress | string | The address used to connect to the control-plane's API. | Yes |
 | syncInterval | duration | How often to check whether an application should be synced. Default is `1m`. | No |
-| appConfigSyncInterval | duration | How often to check whether application configuration files should be synced. Default is `5m`. | No |
+| appConfigSyncInterval | duration | How often to check whether application configuration files should be synced. Default is `1m`. | No |
 | git | [Git](#git) | Git configuration needed for Git commands. | No |
 | repositories | [][Repository](/docs/operator-manual/piped/configuration-reference/#gitrepository) | List of Git repositories this piped will handle. | No |
 | chartRepositories | [][ChartRepository](/docs/operator-manual/piped/configuration-reference/#chartrepository) | List of Helm chart repositories that should be added while starting up. | No |

--- a/pkg/config/piped.go
+++ b/pkg/config/piped.go
@@ -50,8 +50,8 @@ type PipedSpec struct {
 	// Default is 1m.
 	SyncInterval Duration `json:"syncInterval" default:"1m"`
 	// How often to check whether an application configuration file should be synced.
-	// Default is 5m.
-	AppConfigSyncInterval Duration `json:"appConfigSyncInterval" default:"5m"`
+	// Default is 1m.
+	AppConfigSyncInterval Duration `json:"appConfigSyncInterval" default:"1m"`
 	// Git configuration needed for git commands.
 	Git PipedGit `json:"git"`
 	// List of git repositories this piped will handle.

--- a/pkg/config/piped_test.go
+++ b/pkg/config/piped_test.go
@@ -43,7 +43,7 @@ func TestPipedConfig(t *testing.T) {
 				APIAddress:            "your-pipecd.domain",
 				WebAddress:            "https://your-pipecd.domain",
 				SyncInterval:          Duration(time.Minute),
-				AppConfigSyncInterval: Duration(5 * time.Minute),
+				AppConfigSyncInterval: Duration(time.Minute),
 				Git: PipedGit{
 					Username:   "username",
 					Email:      "username@email.com",


### PR DESCRIPTION
**What this PR does / why we need it**:
In case that you have so many unregistered application config files under your repository, it might be not fine to scan files per minute. But it hardly happens. Typically, you would be happy if the application configuration file is reflected in the web console as soon as possible after you add it.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
