### PR TITLE
Update gateway routing to accept new path schema

### DIFF
--- a/manifests/pipecd/templates/envoy-configmap.yaml
+++ b/manifests/pipecd/templates/envoy-configmap.yaml
@@ -62,20 +62,38 @@ data:
 {{- end }}
                   routes:
                     - match:
+                        prefix: /grpc.service.pipedservice.PipedService/
+                        grpc:
+                      route:
+                        cluster: grpc-piped-service
+                    - match:
                         prefix: /pipe.api.service.pipedservice.PipedService/
                         grpc:
                       route:
                         cluster: grpc-piped-service
+                        prefix_rewrite: /grpc.service.pipedservice.PipedService/
+                    - match:
+                        prefix: /grpc.service.webservice.WebService/
+                        grpc:
+                      route:
+                        cluster: grpc-web-service
                     - match:
                         prefix: /pipe.api.service.webservice.WebService/
                         grpc:
                       route:
                         cluster: grpc-web-service
+                        prefix_rewrite: /grpc.service.webservice.WebService/
+                    - match:
+                        prefix: /grpc.service.apiservice.APIService/
+                        grpc:
+                      route:
+                        cluster: grpc-api-service
                     - match:
                         prefix: /pipe.api.service.apiservice.APIService/
                         grpc:
                       route:
                         cluster: grpc-api-service
+                        prefix_rewrite: /grpc.service.apiservice.APIService/
                     - match:
                         prefix: /
                       route:

--- a/manifests/pipecd/templates/envoy-configmap.yaml
+++ b/manifests/pipecd/templates/envoy-configmap.yaml
@@ -77,6 +77,8 @@ data:
                         grpc:
                       route:
                         cluster: grpc-web-service
+                    # TODO: Remove this route for WebService.
+                    # We don't have to keep this old schema for WebService once its gRPC package name is updated.
                     - match:
                         prefix: /pipe.api.service.webservice.WebService/
                         grpc:


### PR DESCRIPTION
**What this PR does / why we need it**:

This allows the new control-plane can be able to accept gRPC requests from both old and new Piped agents.

**Which issue(s) this PR fixes**:

Part of #3024

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
