### PR TITLE
Put deprecated notes on the Environment tab

### DIFF
--- a/pkg/app/web/src/components/settings-page/index.tsx
+++ b/pkg/app/web/src/components/settings-page/index.tsx
@@ -84,7 +84,7 @@ export const SettingsIndexPage: FC = memo(function SettingsIndexPage() {
                 <ListItemText primary={text} />
                 {link === PAGE_PATH_SETTINGS_ENV && (
                   <ListItemIcon className={classes.listItemIcon}>
-                    <Tooltip title="Deprecated">
+                    <Tooltip title="Deprecated. Please use Label instead.">
                       <Warning fontSize="small" />
                     </Tooltip>
                   </ListItemIcon>

--- a/pkg/app/web/src/components/settings-page/index.tsx
+++ b/pkg/app/web/src/components/settings-page/index.tsx
@@ -3,9 +3,12 @@ import {
   List,
   ListItem,
   ListItemText,
+  ListItemIcon,
   makeStyles,
   Toolbar,
+  Tooltip,
 } from "@material-ui/core";
+import { Warning } from "@material-ui/icons";
 import { FC, memo } from "react";
 import { NavLink, Redirect, Route, Switch } from "react-router-dom";
 import {
@@ -46,6 +49,9 @@ const useStyles = makeStyles((theme) => ({
   activeNav: {
     backgroundColor: theme.palette.action.selected,
   },
+  listItemIcon: {
+    minWidth: 110,
+  },
 }));
 
 const MENU_ITEMS = [
@@ -76,6 +82,13 @@ export const SettingsIndexPage: FC = memo(function SettingsIndexPage() {
                 activeClassName={classes.activeNav}
               >
                 <ListItemText primary={text} />
+                {link === PAGE_PATH_SETTINGS_ENV && (
+                  <ListItemIcon className={classes.listItemIcon}>
+                    <Tooltip title="Deprecated">
+                      <Warning fontSize="small" />
+                    </Tooltip>
+                  </ListItemIcon>
+                )}
               </ListItem>
             ))}
           </List>


### PR DESCRIPTION
**What this PR does / why we need it**:
Whenever you hover over the Environment tab at the settings page, you will see the notes "deprecated".

![image](https://user-images.githubusercontent.com/19730728/149100067-bfd04057-206e-4755-8a63-a4499a2e8f62.png)

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
