### PR TITLE
Align deprecated tooltip

### DIFF
--- a/pkg/app/web/src/components/applications-page/application-list/index.tsx
+++ b/pkg/app/web/src/components/applications-page/application-list/index.tsx
@@ -31,8 +31,8 @@ const useStyles = makeStyles(() => ({
     flex: 1,
   },
   tooltip: {
-    paddingTop: 7,
     paddingLeft: 2,
+    marginBottom: -4,
   },
 }));
 

--- a/pkg/app/web/src/components/applications-page/application-list/index.tsx
+++ b/pkg/app/web/src/components/applications-page/application-list/index.tsx
@@ -31,7 +31,7 @@ const useStyles = makeStyles(() => ({
     flex: 1,
   },
   tooltip: {
-    paddingTop: 2,
+    paddingTop: 7,
     paddingLeft: 2,
   },
 }));
@@ -145,7 +145,10 @@ export const ApplicationList: FC<ApplicationListProps> = memo(
                 <TableCell>Kind</TableCell>
                 <TableCell>
                   Environment
-                  <Tooltip title="Deprecated. Please use Label instead." className={classes.tooltip}>
+                  <Tooltip
+                    title="Deprecated. Please use Label instead."
+                    className={classes.tooltip}
+                  >
                     <Warning fontSize="small" />
                   </Tooltip>
                 </TableCell>


### PR DESCRIPTION
**What this PR does / why we need it**:
~So far the only thing I can do to release soon is make the icon smaller.~
Updated according to @khanhtc1202's advice.

![image](https://user-images.githubusercontent.com/19730728/149281359-56369eb3-af63-473c-9b70-aee385f464d2.png)



**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
