### PR TITLE
Enable to handle query parameter as an array even only one

### DIFF
--- a/pkg/app/web/src/utils/search-params.ts
+++ b/pkg/app/web/src/utils/search-params.ts
@@ -6,8 +6,10 @@ export function useSearchParams(): ParsedQuery<string> {
   const location = useLocation();
 
   return useMemo<ParsedQuery<string>>((): ParsedQuery<string> => {
-    return parse(location.search);
+    // NOTE: Without specifying arrayFormat, the value will be considered as a string when the length is 1.
+    return parse(location.search, { arrayFormat: arrayFormat });
   }, [location.search]);
 }
 
 export const stringifySearchParams = stringify;
+export const arrayFormat = "index";


### PR DESCRIPTION
**What this PR does / why we need it**:
For the filtering apps and deployments by Labels, this is required.
If `arrayFormat` is set to default, we can't determine if it's an element of an array or a single string.
See: https://github.com/sindresorhus/query-string#arrayformat-1

**Which issue(s) this PR fixes**:

Ref https://github.com/pipe-cd/pipe/issues/2978

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
