### PR TITLE
Add a missing required field to ingress manifest for control-plane chart

### DIFF
--- a/manifests/pipecd/templates/ingress.yaml
+++ b/manifests/pipecd/templates/ingress.yaml
@@ -22,19 +22,15 @@ spec:
   rules:
   - http:
       paths:
-      - path: /hook
+      - path: /pipe.api.service.pipedservice.PipedService/
+        pathType: Prefix
         backend:
           service:
             name: {{ include "pipecd.fullname" . }}
             port:
               number: {{ .Values.service.port }}
-      - path: /pipe.api.service.pipedservice.PipedService/*
-        backend:
-          service:
-            name: {{ include "pipecd.fullname" . }}
-            port:
-              number: {{ .Values.service.port }}
-      - path: /pipe.api.service.apiservice.APIService/*
+      - path: /pipe.api.service.apiservice.APIService/
+        pathType: Prefix
         backend:
           service:
             name: {{ include "pipecd.fullname" . }}


### PR DESCRIPTION
**What this PR does / why we need it**:

The new ingress version requires `pathType` field must be specified explicitly.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
