### PR TITLE
Show label on the app detail and list page

### DIFF
--- a/pkg/app/web/src/components/application-detail-page/application-detail/index.tsx
+++ b/pkg/app/web/src/components/application-detail-page/application-detail/index.tsx
@@ -221,9 +221,9 @@ export const ApplicationDetail: FC<ApplicationDetailProps> = memo(
                 {env.name}
               </Typography>
             )}
-            {app?.labelsMap.map((label, i) => (
+            {app?.labelsMap.map(([key, value], i) => (
               <Chip
-                label={label[0] + ":" + label[1]}
+                label={key + ": " + value}
                 className={classes.labelChip}
                 variant="outlined"
                 key={i}

--- a/pkg/app/web/src/components/application-detail-page/application-detail/index.tsx
+++ b/pkg/app/web/src/components/application-detail-page/application-detail/index.tsx
@@ -5,6 +5,7 @@ import {
   makeStyles,
   Paper,
   Typography,
+  Chip,
 } from "@material-ui/core";
 import SyncIcon from "@material-ui/icons/Cached";
 import OpenInNewIcon from "@material-ui/icons/OpenInNew";
@@ -74,6 +75,9 @@ const useStyles = makeStyles((theme) => ({
     paddingLeft: theme.spacing(2),
   },
   latestDeploymentLink: {
+    marginLeft: theme.spacing(1),
+  },
+  labelChip: {
     marginLeft: theme.spacing(1),
   },
 }));
@@ -217,6 +221,14 @@ export const ApplicationDetail: FC<ApplicationDetailProps> = memo(
                 {env.name}
               </Typography>
             )}
+            {app?.labelsMap.map((label, i) => (
+              <Chip
+                label={label[0] + ":" + label[1]}
+                className={classes.labelChip}
+                variant="outlined"
+                key={i}
+              />
+            ))}
           </Box>
 
           {app ? (

--- a/pkg/app/web/src/components/applications-page/application-list/application-list-item/index.tsx
+++ b/pkg/app/web/src/components/applications-page/application-list/application-list-item/index.tsx
@@ -122,6 +122,14 @@ export const ApplicationListItem: FC<ApplicationListItemProps> = memo(
           </TableCell>
           <TableCell>{APPLICATION_KIND_TEXT[app.kind]}</TableCell>
           <TableCell>{env?.name}</TableCell>
+          <TableCell>
+            {app.labelsMap.map((label) => (
+              <>
+                <span>{label[0] + ":" + label[1]}</span>
+                <br />
+              </>
+            ))}
+          </TableCell>
           {recentlyDeployment ? (
             <>
               <TableCell className={clsx(classes.version)}>

--- a/pkg/app/web/src/components/applications-page/application-list/application-list-item/index.tsx
+++ b/pkg/app/web/src/components/applications-page/application-list/application-list-item/index.tsx
@@ -121,14 +121,16 @@ export const ApplicationListItem: FC<ApplicationListItemProps> = memo(
             </Link>
           </TableCell>
           <TableCell>{APPLICATION_KIND_TEXT[app.kind]}</TableCell>
-          <TableCell>{env?.name}</TableCell>
+          <TableCell>{env ? env.name : "-"}</TableCell>
           <TableCell>
-            {app.labelsMap.map((label) => (
-              <>
-                <span>{label[0] + ":" + label[1]}</span>
-                <br />
-              </>
-            ))}
+            {app.labelsMap.length !== 0
+              ? app.labelsMap.map((label) => (
+                  <>
+                    <span>{label[0] + ":" + label[1]}</span>
+                    <br />
+                  </>
+                ))
+              : "-"}
           </TableCell>
           {recentlyDeployment ? (
             <>

--- a/pkg/app/web/src/components/applications-page/application-list/application-list-item/index.tsx
+++ b/pkg/app/web/src/components/applications-page/application-list/application-list-item/index.tsx
@@ -124,9 +124,9 @@ export const ApplicationListItem: FC<ApplicationListItemProps> = memo(
           <TableCell>{env ? env.name : "-"}</TableCell>
           <TableCell>
             {app.labelsMap.length !== 0
-              ? app.labelsMap.map((label) => (
+              ? app.labelsMap.map(([key, value]) => (
                   <>
-                    <span>{label[0] + ":" + label[1]}</span>
+                    <span>{key + ":" + value}</span>
                     <br />
                   </>
                 ))

--- a/pkg/app/web/src/components/applications-page/application-list/index.tsx
+++ b/pkg/app/web/src/components/applications-page/application-list/index.tsx
@@ -145,7 +145,7 @@ export const ApplicationList: FC<ApplicationListProps> = memo(
                 <TableCell>Kind</TableCell>
                 <TableCell>
                   Environment
-                  <Tooltip title="Deprecated" className={classes.tooltip}>
+                  <Tooltip title="Deprecated. Please use Label instead." className={classes.tooltip}>
                     <Warning fontSize="small" />
                   </Tooltip>
                 </TableCell>

--- a/pkg/app/web/src/components/applications-page/application-list/index.tsx
+++ b/pkg/app/web/src/components/applications-page/application-list/index.tsx
@@ -138,6 +138,7 @@ export const ApplicationList: FC<ApplicationListProps> = memo(
                 <TableCell>Name</TableCell>
                 <TableCell>Kind</TableCell>
                 <TableCell>Environment</TableCell>
+                <TableCell>Labels</TableCell>
                 <TableCell>Running Version</TableCell>
                 <TableCell>Running Commit</TableCell>
                 <TableCell>Deployed By</TableCell>

--- a/pkg/app/web/src/components/applications-page/application-list/index.tsx
+++ b/pkg/app/web/src/components/applications-page/application-list/index.tsx
@@ -9,7 +9,9 @@ import {
   TableHead,
   TablePagination,
   TableRow,
+  Tooltip,
 } from "@material-ui/core";
+import { Warning } from "@material-ui/icons";
 import { FC, memo, useCallback, useState } from "react";
 import { useAppDispatch, useAppSelector } from "~/hooks/redux";
 import {
@@ -27,6 +29,10 @@ import { SealedSecretDialog } from "./sealed-secret-dialog";
 const useStyles = makeStyles(() => ({
   container: {
     flex: 1,
+  },
+  tooltip: {
+    paddingTop: 2,
+    paddingLeft: 2,
   },
 }));
 
@@ -137,7 +143,12 @@ export const ApplicationList: FC<ApplicationListProps> = memo(
                 <TableCell>Status</TableCell>
                 <TableCell>Name</TableCell>
                 <TableCell>Kind</TableCell>
-                <TableCell>Environment</TableCell>
+                <TableCell>
+                  Environment
+                  <Tooltip title="Deprecated" className={classes.tooltip}>
+                    <Warning fontSize="small" />
+                  </Tooltip>
+                </TableCell>
                 <TableCell>Labels</TableCell>
                 <TableCell>Running Version</TableCell>
                 <TableCell>Running Commit</TableCell>


### PR DESCRIPTION
**What this PR does / why we need it**:
With it we can see labels on the application detail page as well as the application list page.

On the detail page:
![image](https://user-images.githubusercontent.com/19730728/148498226-cb706745-a04b-47ba-a78c-7fe48cf73044.png)

On the list:
![image](https://user-images.githubusercontent.com/19730728/148514954-935b96af-7584-4c1a-85a8-8e87bf46873c.png)


**Which issue(s) this PR fixes**:

Fixes https://github.com/pipe-cd/pipe/issues/3009

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
