### PR TITLE
Fix stale command options in docs

### DIFF
--- a/docs/content/en/docs-dev/operator-manual/piped/adding-a-git-repository.md
+++ b/docs/content/en/docs-dev/operator-manual/piped/adding-a-git-repository.md
@@ -32,8 +32,8 @@ In most of the cases, we want to deal with private Git repositories. For accessi
 ``` console
 helm install dev-piped pipecd/piped --version={VERSION} \
   --set-file config.data={PATH_TO_PIPED_CONFIG_FILE} \
-  --set-file secret.pipedKey.data={PATH_TO_PIPED_KEY_FILE} \
-  --set-file secret.sshKey.data={PATH_TO_PRIVATE_SSH_KEY_FILE}
+  --set-file secret.data.piped-key={PATH_TO_PIPED_KEY_FILE} \
+  --set-file secret.data.ssh-key={PATH_TO_PRIVATE_SSH_KEY_FILE}
 ```
 
 You can see this [configuration reference](/docs/operator-manual/piped/configuration-reference/#git) for more configurable fields about Git commands.

--- a/docs/content/en/docs-dev/quickstart/_index.md
+++ b/docs/content/en/docs-dev/quickstart/_index.md
@@ -62,7 +62,7 @@ You can complete the installation by running the following after replacing `{YOU
 ``` console
 helm install piped pipecd/piped -n pipecd \
   --values https://raw.githubusercontent.com/pipe-cd/manifests/{{< blocks/latest_version >}}/quickstart/piped-values.yaml \
-  --set secret.pipedKey.data={YOUR_PIPED_SECRET_KEY}
+  --set secret.data.piped-key={YOUR_PIPED_SECRET_KEY}
 ```
 
 ### 4. Registering a kubernetes application

--- a/docs/content/en/docs-v0.22.x/quickstart/_index.md
+++ b/docs/content/en/docs-v0.22.x/quickstart/_index.md
@@ -71,7 +71,7 @@ You can complete the installation by running the following after replacing `{YOU
 ``` console
 helm install piped pipecd/piped -n pipecd \
   --values https://raw.githubusercontent.com/pipe-cd/manifests/{{< blocks/latest_version >}}/quickstart/piped-values.yaml \
-  --set secret.pipedKey.data={YOUR_PIPED_SECRET_KEY}
+  --set secret.data.piped-key={YOUR_PIPED_SECRET_KEY}
 ```
 
 ### 5. Configuring a kubernetes application

--- a/docs/content/en/docs/operator-manual/piped/adding-a-git-repository.md
+++ b/docs/content/en/docs/operator-manual/piped/adding-a-git-repository.md
@@ -32,8 +32,8 @@ In most of the cases, we want to deal with private Git repositories. For accessi
 ``` console
 helm install dev-piped pipecd/piped --version={VERSION} \
   --set-file config.data={PATH_TO_PIPED_CONFIG_FILE} \
-  --set-file secret.pipedKey.data={PATH_TO_PIPED_KEY_FILE} \
-  --set-file secret.sshKey.data={PATH_TO_PRIVATE_SSH_KEY_FILE}
+  --set-file secret.data.piped-key={PATH_TO_PIPED_KEY_FILE} \
+  --set-file secret.data.ssh-key={PATH_TO_PRIVATE_SSH_KEY_FILE}
 ```
 
 You can see this [configuration reference](/docs/operator-manual/piped/configuration-reference/#git) for more configurable fields about Git commands.

--- a/docs/content/en/docs/quickstart/_index.md
+++ b/docs/content/en/docs/quickstart/_index.md
@@ -71,7 +71,7 @@ You can complete the installation by running the following after replacing `{YOU
 ``` console
 helm install piped pipecd/piped -n pipecd \
   --values https://raw.githubusercontent.com/pipe-cd/manifests/{{< blocks/latest_version >}}/quickstart/piped-values.yaml \
-  --set secret.pipedKey.data={YOUR_PIPED_SECRET_KEY}
+  --set secret.data.piped-key={YOUR_PIPED_SECRET_KEY}
 ```
 
 ### 5. Configuring a kubernetes application


### PR DESCRIPTION
**What this PR does / why we need it**:

We have migrated to the new using way of those options in the Helm commands but unfortunately somewhere hasn't been updated.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
