### PR TITLE
Add an ability to filter apps by labels

### DIFF
--- a/pkg/app/web/src/api/applications.ts
+++ b/pkg/app/web/src/api/applications.ts
@@ -54,6 +54,9 @@ export const getApplications = ({
       enabled.setValue((options.enabled.value as unknown) as boolean);
       o.setEnabled(enabled);
     }
+    for (const label of options.labelsMap) {
+      o.getLabelsMap().set(label[0], label[1]);
+    }
     req.setOptions(o);
   }
   return apiRequest(req, apiClient.listApplications);

--- a/pkg/app/web/src/components/applications-page/application-filter/index.tsx
+++ b/pkg/app/web/src/components/applications-page/application-filter/index.tsx
@@ -4,8 +4,10 @@ import {
   makeStyles,
   MenuItem,
   Select,
+  TextField,
 } from "@material-ui/core";
-import { FC, memo } from "react";
+import Autocomplete from "@material-ui/lab/Autocomplete";
+import { FC, memo, useState } from "react";
 import { FilterView } from "~/components/filter-view";
 import { APPLICATION_KIND_TEXT } from "~/constants/application-kind";
 import { APPLICATION_SYNC_STATUS_TEXT } from "~/constants/application-sync-status-text";
@@ -51,6 +53,10 @@ export const ApplicationFilter: FC<ApplicationFilterProps> = memo(
     ): void => {
       onChange({ ...options, ...optionPart });
     };
+
+    const [labelOptions, setLabelOptions] = useState(new Array<string>());
+
+    const [selectedLabels, setSelectedLabels] = useState(new Array<string>());
 
     return (
       <FilterView
@@ -192,6 +198,41 @@ export const ApplicationFilter: FC<ApplicationFilterProps> = memo(
             <MenuItem value="enabled">Enabled</MenuItem>
             <MenuItem value="disabled">Disabled</MenuItem>
           </Select>
+        </FormControl>
+
+        <FormControl className={classes.formItem} variant="outlined">
+          <Autocomplete
+            multiple
+            autoHighlight
+            id="labels"
+            noOptionsText="Invalid label"
+            options={labelOptions}
+            value={selectedLabels}
+            onInputChange={(_, value) => {
+              const label = value.split(":");
+              if (label.length !== 2) return;
+              if (label[0].length === 0) return;
+              if (label[1].length === 0) return;
+              setLabelOptions([value]);
+            }}
+            onChange={(_, newValue) => {
+              setLabelOptions([]);
+              setSelectedLabels(newValue);
+              handleUpdateFilterValue({
+                labels: newValue,
+              });
+            }}
+            renderInput={(params) => (
+              <TextField
+                {...params}
+                variant="outlined"
+                label="Labels"
+                margin="dense"
+                placeholder="Labels"
+                fullWidth
+              />
+            )}
+          />
         </FormControl>
       </FilterView>
     );

--- a/pkg/app/web/src/components/applications-page/application-filter/index.tsx
+++ b/pkg/app/web/src/components/applications-page/application-filter/index.tsx
@@ -228,7 +228,7 @@ export const ApplicationFilter: FC<ApplicationFilterProps> = memo(
                 variant="outlined"
                 label="Labels"
                 margin="dense"
-                placeholder="Labels"
+                placeholder="key:value"
                 fullWidth
               />
             )}

--- a/pkg/app/web/src/components/applications-page/index.tsx
+++ b/pkg/app/web/src/components/applications-page/index.tsx
@@ -25,7 +25,11 @@ import {
   clearAddedApplicationId,
   fetchApplications,
 } from "~/modules/applications";
-import { stringifySearchParams, useSearchParams } from "~/utils/search-params";
+import {
+  stringifySearchParams,
+  useSearchParams,
+  arrayFormat,
+} from "~/utils/search-params";
 import { AddApplicationDrawer } from "./add-application-drawer";
 import { ApplicationFilter } from "./application-filter";
 import { ApplicationList } from "./application-list";
@@ -77,9 +81,10 @@ export const ApplicationIndexPage: FC = () => {
   const updateURL = useCallback(
     (options: Record<string, string | number | boolean | undefined>) => {
       history.replace(
-        `${PAGE_PATH_APPLICATIONS}?${stringifySearchParams({
-          ...options,
-        })}`
+        `${PAGE_PATH_APPLICATIONS}?${stringifySearchParams(
+          { ...options },
+          { arrayFormat: arrayFormat }
+        )}`
       );
     },
     [history]


### PR DESCRIPTION
**What this PR does / why we need it**:
Aside from `Autocomplete`I couldn't find out any material UI component which accepts multiple texts that look like those mentioned in the issue.

You can't select other than suggested options, that brings us a kind of validation for label format.

https://user-images.githubusercontent.com/19730728/147307661-f2736e04-13e7-42f8-bb78-25b34695e0fa.mov


**Which issue(s) this PR fixes**:

Fixes https://github.com/pipe-cd/pipe/issues/2756
Ref https://github.com/pipe-cd/pipe/issues/2978

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Filtering applications by Labels is now available
```
