### PR TITLE
Remove unneeded explanation in the quickstart guide

### DIFF
--- a/docs/content/en/docs-dev/quickstart/_index.md
+++ b/docs/content/en/docs-dev/quickstart/_index.md
@@ -8,8 +8,6 @@ description: >
 
 This page is a guideline for installing PipeCD in your Kubernetes cluster and deploying a "hello world" application to that same Kubernetes cluster.
 
-Note that it __does not require installing PipeCD to all clusters where you deploy your applications typically__, we do it here just for the simplicity of this guideline. For further reading about PipeCD's ideas, please visit [overview](/docs/overview/) and [concepts](/docs/concepts/).
-
 ### Prerequisites
 - Having a Kubernetes cluster
 - Installed [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)


### PR DESCRIPTION
**What this PR does / why we need it**:

I feel adding that sentence might confuse the reader.
So this PR removes it to keep the quickstart as simple as possible.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
