### PR TITLE
Add required indexes for deploymentchain and deployment model

### DIFF
--- a/pkg/app/ops/firestoreindexensurer/indexes.json
+++ b/pkg/app/ops/firestoreindexensurer/indexes.json
@@ -289,6 +289,27 @@
     ]
   },
   {
+    "collectionGroup": "Deployment",
+    "queryScope": "COLLECTION",
+    "fields": [
+      {
+        "fieldPath": "DeploymentChainId",
+        "order": "ASCENDING",
+        "arrayConfig": ""
+      },
+      {
+        "fieldPath": "UpdatedAt",
+        "order": "DESCENDING",
+        "arrayConfig": ""
+      },
+      {
+        "fieldPath": "Id",
+        "order": "ASCENDING",
+        "arrayConfig": ""
+      }
+    ]
+  },
+  {
     "collectionGroup": "Event",
     "queryScope": "COLLECTION",
     "fields": [
@@ -346,6 +367,48 @@
       },
       {
         "fieldPath": "CreatedAt",
+        "order": "DESCENDING",
+        "arrayConfig": ""
+      },
+      {
+        "fieldPath": "Id",
+        "order": "ASCENDING",
+        "arrayConfig": ""
+      }
+    ]
+  },
+  {
+    "collectionGroup": "DeploymentChain",
+    "queryScope": "COLLECTION",
+    "fields": [
+      {
+        "fieldPath": "Status",
+        "order": "ASCENDING",
+        "arrayConfig": ""
+      },
+      {
+        "fieldPath": "UpdatedAt",
+        "order": "DESCENDING",
+        "arrayConfig": ""
+      },
+      {
+        "fieldPath": "Id",
+        "order": "ASCENDING",
+        "arrayConfig": ""
+      }
+    ]
+  },
+  {
+    "collectionGroup": "DeploymentChain",
+    "queryScope": "COLLECTION",
+    "fields": [
+      {
+        "fieldPath": "ProjectId",
+        "order": "ASCENDING",
+        "arrayConfig": ""
+      },
+      {
+        "fieldPath": "UpdatedAt",
         "order": "DESCENDING",
         "arrayConfig": ""
       },

--- a/pkg/app/ops/firestoreindexensurer/indexes.json
+++ b/pkg/app/ops/firestoreindexensurer/indexes.json
@@ -382,7 +382,7 @@
     "queryScope": "COLLECTION",
     "fields": [
       {
-        "fieldPath": "Status",
+        "fieldPath": "ProjectId",
         "order": "ASCENDING",
         "arrayConfig": ""
       },
@@ -403,7 +403,7 @@
     "queryScope": "COLLECTION",
     "fields": [
       {
-        "fieldPath": "ProjectId",
+        "fieldPath": "Status",
         "order": "ASCENDING",
         "arrayConfig": ""
       },

--- a/pkg/app/ops/firestoreindexensurer/indexes_test.go
+++ b/pkg/app/ops/firestoreindexensurer/indexes_test.go
@@ -313,6 +313,27 @@ func TestParseIndexes(t *testing.T) {
 			},
 		},
 		{
+			CollectionGroup: "Deployment",
+			QueryScope:      "COLLECTION",
+			Fields: []field{
+				{
+					FieldPath:   "DeploymentChainId",
+					Order:       "ASCENDING",
+					ArrayConfig: "",
+				},
+				{
+					FieldPath:   "UpdatedAt",
+					Order:       "DESCENDING",
+					ArrayConfig: "",
+				},
+				{
+					FieldPath:   "Id",
+					Order:       "ASCENDING",
+					ArrayConfig: "",
+				},
+			},
+		},
+		{
 			CollectionGroup: "Event",
 			QueryScope:      "COLLECTION",
 			Fields: []field{
@@ -370,6 +391,48 @@ func TestParseIndexes(t *testing.T) {
 				},
 				{
 					FieldPath:   "CreatedAt",
+					Order:       "DESCENDING",
+					ArrayConfig: "",
+				},
+				{
+					FieldPath:   "Id",
+					Order:       "ASCENDING",
+					ArrayConfig: "",
+				},
+			},
+		},
+		{
+			CollectionGroup: "DeploymentChain",
+			QueryScope:      "COLLECTION",
+			Fields: []field{
+				{
+					FieldPath:   "ProjectId",
+					Order:       "ASCENDING",
+					ArrayConfig: "",
+				},
+				{
+					FieldPath:   "UpdatedAt",
+					Order:       "DESCENDING",
+					ArrayConfig: "",
+				},
+				{
+					FieldPath:   "Id",
+					Order:       "ASCENDING",
+					ArrayConfig: "",
+				},
+			},
+		},
+		{
+			CollectionGroup: "DeploymentChain",
+			QueryScope:      "COLLECTION",
+			Fields: []field{
+				{
+					FieldPath:   "Status",
+					Order:       "ASCENDING",
+					ArrayConfig: "",
+				},
+				{
+					FieldPath:   "UpdatedAt",
 					Order:       "DESCENDING",
 					ArrayConfig: "",
 				},

--- a/pkg/datastore/mysql/ensurer/indexes.sql
+++ b/pkg/datastore/mysql/ensurer/indexes.sql
@@ -76,6 +76,10 @@ CREATE INDEX deployment_status_updated_at_desc ON Deployment (Status, UpdatedAt 
 ALTER TABLE Deployment ADD COLUMN PipedId VARCHAR(36) GENERATED ALWAYS AS (data->>"$.piped_id") VIRTUAL NOT NULL;
 CREATE INDEX deployment_piped_id ON Deployment (PipedId);
 
+-- index on `DeploymentChainId` ASC and `UpdatedAt` DESC
+ALTER TABLE Deployment ADD COLUMN DeploymentChainId VARCHAR(36) GENERATED ALWAYS AS (data->>"$.deployment_chain_id") VIRTUAL NOT NULL;
+CREATE INDEX deployment_chain_id_updated_at_desc ON Deployment (DeploymentChainId, UpdatedAt DESC);
+
 --
 -- Event table indexes
 --
@@ -101,3 +105,7 @@ CREATE INDEX piped_project_id_env_ids_asc ON Piped (ProjectId, (CAST(EnvIds AS C
 
 -- index on `ProjectId` ASC and `UpdatedAt` DESC
 CREATE INDEX deploymentchain_project_id_updated_at_desc ON DeploymentChain (ProjectId, UpdatedAt DESC);
+
+-- index on `Status` ASC and `UpdatedAt` DESC
+ALTER TABLE DeploymentChain ADD COLUMN Status INT GENERATED ALWAYS AS (IFNULL(data->>"$.status", 0)) VIRTUAL NOT NULL;
+CREATE INDEX deploymentchain_status_updated_at_desc ON Deployment (Status, UpdatedAt DESC);


### PR DESCRIPTION
**What this PR does / why we need it**:

Add 2 indexes for deployment_chain model and 1 index for deployment model
- project_id index for deployment_chain model (used in web_api [ListDeploymentChains rpc](https://github.com/pipe-cd/pipe/blob/master/pkg/app/api/grpcapi/web_api.go#L1788))
- status index for deployment_chain model (used in ops's deployment_chain_controller [ListNotCompletedDeploymentChain](https://github.com/pipe-cd/pipe/blob/master/pkg/app/ops/deploymentchaincontroller/controller.go#L160))
- deployment_chain_id for deployment model (used in ops's updater [ListAllMissingDeployments](https://github.com/pipe-cd/pipe/blob/master/pkg/app/ops/deploymentchaincontroller/updater.go#L165))

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
