### PR TITLE
Enable to register Environment as a label

### DIFF
--- a/docs/content/en/docs-dev/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-dev/user-guide/configuration-reference.md
@@ -21,7 +21,7 @@ spec:
 |-|-|-|-|
 | name | string | The application name. | Yes (if you want to create PipeCD application through the application configuration file) |
 | envName | string | The environment name. You need to make sure that the environment name is unique in your project. Deprecated. | No |
-| labels | map[string]string | Additional attributes to identify applications. The label `pipecd.dev/env` will be recognized as the Environment of this application. | No |
+| labels | map[string]string | Additional attributes to identify applications. PipeCD reserves all keys prefixed by `pipecd.dev/`. The label `pipecd.dev/env` will be recognized as the Environment of this application. | No |
 | input | [KubernetesDeploymentInput](#kubernetesdeploymentinput) | Input for Kubernetes deployment such as kubectl version, helm version, manifests filter... | No |
 | trigger | [DeploymentTrigger](#deploymenttrigger) | Configuration for trigger used to determine should we trigger a new deployment or not. | No |
 | planner | [DeploymentPlanner](#deploymentplanner) | Configuration for planner used while planning deployment. | No |
@@ -52,7 +52,7 @@ spec:
 |-|-|-|-|
 | name | string | The application name. | Yes if you set the application through the application configuration file |
 | envName | string | The environment name. You need to make sure that the environment name is unique in your project. Deprecated. | No |
-| labels | map[string]string | Additional attributes to identify applications. The label `pipecd.dev/env` will be recognized as the Environment of this application. | No |
+| labels | map[string]string | Additional attributes to identify applications. PipeCD reserves all keys prefixed by `pipecd.dev/`. The label `pipecd.dev/env` will be recognized as the Environment of this application. | No |
 | input | [TerraformDeploymentInput](#terraformdeploymentinput) | Input for Terraform deployment such as terraform version, workspace... | No |
 | trigger | [DeploymentTrigger](#deploymenttrigger) | Configuration for trigger used to determine should we trigger a new deployment or not. | No |
 | planner | [DeploymentPlanner](#deploymentplanner) | Configuration for planner used while planning deployment. | No |
@@ -79,7 +79,7 @@ spec:
 |-|-|-|-|
 | name | string | The application name. | Yes if you set the application through the application configuration file |
 | envName | string | The environment name. You need to make sure that the environment name is unique in your project. Deprecated. | No |
-| labels | map[string]string | Additional attributes to identify applications. The label `pipecd.dev/env` will be recognized as the Environment of this application. | No |
+| labels | map[string]string | Additional attributes to identify applications. PipeCD reserves all keys prefixed by `pipecd.dev/`. The label `pipecd.dev/env` will be recognized as the Environment of this application. | No |
 | input | [CloudRunDeploymentInput](#cloudrundeploymentinput) | Input for CloudRun deployment such as docker image... | No |
 | trigger | [DeploymentTrigger](#deploymenttrigger) | Configuration for trigger used to determine should we trigger a new deployment or not. | No |
 | planner | [DeploymentPlanner](#deploymentplanner) | Configuration for planner used while planning deployment. | No |
@@ -105,7 +105,7 @@ spec:
 |-|-|-|-|
 | name | string | The application name. | Yes if you set the application through the application configuration file |
 | envName | string | The environment name. You need to make sure that the environment name is unique in your project. Deprecated. | No |
-| labels | map[string]string | Additional attributes to identify applications. The label `pipecd.dev/env` will be recognized as the Environment of this application. | No |
+| labels | map[string]string | Additional attributes to identify applications. PipeCD reserves all keys prefixed by `pipecd.dev/`. The label `pipecd.dev/env` will be recognized as the Environment of this application. | No |
 | trigger | [DeploymentTrigger](#deploymenttrigger) | Configuration for trigger used to determine should we trigger a new deployment or not. | No |
 | planner | [DeploymentPlanner](#deploymentplanner) | Configuration for planner used while planning deployment. | No |
 | quickSync | [LambdaQuickSync](#lambdaquicksync) | Configuration for quick sync. | No |
@@ -131,7 +131,7 @@ spec:
 |-|-|-|-|
 | name | string | The application name. | Yes if you set the application through the application configuration file |
 | envName | string | The environment name. You need to make sure that the environment name is unique in your project. Deprecated. | No |
-| labels | map[string]string | Additional attributes to identify applications. The label `pipecd.dev/env` will be recognized as the Environment of this application. | No |
+| labels | map[string]string | Additional attributes to identify applications. PipeCD reserves all keys prefixed by `pipecd.dev/`. The label `pipecd.dev/env` will be recognized as the Environment of this application. | No |
 | trigger | [DeploymentTrigger](#deploymenttrigger) | Configuration for trigger used to determine should we trigger a new deployment or not. | No |
 | input | [ECSDeploymentInput](#ecsdeploymentinput) | Input for ECS deployment such as TaskDefinition, Service... | Yes |
 | planner | [DeploymentPlanner](#deploymentplanner) | Configuration for planner used while planning deployment. | No |

--- a/docs/content/en/docs-dev/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-dev/user-guide/configuration-reference.md
@@ -20,7 +20,7 @@ spec:
 | Field | Type | Description | Required |
 |-|-|-|-|
 | name | string | The application name. | Yes (if you want to create PipeCD application through the application configuration file) |
-| envName | string | The environment name. You need to make sure that the environment name is unique in your project. | No |
+| labels | map[string]string | Additional attributes to identify applications. Use "env" as a key then it will be recognized as the Environment of this app. | No |
 | input | [KubernetesDeploymentInput](#kubernetesdeploymentinput) | Input for Kubernetes deployment such as kubectl version, helm version, manifests filter... | No |
 | trigger | [DeploymentTrigger](#deploymenttrigger) | Configuration for trigger used to determine should we trigger a new deployment or not. | No |
 | planner | [DeploymentPlanner](#deploymentplanner) | Configuration for planner used while planning deployment. | No |
@@ -50,7 +50,7 @@ spec:
 | Field | Type | Description | Required |
 |-|-|-|-|
 | name | string | The application name. | Yes if you set the application through the application configuration file |
-| envName | string | The environment name. You need to make sure that the environment name is unique in your project. | No |
+| labels | map[string]string | Additional attributes to identify applications. Use "env" as a key then it will be recognized as the Environment of this app. | No |
 | input | [TerraformDeploymentInput](#terraformdeploymentinput) | Input for Terraform deployment such as terraform version, workspace... | No |
 | trigger | [DeploymentTrigger](#deploymenttrigger) | Configuration for trigger used to determine should we trigger a new deployment or not. | No |
 | planner | [DeploymentPlanner](#deploymentplanner) | Configuration for planner used while planning deployment. | No |
@@ -76,7 +76,7 @@ spec:
 | Field | Type | Description | Required |
 |-|-|-|-|
 | name | string | The application name. | Yes if you set the application through the application configuration file |
-| envName | string | The environment name. You need to make sure that the environment name is unique in your project. | No |
+| labels | map[string]string | Additional attributes to identify applications. Use "env" as a key then it will be recognized as the Environment of this app. | No |
 | input | [CloudRunDeploymentInput](#cloudrundeploymentinput) | Input for CloudRun deployment such as docker image... | No |
 | trigger | [DeploymentTrigger](#deploymenttrigger) | Configuration for trigger used to determine should we trigger a new deployment or not. | No |
 | planner | [DeploymentPlanner](#deploymentplanner) | Configuration for planner used while planning deployment. | No |
@@ -101,7 +101,7 @@ spec:
 | Field | Type | Description | Required |
 |-|-|-|-|
 | name | string | The application name. | Yes if you set the application through the application configuration file |
-| envName | string | The environment name. You need to make sure that the environment name is unique in your project. | No |
+| labels | map[string]string | Additional attributes to identify applications. Use "env" as a key then it will be recognized as the Environment of this app. | No |
 | trigger | [DeploymentTrigger](#deploymenttrigger) | Configuration for trigger used to determine should we trigger a new deployment or not. | No |
 | planner | [DeploymentPlanner](#deploymentplanner) | Configuration for planner used while planning deployment. | No |
 | quickSync | [LambdaQuickSync](#lambdaquicksync) | Configuration for quick sync. | No |
@@ -126,7 +126,7 @@ spec:
 | Field | Type | Description | Required |
 |-|-|-|-|
 | name | string | The application name. | Yes if you set the application through the application configuration file |
-| envName | string | The environment name. You need to make sure that the environment name is unique in your project. | No |
+| labels | map[string]string | Additional attributes to identify applications. Use "env" as a key then it will be recognized as the Environment of this app. | No |
 | trigger | [DeploymentTrigger](#deploymenttrigger) | Configuration for trigger used to determine should we trigger a new deployment or not. | No |
 | input | [ECSDeploymentInput](#ecsdeploymentinput) | Input for ECS deployment such as TaskDefinition, Service... | Yes |
 | planner | [DeploymentPlanner](#deploymentplanner) | Configuration for planner used while planning deployment. | No |

--- a/docs/content/en/docs-dev/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-dev/user-guide/configuration-reference.md
@@ -20,6 +20,7 @@ spec:
 | Field | Type | Description | Required |
 |-|-|-|-|
 | name | string | The application name. | Yes (if you want to create PipeCD application through the application configuration file) |
+| envName | string | The environment name. You need to make sure that the environment name is unique in your project. Deprecated. | No |
 | labels | map[string]string | Additional attributes to identify applications. Use "env" as a key then it will be recognized as the Environment of this app. | No |
 | input | [KubernetesDeploymentInput](#kubernetesdeploymentinput) | Input for Kubernetes deployment such as kubectl version, helm version, manifests filter... | No |
 | trigger | [DeploymentTrigger](#deploymenttrigger) | Configuration for trigger used to determine should we trigger a new deployment or not. | No |
@@ -50,6 +51,7 @@ spec:
 | Field | Type | Description | Required |
 |-|-|-|-|
 | name | string | The application name. | Yes if you set the application through the application configuration file |
+| envName | string | The environment name. You need to make sure that the environment name is unique in your project. Deprecated. | No |
 | labels | map[string]string | Additional attributes to identify applications. Use "env" as a key then it will be recognized as the Environment of this app. | No |
 | input | [TerraformDeploymentInput](#terraformdeploymentinput) | Input for Terraform deployment such as terraform version, workspace... | No |
 | trigger | [DeploymentTrigger](#deploymenttrigger) | Configuration for trigger used to determine should we trigger a new deployment or not. | No |
@@ -76,6 +78,7 @@ spec:
 | Field | Type | Description | Required |
 |-|-|-|-|
 | name | string | The application name. | Yes if you set the application through the application configuration file |
+| envName | string | The environment name. You need to make sure that the environment name is unique in your project. Deprecated. | No |
 | labels | map[string]string | Additional attributes to identify applications. Use "env" as a key then it will be recognized as the Environment of this app. | No |
 | input | [CloudRunDeploymentInput](#cloudrundeploymentinput) | Input for CloudRun deployment such as docker image... | No |
 | trigger | [DeploymentTrigger](#deploymenttrigger) | Configuration for trigger used to determine should we trigger a new deployment or not. | No |
@@ -101,6 +104,7 @@ spec:
 | Field | Type | Description | Required |
 |-|-|-|-|
 | name | string | The application name. | Yes if you set the application through the application configuration file |
+| envName | string | The environment name. You need to make sure that the environment name is unique in your project. Deprecated. | No |
 | labels | map[string]string | Additional attributes to identify applications. Use "env" as a key then it will be recognized as the Environment of this app. | No |
 | trigger | [DeploymentTrigger](#deploymenttrigger) | Configuration for trigger used to determine should we trigger a new deployment or not. | No |
 | planner | [DeploymentPlanner](#deploymentplanner) | Configuration for planner used while planning deployment. | No |
@@ -126,6 +130,7 @@ spec:
 | Field | Type | Description | Required |
 |-|-|-|-|
 | name | string | The application name. | Yes if you set the application through the application configuration file |
+| envName | string | The environment name. You need to make sure that the environment name is unique in your project. Deprecated. | No |
 | labels | map[string]string | Additional attributes to identify applications. Use "env" as a key then it will be recognized as the Environment of this app. | No |
 | trigger | [DeploymentTrigger](#deploymenttrigger) | Configuration for trigger used to determine should we trigger a new deployment or not. | No |
 | input | [ECSDeploymentInput](#ecsdeploymentinput) | Input for ECS deployment such as TaskDefinition, Service... | Yes |

--- a/docs/content/en/docs-dev/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-dev/user-guide/configuration-reference.md
@@ -21,7 +21,7 @@ spec:
 |-|-|-|-|
 | name | string | The application name. | Yes (if you want to create PipeCD application through the application configuration file) |
 | envName | string | The environment name. You need to make sure that the environment name is unique in your project. Deprecated. | No |
-| labels | map[string]string | Additional attributes to identify applications. Use "env" as a key then it will be recognized as the Environment of this app. | No |
+| labels | map[string]string | Additional attributes to identify applications. The label `pipecd.dev/env` will be recognized as the Environment of this application. | No |
 | input | [KubernetesDeploymentInput](#kubernetesdeploymentinput) | Input for Kubernetes deployment such as kubectl version, helm version, manifests filter... | No |
 | trigger | [DeploymentTrigger](#deploymenttrigger) | Configuration for trigger used to determine should we trigger a new deployment or not. | No |
 | planner | [DeploymentPlanner](#deploymentplanner) | Configuration for planner used while planning deployment. | No |
@@ -52,7 +52,7 @@ spec:
 |-|-|-|-|
 | name | string | The application name. | Yes if you set the application through the application configuration file |
 | envName | string | The environment name. You need to make sure that the environment name is unique in your project. Deprecated. | No |
-| labels | map[string]string | Additional attributes to identify applications. Use "env" as a key then it will be recognized as the Environment of this app. | No |
+| labels | map[string]string | Additional attributes to identify applications. The label `pipecd.dev/env` will be recognized as the Environment of this application. | No |
 | input | [TerraformDeploymentInput](#terraformdeploymentinput) | Input for Terraform deployment such as terraform version, workspace... | No |
 | trigger | [DeploymentTrigger](#deploymenttrigger) | Configuration for trigger used to determine should we trigger a new deployment or not. | No |
 | planner | [DeploymentPlanner](#deploymentplanner) | Configuration for planner used while planning deployment. | No |
@@ -79,7 +79,7 @@ spec:
 |-|-|-|-|
 | name | string | The application name. | Yes if you set the application through the application configuration file |
 | envName | string | The environment name. You need to make sure that the environment name is unique in your project. Deprecated. | No |
-| labels | map[string]string | Additional attributes to identify applications. Use "env" as a key then it will be recognized as the Environment of this app. | No |
+| labels | map[string]string | Additional attributes to identify applications. The label `pipecd.dev/env` will be recognized as the Environment of this application. | No |
 | input | [CloudRunDeploymentInput](#cloudrundeploymentinput) | Input for CloudRun deployment such as docker image... | No |
 | trigger | [DeploymentTrigger](#deploymenttrigger) | Configuration for trigger used to determine should we trigger a new deployment or not. | No |
 | planner | [DeploymentPlanner](#deploymentplanner) | Configuration for planner used while planning deployment. | No |
@@ -105,7 +105,7 @@ spec:
 |-|-|-|-|
 | name | string | The application name. | Yes if you set the application through the application configuration file |
 | envName | string | The environment name. You need to make sure that the environment name is unique in your project. Deprecated. | No |
-| labels | map[string]string | Additional attributes to identify applications. Use "env" as a key then it will be recognized as the Environment of this app. | No |
+| labels | map[string]string | Additional attributes to identify applications. The label `pipecd.dev/env` will be recognized as the Environment of this application. | No |
 | trigger | [DeploymentTrigger](#deploymenttrigger) | Configuration for trigger used to determine should we trigger a new deployment or not. | No |
 | planner | [DeploymentPlanner](#deploymentplanner) | Configuration for planner used while planning deployment. | No |
 | quickSync | [LambdaQuickSync](#lambdaquicksync) | Configuration for quick sync. | No |
@@ -131,7 +131,7 @@ spec:
 |-|-|-|-|
 | name | string | The application name. | Yes if you set the application through the application configuration file |
 | envName | string | The environment name. You need to make sure that the environment name is unique in your project. Deprecated. | No |
-| labels | map[string]string | Additional attributes to identify applications. Use "env" as a key then it will be recognized as the Environment of this app. | No |
+| labels | map[string]string | Additional attributes to identify applications. The label `pipecd.dev/env` will be recognized as the Environment of this application. | No |
 | trigger | [DeploymentTrigger](#deploymenttrigger) | Configuration for trigger used to determine should we trigger a new deployment or not. | No |
 | input | [ECSDeploymentInput](#ecsdeploymentinput) | Input for ECS deployment such as TaskDefinition, Service... | Yes |
 | planner | [DeploymentPlanner](#deploymentplanner) | Configuration for planner used while planning deployment. | No |

--- a/pkg/app/piped/appconfigreporter/appconfigreporter.go
+++ b/pkg/app/piped/appconfigreporter/appconfigreporter.go
@@ -383,6 +383,10 @@ func (r *Reporter) readApplicationInfo(repoDir, repoID, cfgRelPath string) (*mod
 	if spec.Name == "" {
 		return nil, fmt.Errorf("missing application name: %w", errMissingRequiredField)
 	}
+	envName := ""
+	if e, ok := spec.Labels[config.EnvLabelKey]; ok {
+		envName = e
+	}
 	return &model.ApplicationInfo{
 		Name:           spec.Name,
 		Kind:           kind,
@@ -391,6 +395,6 @@ func (r *Reporter) readApplicationInfo(repoDir, repoID, cfgRelPath string) (*mod
 		Path:           filepath.Dir(cfgRelPath),
 		ConfigFilename: filepath.Base(cfgRelPath),
 		PipedId:        r.config.PipedID,
-		EnvName:        spec.EnvName,
+		EnvName:        envName,
 	}, nil
 }

--- a/pkg/app/piped/appconfigreporter/appconfigreporter.go
+++ b/pkg/app/piped/appconfigreporter/appconfigreporter.go
@@ -383,7 +383,7 @@ func (r *Reporter) readApplicationInfo(repoDir, repoID, cfgRelPath string) (*mod
 	if spec.Name == "" {
 		return nil, fmt.Errorf("missing application name: %w", errMissingRequiredField)
 	}
-	envName := ""
+	envName := spec.EnvName
 	if e, ok := spec.Labels[config.EnvLabelKey]; ok {
 		envName = e
 	}

--- a/pkg/app/piped/appconfigreporter/appconfigreporter_test.go
+++ b/pkg/app/piped/appconfigreporter/appconfigreporter_test.go
@@ -96,7 +96,7 @@ func TestReporter_findRegisteredApps(t *testing.T) {
 			reporter: &Reporter{
 				config: &config.PipedSpec{PipedID: "piped-1"},
 				applicationLister: &fakeApplicationLister{apps: []*model.Application{
-					{Id: "id-1", Name: "app-1", Labels: map[string]string{"key-1": "value-1"}, GitPath: &model.ApplicationGitPath{Repo: &model.ApplicationGitRepository{Id: "repo-1"}, Path: "app-1", ConfigFilename: "app.pipecd.yaml"}},
+					{Id: "id-1", Name: "app-1", Labels: map[string]string{"key-1": "value-1", "env": "dev"}, GitPath: &model.ApplicationGitPath{Repo: &model.ApplicationGitRepository{Id: "repo-1"}, Path: "app-1", ConfigFilename: "app.pipecd.yaml"}},
 				}},
 				fileSystem: fstest.MapFS{
 					"path/to/repo-1/app-1/app.pipecd.yaml": &fstest.MapFile{Data: []byte(`
@@ -104,8 +104,8 @@ apiVersion: pipecd.dev/v1beta1
 kind: KubernetesApp
 spec:
   name: app-1
-  envName: dev
   labels:
+    env: dev
     key-1: value-1`)},
 				},
 				logger: zap.NewNop(),
@@ -122,7 +122,7 @@ spec:
 			reporter: &Reporter{
 				config: &config.PipedSpec{PipedID: "piped-1"},
 				applicationLister: &fakeApplicationLister{apps: []*model.Application{
-					{Id: "id-1", Name: "app-1", Labels: map[string]string{"key-1": "value-1"}, GitPath: &model.ApplicationGitPath{Repo: &model.ApplicationGitRepository{Id: "repo-1"}, Path: "app-1", ConfigFilename: "app.pipecd.yaml"}},
+					{Id: "id-1", Name: "app-1", Labels: map[string]string{"key-1": "value-1", "env": "dev"}, GitPath: &model.ApplicationGitPath{Repo: &model.ApplicationGitRepository{Id: "repo-1"}, Path: "app-1", ConfigFilename: "app.pipecd.yaml"}},
 				}},
 				fileSystem: fstest.MapFS{
 					"path/to/repo-1/app-1/app.pipecd.yaml": &fstest.MapFile{Data: []byte(`
@@ -130,8 +130,8 @@ apiVersion: pipecd.dev/v1beta1
 kind: KubernetesApp
 spec:
   name: new-app-1
-  envName: dev
   labels:
+    env: dev
     key-1: value-1`)},
 				},
 				logger: zap.NewNop(),
@@ -144,7 +144,7 @@ spec:
 				{
 					Id:             "id-1",
 					Name:           "new-app-1",
-					Labels:         map[string]string{"key-1": "value-1"},
+					Labels:         map[string]string{"key-1": "value-1", "env": "dev"},
 					RepoId:         "repo-1",
 					Path:           "app-1",
 					ConfigFilename: "app.pipecd.yaml",
@@ -240,8 +240,8 @@ apiVersion: pipecd.dev/v1beta1
 kind: KubernetesApp
 spec:
   name: app-1
-  envName: dev
   labels:
+    env: dev
     key-1: value-1`)},
 				},
 				logger: zap.NewNop(),
@@ -254,7 +254,7 @@ spec:
 			want: []*model.ApplicationInfo{
 				{
 					Name:           "app-1",
-					Labels:         map[string]string{"key-1": "value-1"},
+					Labels:         map[string]string{"key-1": "value-1", "env": "dev"},
 					RepoId:         "repo-1",
 					Path:           "app-1",
 					ConfigFilename: "app.pipecd.yaml",
@@ -275,8 +275,8 @@ apiVersion: pipecd.dev/v1beta1
 kind: KubernetesApp
 spec:
   name: app-1
-  envName: dev
   labels:
+    env: dev
     key-1: value-1`)},
 				},
 				logger: zap.NewNop(),
@@ -289,7 +289,7 @@ spec:
 			want: []*model.ApplicationInfo{
 				{
 					Name:           "app-1",
-					Labels:         map[string]string{"key-1": "value-1"},
+					Labels:         map[string]string{"key-1": "value-1", "env": "dev"},
 					RepoId:         "repo-1",
 					Path:           "app-1",
 					ConfigFilename: "dev.pipecd.yaml",

--- a/pkg/app/piped/appconfigreporter/appconfigreporter_test.go
+++ b/pkg/app/piped/appconfigreporter/appconfigreporter_test.go
@@ -96,7 +96,7 @@ func TestReporter_findRegisteredApps(t *testing.T) {
 			reporter: &Reporter{
 				config: &config.PipedSpec{PipedID: "piped-1"},
 				applicationLister: &fakeApplicationLister{apps: []*model.Application{
-					{Id: "id-1", Name: "app-1", Labels: map[string]string{"key-1": "value-1", "env": "dev"}, GitPath: &model.ApplicationGitPath{Repo: &model.ApplicationGitRepository{Id: "repo-1"}, Path: "app-1", ConfigFilename: "app.pipecd.yaml"}},
+					{Id: "id-1", Name: "app-1", Labels: map[string]string{"key-1": "value-1", "pipecd.dev/env": "dev"}, GitPath: &model.ApplicationGitPath{Repo: &model.ApplicationGitRepository{Id: "repo-1"}, Path: "app-1", ConfigFilename: "app.pipecd.yaml"}},
 				}},
 				fileSystem: fstest.MapFS{
 					"path/to/repo-1/app-1/app.pipecd.yaml": &fstest.MapFile{Data: []byte(`
@@ -105,7 +105,7 @@ kind: KubernetesApp
 spec:
   name: app-1
   labels:
-    env: dev
+    pipecd.dev/env: dev
     key-1: value-1`)},
 				},
 				logger: zap.NewNop(),
@@ -122,7 +122,7 @@ spec:
 			reporter: &Reporter{
 				config: &config.PipedSpec{PipedID: "piped-1"},
 				applicationLister: &fakeApplicationLister{apps: []*model.Application{
-					{Id: "id-1", Name: "app-1", Labels: map[string]string{"key-1": "value-1", "env": "dev"}, GitPath: &model.ApplicationGitPath{Repo: &model.ApplicationGitRepository{Id: "repo-1"}, Path: "app-1", ConfigFilename: "app.pipecd.yaml"}},
+					{Id: "id-1", Name: "app-1", Labels: map[string]string{"key-1": "value-1", "pipecd.dev/env": "dev"}, GitPath: &model.ApplicationGitPath{Repo: &model.ApplicationGitRepository{Id: "repo-1"}, Path: "app-1", ConfigFilename: "app.pipecd.yaml"}},
 				}},
 				fileSystem: fstest.MapFS{
 					"path/to/repo-1/app-1/app.pipecd.yaml": &fstest.MapFile{Data: []byte(`
@@ -131,7 +131,7 @@ kind: KubernetesApp
 spec:
   name: new-app-1
   labels:
-    env: dev
+    pipecd.dev/env: dev
     key-1: value-1`)},
 				},
 				logger: zap.NewNop(),
@@ -144,7 +144,7 @@ spec:
 				{
 					Id:             "id-1",
 					Name:           "new-app-1",
-					Labels:         map[string]string{"key-1": "value-1", "env": "dev"},
+					Labels:         map[string]string{"key-1": "value-1", "pipecd.dev/env": "dev"},
 					RepoId:         "repo-1",
 					Path:           "app-1",
 					ConfigFilename: "app.pipecd.yaml",
@@ -241,7 +241,7 @@ kind: KubernetesApp
 spec:
   name: app-1
   labels:
-    env: dev
+    pipecd.dev/env: dev
     key-1: value-1`)},
 				},
 				logger: zap.NewNop(),
@@ -254,7 +254,7 @@ spec:
 			want: []*model.ApplicationInfo{
 				{
 					Name:           "app-1",
-					Labels:         map[string]string{"key-1": "value-1", "env": "dev"},
+					Labels:         map[string]string{"key-1": "value-1", "pipecd.dev/env": "dev"},
 					RepoId:         "repo-1",
 					Path:           "app-1",
 					ConfigFilename: "app.pipecd.yaml",
@@ -276,7 +276,7 @@ kind: KubernetesApp
 spec:
   name: app-1
   labels:
-    env: dev
+    pipecd.dev/env: dev
     key-1: value-1`)},
 				},
 				logger: zap.NewNop(),
@@ -289,7 +289,7 @@ spec:
 			want: []*model.ApplicationInfo{
 				{
 					Name:           "app-1",
-					Labels:         map[string]string{"key-1": "value-1", "env": "dev"},
+					Labels:         map[string]string{"key-1": "value-1", "pipecd.dev/env": "dev"},
 					RepoId:         "repo-1",
 					Path:           "app-1",
 					ConfigFilename: "dev.pipecd.yaml",

--- a/pkg/config/application.go
+++ b/pkg/config/application.go
@@ -33,6 +33,9 @@ type GenericApplicationSpec struct {
 	// The application name.
 	// This is required if you set the application through the application configuration file.
 	Name string `json:"name"`
+	// The environment name. You need to make sure that the environment name is unique in your project.
+	// Deprecated.
+	EnvName string `json:"envName"`
 	// Additional attributes to identify applications.
 	// Use "env" as a key then it will be recognized as the Environment of this app.
 	Labels map[string]string `json:"labels"`

--- a/pkg/config/application.go
+++ b/pkg/config/application.go
@@ -38,7 +38,8 @@ type GenericApplicationSpec struct {
 	// Deprecated.
 	EnvName string `json:"envName"`
 	// Additional attributes to identify applications.
-	// Use "env" as a key then it will be recognized as the Environment of this app.
+	// PipeCD reserves all keys prefixed by `pipecd.dev/`.
+	// The label `pipecd.dev/env` will be recognized as the Environment of this application.
 	Labels map[string]string `json:"labels"`
 
 	// Configuration used while planning deployment.

--- a/pkg/config/application.go
+++ b/pkg/config/application.go
@@ -26,7 +26,8 @@ const (
 	defaultWaitApprovalTimeout  = Duration(6 * time.Hour)
 	defaultAnalysisQueryTimeout = Duration(30 * time.Second)
 	allEventsSymbol             = "*"
-	EnvLabelKey                 = "env"
+
+	EnvLabelKey = "pipecd.dev/env"
 )
 
 type GenericApplicationSpec struct {

--- a/pkg/config/application.go
+++ b/pkg/config/application.go
@@ -26,15 +26,15 @@ const (
 	defaultWaitApprovalTimeout  = Duration(6 * time.Hour)
 	defaultAnalysisQueryTimeout = Duration(30 * time.Second)
 	allEventsSymbol             = "*"
+	EnvLabelKey                 = "env"
 )
 
 type GenericApplicationSpec struct {
 	// The application name.
 	// This is required if you set the application through the application configuration file.
 	Name string `json:"name"`
-	// The environment name. You need to make sure that the environment name is unique in your project.
-	EnvName string `json:"envName"`
 	// Additional attributes to identify applications.
+	// Use "env" as a key then it will be recognized as the Environment of this app.
 	Labels map[string]string `json:"labels"`
 
 	// Configuration used while planning deployment.


### PR DESCRIPTION
**What this PR does / why we need it**:
Let's say you define a label as below, both Env and Label will be updated.

```yaml
apiVersion: pipecd.dev/v1beta1
kind: KubernetesApp
spec:
  name: app-1
  labels:
    env: dev
```

This will encourage you to switch to use labels instead of Env seamlessly.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
