### PR TITLE
Enable to update env via App config

### DIFF
--- a/pkg/app/api/grpcapi/piped_api.go
+++ b/pkg/app/api/grpcapi/piped_api.go
@@ -970,7 +970,6 @@ func (a *PipedAPI) UpdateApplicationConfigurations(ctx context.Context, req *pip
 	}
 
 	opts := datastore.ListOptions{
-		Limit: 1,
 		Filters: []datastore.ListFilter{
 			{
 				Field:    "ProjectId",
@@ -989,17 +988,17 @@ func (a *PipedAPI) UpdateApplicationConfigurations(ctx context.Context, req *pip
 		a.logger.Error("failed to get environments", zap.Error(err))
 		return nil, status.Error(codes.Internal, "Failed to get environments")
 	}
-	envsMap := make(map[string]string, len(envs))
+	envMap := make(map[string]string, len(envs))
 	for _, env := range envs {
 		// It is assumed that the env name is kept unique by the user.
-		envsMap[env.Name] = env.Id
+		envMap[env.Name] = env.Id
 	}
 
 	for _, appInfo := range req.Applications {
 		envID := ""
 		if appInfo.EnvName != "" {
 			var ok bool
-			envID, ok = envsMap[appInfo.EnvName]
+			envID, ok = envMap[appInfo.EnvName]
 			if !ok {
 				a.logger.Error("unknown environment name given",
 					zap.String("env", appInfo.EnvName),


### PR DESCRIPTION
**What this PR does / why we need it**:
Because an application config file has only env name, PipedAPI does have to fetch the env id by name. We don't want to add additional method to fetch by name as the Environment concept is deprecated, that's why I settled on using `ListEnvironments` for this case.

**Which issue(s) this PR fixes**:

Fixes https://github.com/pipe-cd/pipe/issues/3019

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
