### PR TITLE
Remove env concept from app config file

### DIFF
--- a/docs/content/en/docs-dev/user-guide/configuration-reference.md
+++ b/docs/content/en/docs-dev/user-guide/configuration-reference.md
@@ -20,8 +20,7 @@ spec:
 | Field | Type | Description | Required |
 |-|-|-|-|
 | name | string | The application name. | Yes (if you want to create PipeCD application through the application configuration file) |
-| envName | string | The environment name. You need to make sure that the environment name is unique in your project. | No (deprecated) |
-| labels | map[string]string | Additional attributes to identify applications. PipeCD reserves all keys prefixed by `pipecd.dev/`. The label `env` will be recognized as the Environment of this application. | No |
+| labels | map[string]string | Additional attributes to identify applications. | No |
 | description | string | Notes on the Application. | No |
 | input | [KubernetesDeploymentInput](#kubernetesdeploymentinput) | Input for Kubernetes deployment such as kubectl version, helm version, manifests filter... | No |
 | trigger | [DeploymentTrigger](#deploymenttrigger) | Configuration for trigger used to determine should we trigger a new deployment or not. | No |
@@ -52,8 +51,7 @@ spec:
 | Field | Type | Description | Required |
 |-|-|-|-|
 | name | string | The application name. | Yes if you set the application through the application configuration file |
-| envName | string | The environment name. You need to make sure that the environment name is unique in your project. | No (deprecated) |
-| labels | map[string]string | Additional attributes to identify applications. PipeCD reserves all keys prefixed by `pipecd.dev/`. The label `env` will be recognized as the Environment of this application. | No |
+| labels | map[string]string | Additional attributes to identify applications. | No |
 | description | string | Notes on the Application. | No |
 | input | [TerraformDeploymentInput](#terraformdeploymentinput) | Input for Terraform deployment such as terraform version, workspace... | No |
 | trigger | [DeploymentTrigger](#deploymenttrigger) | Configuration for trigger used to determine should we trigger a new deployment or not. | No |
@@ -80,8 +78,7 @@ spec:
 | Field | Type | Description | Required |
 |-|-|-|-|
 | name | string | The application name. | Yes if you set the application through the application configuration file |
-| envName | string | The environment name. You need to make sure that the environment name is unique in your project. | No (deprecated) |
-| labels | map[string]string | Additional attributes to identify applications. PipeCD reserves all keys prefixed by `pipecd.dev/`. The label `env` will be recognized as the Environment of this application. | No |
+| labels | map[string]string | Additional attributes to identify applications. | No |
 | description | string | Notes on the Application. | No |
 | input | [CloudRunDeploymentInput](#cloudrundeploymentinput) | Input for CloudRun deployment such as docker image... | No |
 | trigger | [DeploymentTrigger](#deploymenttrigger) | Configuration for trigger used to determine should we trigger a new deployment or not. | No |
@@ -107,8 +104,7 @@ spec:
 | Field | Type | Description | Required |
 |-|-|-|-|
 | name | string | The application name. | Yes if you set the application through the application configuration file |
-| envName | string | The environment name. You need to make sure that the environment name is unique in your project. | No (deprecated) |
-| labels | map[string]string | Additional attributes to identify applications. PipeCD reserves all keys prefixed by `pipecd.dev/`. The label `env` will be recognized as the Environment of this application. | No |
+| labels | map[string]string | Additional attributes to identify applications. | No |
 | description | string | Notes on the Application. | No |
 | trigger | [DeploymentTrigger](#deploymenttrigger) | Configuration for trigger used to determine should we trigger a new deployment or not. | No |
 | planner | [DeploymentPlanner](#deploymentplanner) | Configuration for planner used while planning deployment. | No |
@@ -134,8 +130,7 @@ spec:
 | Field | Type | Description | Required |
 |-|-|-|-|
 | name | string | The application name. | Yes if you set the application through the application configuration file |
-| envName | string | The environment name. You need to make sure that the environment name is unique in your project. | No (deprecated) |
-| labels | map[string]string | Additional attributes to identify applications. PipeCD reserves all keys prefixed by `pipecd.dev/`. The label `env` will be recognized as the Environment of this application. | No |
+| labels | map[string]string | Additional attributes to identify applications. | No |
 | description | string | Notes on the Application. | No |
 | trigger | [DeploymentTrigger](#deploymenttrigger) | Configuration for trigger used to determine should we trigger a new deployment or not. | No |
 | input | [ECSDeploymentInput](#ecsdeploymentinput) | Input for ECS deployment such as TaskDefinition, Service... | Yes |

--- a/pkg/app/piped/appconfigreporter/appconfigreporter.go
+++ b/pkg/app/piped/appconfigreporter/appconfigreporter.go
@@ -386,10 +386,6 @@ func (r *Reporter) readApplicationInfo(repoDir, repoID, cfgRelPath string) (*mod
 	if spec.Name == "" {
 		return nil, fmt.Errorf("missing application name: %w", errMissingRequiredField)
 	}
-	envName := spec.EnvName
-	if e, ok := spec.Labels[config.EnvLabelKey]; ok {
-		envName = e
-	}
 	return &model.ApplicationInfo{
 		Name:           spec.Name,
 		Kind:           kind,
@@ -399,6 +395,5 @@ func (r *Reporter) readApplicationInfo(repoDir, repoID, cfgRelPath string) (*mod
 		ConfigFilename: filepath.Base(cfgRelPath),
 		PipedId:        r.config.PipedID,
 		Description:    spec.Description,
-		EnvName:        envName,
 	}, nil
 }

--- a/pkg/app/piped/appconfigreporter/appconfigreporter_test.go
+++ b/pkg/app/piped/appconfigreporter/appconfigreporter_test.go
@@ -96,7 +96,7 @@ func TestReporter_findRegisteredApps(t *testing.T) {
 			reporter: &Reporter{
 				config: &config.PipedSpec{PipedID: "piped-1"},
 				applicationLister: &fakeApplicationLister{apps: []*model.Application{
-					{Id: "id-1", Name: "app-1", Labels: map[string]string{"key-1": "value-1", "env": "dev"}, GitPath: &model.ApplicationGitPath{Repo: &model.ApplicationGitRepository{Id: "repo-1"}, Path: "app-1", ConfigFilename: "app.pipecd.yaml"}},
+					{Id: "id-1", Name: "app-1", Labels: map[string]string{"key-1": "value-1"}, GitPath: &model.ApplicationGitPath{Repo: &model.ApplicationGitRepository{Id: "repo-1"}, Path: "app-1", ConfigFilename: "app.pipecd.yaml"}},
 				}},
 				fileSystem: fstest.MapFS{
 					"path/to/repo-1/app-1/app.pipecd.yaml": &fstest.MapFile{Data: []byte(`
@@ -105,7 +105,6 @@ kind: KubernetesApp
 spec:
   name: app-1
   labels:
-    env: dev
     key-1: value-1`)},
 				},
 				logger: zap.NewNop(),
@@ -122,7 +121,7 @@ spec:
 			reporter: &Reporter{
 				config: &config.PipedSpec{PipedID: "piped-1"},
 				applicationLister: &fakeApplicationLister{apps: []*model.Application{
-					{Id: "id-1", Name: "app-1", Labels: map[string]string{"key-1": "value-1", "env": "dev"}, GitPath: &model.ApplicationGitPath{Repo: &model.ApplicationGitRepository{Id: "repo-1"}, Path: "app-1", ConfigFilename: "app.pipecd.yaml"}},
+					{Id: "id-1", Name: "app-1", Labels: map[string]string{"key-1": "value-1"}, GitPath: &model.ApplicationGitPath{Repo: &model.ApplicationGitRepository{Id: "repo-1"}, Path: "app-1", ConfigFilename: "app.pipecd.yaml"}},
 				}},
 				fileSystem: fstest.MapFS{
 					"path/to/repo-1/app-1/app.pipecd.yaml": &fstest.MapFile{Data: []byte(`
@@ -131,7 +130,6 @@ kind: KubernetesApp
 spec:
   name: new-app-1
   labels:
-    env: dev
     key-1: value-1`)},
 				},
 				logger: zap.NewNop(),
@@ -144,12 +142,11 @@ spec:
 				{
 					Id:             "id-1",
 					Name:           "new-app-1",
-					Labels:         map[string]string{"key-1": "value-1", "env": "dev"},
+					Labels:         map[string]string{"key-1": "value-1"},
 					RepoId:         "repo-1",
 					Path:           "app-1",
 					ConfigFilename: "app.pipecd.yaml",
 					PipedId:        "piped-1",
-					EnvName:        "dev",
 				},
 			},
 			wantErr: false,
@@ -241,7 +238,6 @@ kind: KubernetesApp
 spec:
   name: app-1
   labels:
-    env: dev
     key-1: value-1`)},
 				},
 				logger: zap.NewNop(),
@@ -254,12 +250,11 @@ spec:
 			want: []*model.ApplicationInfo{
 				{
 					Name:           "app-1",
-					Labels:         map[string]string{"key-1": "value-1", "env": "dev"},
+					Labels:         map[string]string{"key-1": "value-1"},
 					RepoId:         "repo-1",
 					Path:           "app-1",
 					ConfigFilename: "app.pipecd.yaml",
 					PipedId:        "piped-1",
-					EnvName:        "dev",
 				},
 			},
 			wantErr: false,
@@ -276,7 +271,6 @@ kind: KubernetesApp
 spec:
   name: app-1
   labels:
-    env: dev
     key-1: value-1`)},
 				},
 				logger: zap.NewNop(),
@@ -289,12 +283,11 @@ spec:
 			want: []*model.ApplicationInfo{
 				{
 					Name:           "app-1",
-					Labels:         map[string]string{"key-1": "value-1", "env": "dev"},
+					Labels:         map[string]string{"key-1": "value-1"},
 					RepoId:         "repo-1",
 					Path:           "app-1",
 					ConfigFilename: "dev.pipecd.yaml",
 					PipedId:        "piped-1",
-					EnvName:        "dev",
 				},
 			},
 			wantErr: false,

--- a/pkg/app/server/grpcapi/piped_api.go
+++ b/pkg/app/server/grpcapi/piped_api.go
@@ -973,7 +973,6 @@ func (a *PipedAPI) UpdateApplicationConfigurations(ctx context.Context, req *pip
 			app.Name = appInfo.Name
 			app.Labels = appInfo.Labels
 			app.Description = appInfo.Description
-			// TODO: Enable to update env via PipedAPI
 			return nil
 		}
 		if err := a.applicationStore.UpdateApplication(ctx, appInfo.Id, updater); err != nil {

--- a/pkg/config/application.go
+++ b/pkg/config/application.go
@@ -26,20 +26,13 @@ const (
 	defaultWaitApprovalTimeout  = Duration(6 * time.Hour)
 	defaultAnalysisQueryTimeout = Duration(30 * time.Second)
 	allEventsSymbol             = "*"
-
-	EnvLabelKey = "env"
 )
 
 type GenericApplicationSpec struct {
 	// The application name.
 	// This is required if you set the application through the application configuration file.
 	Name string `json:"name"`
-	// The environment name. You need to make sure that the environment name is unique in your project.
-	// Deprecated.
-	EnvName string `json:"envName"`
 	// Additional attributes to identify applications.
-	// PipeCD reserves all keys prefixed by `pipecd.dev/`.
-	// The label `env` will be recognized as the Environment of this application.
 	Labels map[string]string `json:"labels"`
 	// Notes on the Application.
 	Description string `json:"description"`

--- a/pkg/config/application.go
+++ b/pkg/config/application.go
@@ -32,6 +32,9 @@ type GenericApplicationSpec struct {
 	// The application name.
 	// This is required if you set the application through the application configuration file.
 	Name string `json:"name"`
+	// The environment name. You need to make sure that the environment name is unique in your project.
+	// Deprecated.
+	EnvName string `json:"envName"`
 	// Additional attributes to identify applications.
 	Labels map[string]string `json:"labels"`
 	// Notes on the Application.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR disables updating the environment via the application config file.

**Which issue(s) this PR fixes**:

Fixes https://github.com/pipe-cd/pipe/issues/3019

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
-->
```release-note
Disable to update the environment via your application config file
```
