### PR TITLE
Change text shown on deployment/application labels filter

### DIFF
--- a/pkg/app/web/src/components/applications-page/application-filter/index.tsx
+++ b/pkg/app/web/src/components/applications-page/application-filter/index.tsx
@@ -205,7 +205,7 @@ export const ApplicationFilter: FC<ApplicationFilterProps> = memo(
             multiple
             autoHighlight
             id="labels"
-            noOptionsText="Invalid label"
+            noOptionsText="No selectable labels"
             options={labelOptions}
             value={options.labels ?? selectedLabels}
             onInputChange={(_, value) => {

--- a/pkg/app/web/src/components/deployments-page/deployment-filter/index.tsx
+++ b/pkg/app/web/src/components/deployments-page/deployment-filter/index.tsx
@@ -232,7 +232,7 @@ export const DeploymentFilter: FC<DeploymentFilterProps> = memo(
             multiple
             autoHighlight
             id="labels"
-            noOptionsText="Invalid label"
+            noOptionsText="No selectable labels"
             options={labelOptions}
             value={options.labels ?? selectedLabels}
             onInputChange={(_, value) => {


### PR DESCRIPTION
**What this PR does / why we need it**:

before

<img width="338" alt="Screen Shot 2022-01-06 at 13 55 25" src="https://user-images.githubusercontent.com/32532742/148331138-dd363c0e-fb70-45b8-843e-08182adc20d0.png">

after

<img width="340" alt="Screen Shot 2022-01-06 at 13 59 59" src="https://user-images.githubusercontent.com/32532742/148331155-3e275f4c-850a-47e5-8bf6-0119e73137ad.png">


**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
