### PR TITLE
Make description changeable via App config

### DIFF
--- a/docs/content/en/docs-dev/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-dev/user-guide/configuration-reference.md
@@ -22,6 +22,7 @@ spec:
 | name | string | The application name. | Yes (if you want to create PipeCD application through the application configuration file) |
 | envName | string | The environment name. You need to make sure that the environment name is unique in your project. Deprecated. | No |
 | labels | map[string]string | Additional attributes to identify applications. PipeCD reserves all keys prefixed by `pipecd.dev/`. The label `pipecd.dev/env` will be recognized as the Environment of this application. | No |
+| description | string | Notes on the Application. | No |
 | input | [KubernetesDeploymentInput](#kubernetesdeploymentinput) | Input for Kubernetes deployment such as kubectl version, helm version, manifests filter... | No |
 | trigger | [DeploymentTrigger](#deploymenttrigger) | Configuration for trigger used to determine should we trigger a new deployment or not. | No |
 | planner | [DeploymentPlanner](#deploymentplanner) | Configuration for planner used while planning deployment. | No |
@@ -53,6 +54,7 @@ spec:
 | name | string | The application name. | Yes if you set the application through the application configuration file |
 | envName | string | The environment name. You need to make sure that the environment name is unique in your project. Deprecated. | No |
 | labels | map[string]string | Additional attributes to identify applications. PipeCD reserves all keys prefixed by `pipecd.dev/`. The label `pipecd.dev/env` will be recognized as the Environment of this application. | No |
+| description | string | Notes on the Application. | No |
 | input | [TerraformDeploymentInput](#terraformdeploymentinput) | Input for Terraform deployment such as terraform version, workspace... | No |
 | trigger | [DeploymentTrigger](#deploymenttrigger) | Configuration for trigger used to determine should we trigger a new deployment or not. | No |
 | planner | [DeploymentPlanner](#deploymentplanner) | Configuration for planner used while planning deployment. | No |
@@ -80,6 +82,7 @@ spec:
 | name | string | The application name. | Yes if you set the application through the application configuration file |
 | envName | string | The environment name. You need to make sure that the environment name is unique in your project. Deprecated. | No |
 | labels | map[string]string | Additional attributes to identify applications. PipeCD reserves all keys prefixed by `pipecd.dev/`. The label `pipecd.dev/env` will be recognized as the Environment of this application. | No |
+| description | string | Notes on the Application. | No |
 | input | [CloudRunDeploymentInput](#cloudrundeploymentinput) | Input for CloudRun deployment such as docker image... | No |
 | trigger | [DeploymentTrigger](#deploymenttrigger) | Configuration for trigger used to determine should we trigger a new deployment or not. | No |
 | planner | [DeploymentPlanner](#deploymentplanner) | Configuration for planner used while planning deployment. | No |
@@ -106,6 +109,7 @@ spec:
 | name | string | The application name. | Yes if you set the application through the application configuration file |
 | envName | string | The environment name. You need to make sure that the environment name is unique in your project. Deprecated. | No |
 | labels | map[string]string | Additional attributes to identify applications. PipeCD reserves all keys prefixed by `pipecd.dev/`. The label `pipecd.dev/env` will be recognized as the Environment of this application. | No |
+| description | string | Notes on the Application. | No |
 | trigger | [DeploymentTrigger](#deploymenttrigger) | Configuration for trigger used to determine should we trigger a new deployment or not. | No |
 | planner | [DeploymentPlanner](#deploymentplanner) | Configuration for planner used while planning deployment. | No |
 | quickSync | [LambdaQuickSync](#lambdaquicksync) | Configuration for quick sync. | No |
@@ -132,6 +136,7 @@ spec:
 | name | string | The application name. | Yes if you set the application through the application configuration file |
 | envName | string | The environment name. You need to make sure that the environment name is unique in your project. Deprecated. | No |
 | labels | map[string]string | Additional attributes to identify applications. PipeCD reserves all keys prefixed by `pipecd.dev/`. The label `pipecd.dev/env` will be recognized as the Environment of this application. | No |
+| description | string | Notes on the Application. | No |
 | trigger | [DeploymentTrigger](#deploymenttrigger) | Configuration for trigger used to determine should we trigger a new deployment or not. | No |
 | input | [ECSDeploymentInput](#ecsdeploymentinput) | Input for ECS deployment such as TaskDefinition, Service... | Yes |
 | planner | [DeploymentPlanner](#deploymentplanner) | Configuration for planner used while planning deployment. | No |

--- a/pkg/app/api/grpcapi/piped_api.go
+++ b/pkg/app/api/grpcapi/piped_api.go
@@ -972,6 +972,8 @@ func (a *PipedAPI) UpdateApplicationConfigurations(ctx context.Context, req *pip
 		updater := func(app *model.Application) error {
 			app.Name = appInfo.Name
 			app.Labels = appInfo.Labels
+			app.Description = appInfo.Description
+			// TODO: Enable to update env via PipedAPI
 			return nil
 		}
 		if err := a.applicationStore.UpdateApplication(ctx, appInfo.Id, updater); err != nil {

--- a/pkg/app/piped/appconfigreporter/appconfigreporter.go
+++ b/pkg/app/piped/appconfigreporter/appconfigreporter.go
@@ -290,6 +290,9 @@ func (r *Reporter) isSynced(appInfo *model.ApplicationInfo, app *model.Applicati
 	if appInfo.Name != app.Name {
 		return false
 	}
+	if appInfo.Description != app.Description {
+		return false
+	}
 	if len(appInfo.Labels) != len(app.Labels) {
 		return false
 	}
@@ -395,6 +398,7 @@ func (r *Reporter) readApplicationInfo(repoDir, repoID, cfgRelPath string) (*mod
 		Path:           filepath.Dir(cfgRelPath),
 		ConfigFilename: filepath.Base(cfgRelPath),
 		PipedId:        r.config.PipedID,
+		Description:    spec.Description,
 		EnvName:        envName,
 	}, nil
 }

--- a/pkg/config/application.go
+++ b/pkg/config/application.go
@@ -41,6 +41,8 @@ type GenericApplicationSpec struct {
 	// PipeCD reserves all keys prefixed by `pipecd.dev/`.
 	// The label `pipecd.dev/env` will be recognized as the Environment of this application.
 	Labels map[string]string `json:"labels"`
+	// Notes on the Application.
+	Description string `json:"description"`
 
 	// Configuration used while planning deployment.
 	Planner DeploymentPlanner `json:"planner"`

--- a/pkg/model/common.proto
+++ b/pkg/model/common.proto
@@ -69,6 +69,7 @@ message ApplicationInfo {
     // This field is not allowed to be changed.
     string config_filename = 7;
     string piped_id = 8 [(validate.rules).string.min_len = 1];
+    string description = 9;
     // This field will be no longer needed as labels can be an alternative.
     string env_name = 14 [deprecated=true];
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Like other fields, you will be able to change the description field via app config.
I will remove the description box on the web page later.

**Which issue(s) this PR fixes**:

Ref https://github.com/pipe-cd/pipe/issues/3002

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
The application description is now changeable via your application configuration file
```
