### PR TITLE
Remove duplicate value in version details on application list page

### DIFF
--- a/pkg/app/web/src/components/applications-page/application-list/application-list-item/index.tsx
+++ b/pkg/app/web/src/components/applications-page/application-list/application-list-item/index.tsx
@@ -126,12 +126,15 @@ export const ApplicationListItem: FC<ApplicationListItemProps> = memo(
             <>
               <TableCell className={clsx(classes.version)}>
                 {recentlyDeployment.version.includes(",") ? (
-                  recentlyDeployment.version.split(",").map((v) => (
-                    <>
-                      <span>{v}</span>
-                      <br />
-                    </>
-                  ))
+                  recentlyDeployment.version
+                    .split(",")
+                    .filter((item, index, arr) => arr.indexOf(item) === index)
+                    .map((v) => (
+                      <>
+                        <span>{v}</span>
+                        <br />
+                      </>
+                    ))
                 ) : (
                   <span>{recentlyDeployment.version}</span>
                 )}


### PR DESCRIPTION
**What this PR does / why we need it**:

Before
<img width="1415" alt="Screen Shot 2022-01-12 at 18 11 40" src="https://user-images.githubusercontent.com/32532742/149098453-a2e9fcc3-bee3-49ec-b090-85d9dddbe516.png">

After
<img width="1417" alt="Screen Shot 2022-01-12 at 18 11 46" src="https://user-images.githubusercontent.com/32532742/149098469-df607203-6103-4e08-8f2f-fe6a377ce3ca.png">

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
