### PR TITLE
Enable to filter deployments by Labels

### DIFF
--- a/pkg/app/web/src/api/deployments.ts
+++ b/pkg/app/web/src/api/deployments.ts
@@ -36,6 +36,9 @@ export const getDeployments = ({
     req.setOptions(opts);
     req.setPageSize(pageSize);
     req.setCursor(cursor);
+    for (const label of options.labelsMap) {
+      opts.getLabelsMap().set(label[0], label[1]);
+    }
   }
   return apiRequest(req, apiClient.listDeployments);
 };

--- a/pkg/app/web/src/components/deployments-page/deployment-filter/index.tsx
+++ b/pkg/app/web/src/components/deployments-page/deployment-filter/index.tsx
@@ -78,6 +78,9 @@ export const DeploymentFilter: FC<DeploymentFilterProps> = memo(
       }
     }, [applications, options]);
 
+    const [labelOptions, setLabelOptions] = useState(new Array<string>());
+    const [selectedLabels, setSelectedLabels] = useState(new Array<string>());
+
     return (
       <FilterView
         onClear={() => {
@@ -222,6 +225,41 @@ export const DeploymentFilter: FC<DeploymentFilterProps> = memo(
               </MenuItem>
             ))}
           </Select>
+        </FormControl>
+
+        <FormControl className={classes.formItem} variant="outlined">
+          <Autocomplete
+            multiple
+            autoHighlight
+            id="labels"
+            noOptionsText="Invalid label"
+            options={labelOptions}
+            value={selectedLabels}
+            onInputChange={(_, value) => {
+              const label = value.split(":");
+              if (label.length !== 2) return;
+              if (label[0].length === 0) return;
+              if (label[1].length === 0) return;
+              setLabelOptions([value]);
+            }}
+            onChange={(_, newValue) => {
+              setLabelOptions([]);
+              setSelectedLabels(newValue);
+              handleUpdateFilterValue({
+                labels: newValue,
+              });
+            }}
+            renderInput={(params) => (
+              <TextField
+                {...params}
+                variant="outlined"
+                label="Labels"
+                margin="dense"
+                placeholder="key:value"
+                fullWidth
+              />
+            )}
+          />
         </FormControl>
       </FilterView>
     );

--- a/pkg/app/web/src/components/deployments-page/index.tsx
+++ b/pkg/app/web/src/components/deployments-page/index.tsx
@@ -36,7 +36,11 @@ import {
   selectIds as selectDeploymentIds,
 } from "~/modules/deployments";
 import { useStyles as useButtonStyles } from "~/styles/button";
-import { stringifySearchParams, useSearchParams } from "~/utils/search-params";
+import {
+  stringifySearchParams,
+  useSearchParams,
+  arrayFormat,
+} from "~/utils/search-params";
 import { DeploymentFilter } from "./deployment-filter";
 import { DeploymentItem } from "./deployment-item";
 
@@ -119,7 +123,10 @@ export const DeploymentIndexPage: FC = () => {
   const handleFilterChange = useCallback(
     (options: DeploymentFilterOptions) => {
       history.replace(
-        `${PAGE_PATH_DEPLOYMENTS}?${stringifySearchParams(options)}`
+        `${PAGE_PATH_DEPLOYMENTS}?${stringifySearchParams(
+          { ...options },
+          { arrayFormat: arrayFormat }
+        )}`
       );
     },
     [history]

--- a/pkg/app/web/src/modules/deployments/index.ts
+++ b/pkg/app/web/src/modules/deployments/index.ts
@@ -29,6 +29,9 @@ export interface DeploymentFilterOptions {
   applicationId?: string;
   envId?: string;
   applicationName?: string;
+  // Suppose to be like ["key-1:value-1"]
+  // sindresorhus/query-string doesn't support multidimensional arrays, that's why the format is a bit tricky.
+  labels?: Array<string>;
 }
 
 export const isDeploymentRunning = (
@@ -92,6 +95,13 @@ export const fetchDeploymentById = createAsyncThunk<
 const convertFilterOptions = (
   options: DeploymentFilterOptions
 ): ListDeploymentsRequest.Options.AsObject => {
+  const labels = new Array<[string, string]>();
+  if (options.labels) {
+    for (const label of options.labels) {
+      const pair = label.split(":");
+      pair.length === 2 && labels.push([pair[0], pair[1]]);
+    }
+  }
   return {
     applicationName: options.applicationName ?? "",
     applicationIdsList: options.applicationId ? [options.applicationId] : [],
@@ -102,7 +112,7 @@ const convertFilterOptions = (
     statusesList: options.status
       ? [parseInt(options.status, 10) as DeploymentStatus]
       : [],
-    labelsMap: [], // TODO: Specify labels for ListDeployments
+    labelsMap: labels,
   };
 };
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds an ability to filter deployments by Labels like [the applications page](https://github.com/pipe-cd/pipe/pull/2987).
Keep in mind the GIF animation below is what merges the MORE button PR (https://github.com/pipe-cd/pipe/pull/2999).

![Kapture 2022-01-05 at 15 17 06](https://user-images.githubusercontent.com/19730728/148169587-7ee2c3ab-da0c-4d65-843a-9cfb13899f44.gif)


**Which issue(s) this PR fixes**:

Fixes https://github.com/pipe-cd/pipe/issues/2978
Fixes https://github.com/pipe-cd/pipe/issues/2757

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Filtering deployments by Labels is now available
```
