### PR TITLE
Change the reserved label key for env

### DIFF
--- a/docs/content/en/docs-dev/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-dev/user-guide/configuration-reference.md
@@ -21,7 +21,7 @@ spec:
 |-|-|-|-|
 | name | string | The application name. | Yes (if you want to create PipeCD application through the application configuration file) |
 | envName | string | The environment name. You need to make sure that the environment name is unique in your project. | No (deprecated) |
-| labels | map[string]string | Additional attributes to identify applications. PipeCD reserves all keys prefixed by `pipecd.dev/`. The label `pipecd.dev/env` will be recognized as the Environment of this application. | No |
+| labels | map[string]string | Additional attributes to identify applications. PipeCD reserves all keys prefixed by `pipecd.dev/`. The label `env` will be recognized as the Environment of this application. | No |
 | description | string | Notes on the Application. | No |
 | input | [KubernetesDeploymentInput](#kubernetesdeploymentinput) | Input for Kubernetes deployment such as kubectl version, helm version, manifests filter... | No |
 | trigger | [DeploymentTrigger](#deploymenttrigger) | Configuration for trigger used to determine should we trigger a new deployment or not. | No |
@@ -53,7 +53,7 @@ spec:
 |-|-|-|-|
 | name | string | The application name. | Yes if you set the application through the application configuration file |
 | envName | string | The environment name. You need to make sure that the environment name is unique in your project. | No (deprecated) |
-| labels | map[string]string | Additional attributes to identify applications. PipeCD reserves all keys prefixed by `pipecd.dev/`. The label `pipecd.dev/env` will be recognized as the Environment of this application. | No |
+| labels | map[string]string | Additional attributes to identify applications. PipeCD reserves all keys prefixed by `pipecd.dev/`. The label `env` will be recognized as the Environment of this application. | No |
 | description | string | Notes on the Application. | No |
 | input | [TerraformDeploymentInput](#terraformdeploymentinput) | Input for Terraform deployment such as terraform version, workspace... | No |
 | trigger | [DeploymentTrigger](#deploymenttrigger) | Configuration for trigger used to determine should we trigger a new deployment or not. | No |
@@ -81,7 +81,7 @@ spec:
 |-|-|-|-|
 | name | string | The application name. | Yes if you set the application through the application configuration file |
 | envName | string | The environment name. You need to make sure that the environment name is unique in your project. | No (deprecated) |
-| labels | map[string]string | Additional attributes to identify applications. PipeCD reserves all keys prefixed by `pipecd.dev/`. The label `pipecd.dev/env` will be recognized as the Environment of this application. | No |
+| labels | map[string]string | Additional attributes to identify applications. PipeCD reserves all keys prefixed by `pipecd.dev/`. The label `env` will be recognized as the Environment of this application. | No |
 | description | string | Notes on the Application. | No |
 | input | [CloudRunDeploymentInput](#cloudrundeploymentinput) | Input for CloudRun deployment such as docker image... | No |
 | trigger | [DeploymentTrigger](#deploymenttrigger) | Configuration for trigger used to determine should we trigger a new deployment or not. | No |
@@ -108,7 +108,7 @@ spec:
 |-|-|-|-|
 | name | string | The application name. | Yes if you set the application through the application configuration file |
 | envName | string | The environment name. You need to make sure that the environment name is unique in your project. | No (deprecated) |
-| labels | map[string]string | Additional attributes to identify applications. PipeCD reserves all keys prefixed by `pipecd.dev/`. The label `pipecd.dev/env` will be recognized as the Environment of this application. | No |
+| labels | map[string]string | Additional attributes to identify applications. PipeCD reserves all keys prefixed by `pipecd.dev/`. The label `env` will be recognized as the Environment of this application. | No |
 | description | string | Notes on the Application. | No |
 | trigger | [DeploymentTrigger](#deploymenttrigger) | Configuration for trigger used to determine should we trigger a new deployment or not. | No |
 | planner | [DeploymentPlanner](#deploymentplanner) | Configuration for planner used while planning deployment. | No |
@@ -135,7 +135,7 @@ spec:
 |-|-|-|-|
 | name | string | The application name. | Yes if you set the application through the application configuration file |
 | envName | string | The environment name. You need to make sure that the environment name is unique in your project. | No (deprecated) |
-| labels | map[string]string | Additional attributes to identify applications. PipeCD reserves all keys prefixed by `pipecd.dev/`. The label `pipecd.dev/env` will be recognized as the Environment of this application. | No |
+| labels | map[string]string | Additional attributes to identify applications. PipeCD reserves all keys prefixed by `pipecd.dev/`. The label `env` will be recognized as the Environment of this application. | No |
 | description | string | Notes on the Application. | No |
 | trigger | [DeploymentTrigger](#deploymenttrigger) | Configuration for trigger used to determine should we trigger a new deployment or not. | No |
 | input | [ECSDeploymentInput](#ecsdeploymentinput) | Input for ECS deployment such as TaskDefinition, Service... | Yes |

--- a/pkg/app/piped/appconfigreporter/appconfigreporter_test.go
+++ b/pkg/app/piped/appconfigreporter/appconfigreporter_test.go
@@ -96,7 +96,7 @@ func TestReporter_findRegisteredApps(t *testing.T) {
 			reporter: &Reporter{
 				config: &config.PipedSpec{PipedID: "piped-1"},
 				applicationLister: &fakeApplicationLister{apps: []*model.Application{
-					{Id: "id-1", Name: "app-1", Labels: map[string]string{"key-1": "value-1", "pipecd.dev/env": "dev"}, GitPath: &model.ApplicationGitPath{Repo: &model.ApplicationGitRepository{Id: "repo-1"}, Path: "app-1", ConfigFilename: "app.pipecd.yaml"}},
+					{Id: "id-1", Name: "app-1", Labels: map[string]string{"key-1": "value-1", "env": "dev"}, GitPath: &model.ApplicationGitPath{Repo: &model.ApplicationGitRepository{Id: "repo-1"}, Path: "app-1", ConfigFilename: "app.pipecd.yaml"}},
 				}},
 				fileSystem: fstest.MapFS{
 					"path/to/repo-1/app-1/app.pipecd.yaml": &fstest.MapFile{Data: []byte(`
@@ -105,7 +105,7 @@ kind: KubernetesApp
 spec:
   name: app-1
   labels:
-    pipecd.dev/env: dev
+    env: dev
     key-1: value-1`)},
 				},
 				logger: zap.NewNop(),
@@ -122,7 +122,7 @@ spec:
 			reporter: &Reporter{
 				config: &config.PipedSpec{PipedID: "piped-1"},
 				applicationLister: &fakeApplicationLister{apps: []*model.Application{
-					{Id: "id-1", Name: "app-1", Labels: map[string]string{"key-1": "value-1", "pipecd.dev/env": "dev"}, GitPath: &model.ApplicationGitPath{Repo: &model.ApplicationGitRepository{Id: "repo-1"}, Path: "app-1", ConfigFilename: "app.pipecd.yaml"}},
+					{Id: "id-1", Name: "app-1", Labels: map[string]string{"key-1": "value-1", "env": "dev"}, GitPath: &model.ApplicationGitPath{Repo: &model.ApplicationGitRepository{Id: "repo-1"}, Path: "app-1", ConfigFilename: "app.pipecd.yaml"}},
 				}},
 				fileSystem: fstest.MapFS{
 					"path/to/repo-1/app-1/app.pipecd.yaml": &fstest.MapFile{Data: []byte(`
@@ -131,7 +131,7 @@ kind: KubernetesApp
 spec:
   name: new-app-1
   labels:
-    pipecd.dev/env: dev
+    env: dev
     key-1: value-1`)},
 				},
 				logger: zap.NewNop(),
@@ -144,7 +144,7 @@ spec:
 				{
 					Id:             "id-1",
 					Name:           "new-app-1",
-					Labels:         map[string]string{"key-1": "value-1", "pipecd.dev/env": "dev"},
+					Labels:         map[string]string{"key-1": "value-1", "env": "dev"},
 					RepoId:         "repo-1",
 					Path:           "app-1",
 					ConfigFilename: "app.pipecd.yaml",
@@ -241,7 +241,7 @@ kind: KubernetesApp
 spec:
   name: app-1
   labels:
-    pipecd.dev/env: dev
+    env: dev
     key-1: value-1`)},
 				},
 				logger: zap.NewNop(),
@@ -254,7 +254,7 @@ spec:
 			want: []*model.ApplicationInfo{
 				{
 					Name:           "app-1",
-					Labels:         map[string]string{"key-1": "value-1", "pipecd.dev/env": "dev"},
+					Labels:         map[string]string{"key-1": "value-1", "env": "dev"},
 					RepoId:         "repo-1",
 					Path:           "app-1",
 					ConfigFilename: "app.pipecd.yaml",
@@ -276,7 +276,7 @@ kind: KubernetesApp
 spec:
   name: app-1
   labels:
-    pipecd.dev/env: dev
+    env: dev
     key-1: value-1`)},
 				},
 				logger: zap.NewNop(),
@@ -289,7 +289,7 @@ spec:
 			want: []*model.ApplicationInfo{
 				{
 					Name:           "app-1",
-					Labels:         map[string]string{"key-1": "value-1", "pipecd.dev/env": "dev"},
+					Labels:         map[string]string{"key-1": "value-1", "env": "dev"},
 					RepoId:         "repo-1",
 					Path:           "app-1",
 					ConfigFilename: "dev.pipecd.yaml",

--- a/pkg/config/application.go
+++ b/pkg/config/application.go
@@ -27,7 +27,7 @@ const (
 	defaultAnalysisQueryTimeout = Duration(30 * time.Second)
 	allEventsSymbol             = "*"
 
-	EnvLabelKey = "pipecd.dev/env"
+	EnvLabelKey = "env"
 )
 
 type GenericApplicationSpec struct {
@@ -39,7 +39,7 @@ type GenericApplicationSpec struct {
 	EnvName string `json:"envName"`
 	// Additional attributes to identify applications.
 	// PipeCD reserves all keys prefixed by `pipecd.dev/`.
-	// The label `pipecd.dev/env` will be recognized as the Environment of this application.
+	// The label `env` will be recognized as the Environment of this application.
 	Labels map[string]string `json:"labels"`
 	// Notes on the Application.
 	Description string `json:"description"`


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR changes the special label key name to `env` from `pipecd.dev/env`.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
NONE
```
