### PR TITLE
Make deployment detail page scrollable

### DIFF
--- a/pkg/app/web/src/components/deployments-detail-page/index.tsx
+++ b/pkg/app/web/src/components/deployments-detail-page/index.tsx
@@ -22,6 +22,7 @@ const useStyles = makeStyles({
     flexDirection: "column",
     alignItems: "stretch",
     flex: 1,
+    overflow: "auto",
   },
 });
 


### PR DESCRIPTION
**What this PR does / why we need it**:
We have faced what the deployment pipeline gets invisible when it has a long sentence.
If you think about it, we can solve it by making the page scrollable.

![Kapture 2022-01-07 at 18 05 16](https://user-images.githubusercontent.com/19730728/148519879-c5ef1bde-222f-4e87-bfa4-2048c204eb22.gif)

**Which issue(s) this PR fixes**:

Fixes https://github.com/pipe-cd/pipe/issues/3008

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Fix a bug that the deployment pipeline gets invisible when it has a long sentence.
```
