### PR TITLE
Add the navigation link to the doc covering to add app from Git

### DIFF
--- a/pkg/app/web/src/components/application-form/index.tsx
+++ b/pkg/app/web/src/components/application-form/index.tsx
@@ -145,11 +145,14 @@ const useStyles = makeStyles((theme) => ({
   actionsContainer: {
     marginBottom: theme.spacing(2),
   },
-  tab: {
-    flexDirection: "row-reverse",
-  },
-  labelIcon: {
-    "min-height": 0,
+  tabLabel: {
+    minHeight: 0,
+    "& .MuiTab-wrapper": {
+      flexDirection: "row-reverse",
+    },
+    "& .MuiTab-wrapper > *:first-child": {
+      marginBottom: 0,
+    },
   },
 }));
 
@@ -204,13 +207,13 @@ export const ApplicationFormTabs: React.FC<ApplicationFormProps> = (props) => {
           aria-label="basic tabs example"
         >
           <Tab
-            classes={{ wrapper: classes.tab, labelIcon: classes.labelIcon }}
+            className={classes.tabLabel}
             label="Add manually"
             icon=" "
             {...a11yProps(0)}
           />
           <Tab
-            classes={{ wrapper: classes.tab, labelIcon: classes.labelIcon }}
+            className={classes.tabLabel}
             label="ADD FROM GIT"
             icon={
               <IconButton

--- a/pkg/app/web/src/components/application-form/index.tsx
+++ b/pkg/app/web/src/components/application-form/index.tsx
@@ -148,6 +148,9 @@ const useStyles = makeStyles((theme) => ({
   tab: {
     flexDirection: "row-reverse",
   },
+  labelIcon: {
+    "min-height": 0,
+  },
 }));
 
 interface TabPanelProps {
@@ -200,12 +203,19 @@ export const ApplicationFormTabs: React.FC<ApplicationFormProps> = (props) => {
           onChange={handleChange}
           aria-label="basic tabs example"
         >
-          <Tab label="Add manually" {...a11yProps(0)} />
           <Tab
-            classes={{ wrapper: classes.tab }}
+            classes={{ wrapper: classes.tab, labelIcon: classes.labelIcon }}
+            label="Add manually"
+            icon=" "
+            {...a11yProps(0)}
+          />
+          <Tab
+            classes={{ wrapper: classes.tab, labelIcon: classes.labelIcon }}
+            label="ADD FROM GIT"
             icon={
               <IconButton
                 size="small"
+                edge="start"
                 href="https://pipecd.dev/docs/user-guide/adding-an-application/#from-the-application-configuration-in-your-git-repository-recommended"
                 target="_blank"
                 rel="noopener noreferrer"
@@ -213,7 +223,6 @@ export const ApplicationFormTabs: React.FC<ApplicationFormProps> = (props) => {
                 <Help fontSize="small" />
               </IconButton>
             }
-            label="ADD FROM GIT"
             {...a11yProps(1)}
           />
         </Tabs>

--- a/pkg/app/web/src/components/application-form/index.tsx
+++ b/pkg/app/web/src/components/application-form/index.tsx
@@ -23,8 +23,9 @@ import {
   Step,
   StepLabel,
   StepContent,
+  IconButton,
 } from "@material-ui/core";
-import ExpandMore from "@material-ui/icons/ExpandMore";
+import { ExpandMore, Help } from "@material-ui/icons";
 import { FormikProps } from "formik";
 import {
   FC,
@@ -144,6 +145,9 @@ const useStyles = makeStyles((theme) => ({
   actionsContainer: {
     marginBottom: theme.spacing(2),
   },
+  tab: {
+    flexDirection: "row-reverse",
+  },
 }));
 
 interface TabPanelProps {
@@ -177,6 +181,8 @@ function a11yProps(index: number): { id: string; "aria-controls": string } {
 }
 
 export const ApplicationFormTabs: React.FC<ApplicationFormProps> = (props) => {
+  const classes = useStyles();
+
   const [selectedTabIndex, setSelectedTabIndex] = useState(0);
 
   const handleChange = (
@@ -195,7 +201,21 @@ export const ApplicationFormTabs: React.FC<ApplicationFormProps> = (props) => {
           aria-label="basic tabs example"
         >
           <Tab label="Add manually" {...a11yProps(0)} />
-          <Tab label="Add from Git (Alpha)" {...a11yProps(1)} />
+          <Tab
+            classes={{ wrapper: classes.tab }}
+            icon={
+              <IconButton
+                size="small"
+                href="https://pipecd.dev/docs/user-guide/adding-an-application/#from-the-application-configuration-in-your-git-repository-recommended"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Help fontSize="small" />
+              </IconButton>
+            }
+            label="ADD FROM GIT"
+            {...a11yProps(1)}
+          />
         </Tabs>
       </Box>
       <TabPanel selected={selectedTabIndex === 0} index={0}>


### PR DESCRIPTION
**What this PR does / why we need it**:
Some existing users will be more likely to get confused when facing this UI first, so it's kind to navigate to the documentation.

https://user-images.githubusercontent.com/19730728/146904794-62e2216f-9975-4f3f-ad59-e68611033516.mov

**Which issue(s) this PR fixes**:

Fixes https://github.com/pipe-cd/pipe/issues/2929

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
